### PR TITLE
feat: add Tooltip component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,7 @@
+# @refraction-ui/react
+
+This package contains React components for Refraction UI.
+
+## Tooltip
+
+A minimal tooltip component supporting custom positioning, triggers and delays.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@refraction-ui/react",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --outDir dist --declaration",
+    "test": "echo \"No tests yet\""
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/packages/react/src/components/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+export type TooltipTrigger = 'hover' | 'focus' | 'click';
+
+export interface TooltipProps {
+  content: React.ReactNode;
+  position?: TooltipPosition;
+  trigger?: TooltipTrigger;
+  delay?: number; // ms
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactElement;
+}
+
+/**
+ * Tooltip component with configurable positioning and triggers.
+ * Uses aria-describedby and role="tooltip" for accessibility.
+ */
+export const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  position = 'top',
+  trigger = 'hover',
+  delay = 300,
+  open: openProp,
+  onOpenChange,
+  children,
+}) => {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const timeoutRef = useRef<number>();
+
+  const controlled = openProp !== undefined;
+  const isOpen = controlled ? openProp : open;
+
+  const show = () => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = window.setTimeout(() => {
+      if (!controlled) setOpen(true);
+      onOpenChange?.(true);
+    }, delay);
+  };
+
+  const hide = () => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = window.setTimeout(() => {
+      if (!controlled) setOpen(false);
+      onOpenChange?.(false);
+    }, delay);
+  };
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const triggerProps: Record<string, any> = {};
+  if (trigger === 'hover') {
+    triggerProps.onMouseEnter = show;
+    triggerProps.onMouseLeave = hide;
+  }
+  if (trigger === 'focus') {
+    triggerProps.onFocus = show;
+    triggerProps.onBlur = hide;
+  }
+  if (trigger === 'click') {
+    triggerProps.onClick = () => {
+      if (isOpen) hide();
+      else show();
+    };
+  }
+
+  const tooltipId = `tooltip-${useId()}`;
+
+  return (
+    <>
+      {React.cloneElement(children, {
+        ref: (node: HTMLElement) => {
+          triggerRef.current = node;
+          const { ref } = children as any;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) (ref as React.MutableRefObject<HTMLElement | null>).current = node;
+        },
+        'aria-describedby': isOpen ? tooltipId : undefined,
+        ...triggerProps,
+      })}
+      {isOpen && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          ref={tooltipRef}
+          style={getPositionStyle(triggerRef.current, position)}
+        >
+          {content}
+          <span className="tooltip-arrow" />
+        </div>
+      )}
+    </>
+  );
+};
+
+function useId() {
+  const [id] = useState(() => Math.random().toString(36).slice(2));
+  return id;
+}
+
+function getPositionStyle(triggerEl: HTMLElement | null, position: TooltipPosition) {
+  if (!triggerEl) return { position: 'absolute' } as React.CSSProperties;
+  const rect = triggerEl.getBoundingClientRect();
+  const style: React.CSSProperties = { position: 'absolute' };
+  switch (position) {
+    case 'bottom':
+      style.top = rect.bottom + window.scrollY + 8;
+      style.left = rect.left + window.scrollX + rect.width / 2;
+      style.transform = 'translateX(-50%)';
+      break;
+    case 'left':
+      style.top = rect.top + window.scrollY + rect.height / 2;
+      style.left = rect.left + window.scrollX - 8;
+      style.transform = 'translate(-100%, -50%)';
+      break;
+    case 'right':
+      style.top = rect.top + window.scrollY + rect.height / 2;
+      style.left = rect.right + window.scrollX + 8;
+      style.transform = 'translate(0, -50%)';
+      break;
+    default: // top
+      style.top = rect.top + window.scrollY - 8;
+      style.left = rect.left + window.scrollX + rect.width / 2;
+      style.transform = 'translate(-50%, -100%)';
+  }
+  return style;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/Tooltip';

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/react" }
+  ]
+}


### PR DESCRIPTION
## Summary
- create workspace layout with root package.json and tsconfig
- add `@refraction-ui/react` package
- implement `Tooltip` component supporting basic positioning, delay and triggers

## Checklist
- [ ] Tests added or updated
- [ ] Linting and type checks pass


------
https://chatgpt.com/codex/tasks/task_b_6883113f7c08832cb0204859627bf88b