### PR TITLE
Implement CLI upgrade prototype

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -1,0 +1,8 @@
+/**
+ * @refraction-version 1.0.0
+ * @refraction-component button
+ * @refraction-updated 2024-01-01
+ */
+export function Button({ label }) {
+  return `<button>${label}</button>`;
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,9 @@
+# Refraction UI CLI
+
+This package provides the `refraction-upgrade` command used to upgrade component templates.
+
+```
+refraction-upgrade [component...] [--check] [--dry] [--diff] [--rollback name]
+```
+
+Components are stored in `components/` with version headers. Templates live in `templates/<component>/<version>/`.

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "@refraction-ui/cli",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@refraction-ui/cli",
+      "version": "0.0.1",
+      "dependencies": {
+        "diff3": "^0.0.4",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "refraction-upgrade": "upgrade.js"
+      }
+    },
+    "node_modules/diff3": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+      "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@refraction-ui/cli",
+  "version": "0.0.1",
+  "main": "upgrade.js",
+  "bin": {
+    "refraction-upgrade": "./upgrade.js"
+  },
+  "dependencies": {
+    "diff3": "^0.0.4",
+    "minimist": "^1.2.8"
+  }
+}

--- a/packages/cli/upgrade.js
+++ b/packages/cli/upgrade.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const diff3 = require('diff3');
+
+function parseHeader(content) {
+  const versionMatch = content.match(/@refraction-version\s+(\S+)/);
+  const compMatch = content.match(/@refraction-component\s+(\S+)/);
+  return {
+    version: versionMatch ? versionMatch[1] : null,
+    component: compMatch ? compMatch[1] : null,
+  };
+}
+
+function mergeFiles(current, base, incoming) {
+  const result = diff3(current.split('\n'), base.split('\n'), incoming.split('\n'));
+  let merged = [];
+  let conflict = false;
+  for (const part of result) {
+    if (part.ok) {
+      merged.push(...part.ok);
+    } else if (part.conflict) {
+      conflict = true;
+      merged.push('<<<<<<< current');
+      merged.push(...part.conflict.a);
+      merged.push('=======');
+      merged.push(...part.conflict.b);
+      merged.push('>>>>>>> incoming');
+    }
+  }
+  return { text: merged.join('\n'), conflict };
+}
+
+function backupFile(file) {
+  const ts = Date.now();
+  const dir = path.join(process.cwd(), 'backups');
+  fs.mkdirSync(dir, { recursive: true });
+  const target = path.join(dir, path.basename(file) + '.' + ts);
+  fs.copyFileSync(file, target);
+  return target;
+}
+
+function upgradeComponent(name, opts) {
+  const compDir = path.join(process.cwd(), 'components');
+  const tmplDir = path.join(process.cwd(), 'templates');
+  const file = path.join(compDir, `${name}.js`);
+  if (!fs.existsSync(file)) {
+    console.error(`Component ${name} not found`);
+    return;
+  }
+  const current = fs.readFileSync(file, 'utf8');
+  const header = parseHeader(current);
+  if (!header.version) {
+    console.error(`No version header in ${file}`);
+    return;
+  }
+  const basePath = path.join(tmplDir, name, header.version, `${name}.js`);
+  const incomingPath = path.join(tmplDir, name, 'latest', `${name}.js`);
+  if (!fs.existsSync(basePath) || !fs.existsSync(incomingPath)) {
+    console.error(`Template missing for ${name}`);
+    return;
+  }
+  const base = fs.readFileSync(basePath, 'utf8');
+  const incoming = fs.readFileSync(incomingPath, 'utf8');
+  const { text, conflict } = mergeFiles(current, base, incoming);
+  if (opts.check) {
+    console.log(`${name}: ${header.version} -> latest${conflict ? ' (conflict)' : ''}`);
+    return;
+  }
+  if (opts.diff) {
+    const tmp = text.split('\n');
+    const orig = current.split('\n');
+    const diff = require('diff').createPatch(file, current, text);
+    console.log(diff);
+  }
+  if (!opts.dry) {
+    const bak = backupFile(file);
+    fs.writeFileSync(file, text, 'utf8');
+    console.log(`Upgraded ${name} (backup ${bak})${conflict ? ' with conflicts' : ''}`);
+  }
+}
+
+function run() {
+  const args = minimist(process.argv.slice(2), {
+    boolean: ['check', 'dry', 'diff'],
+    string: ['rollback'],
+  });
+  if (args.rollback) {
+    const dir = path.join(process.cwd(), 'backups');
+    const backups = fs.readdirSync(dir).filter(f => f.startsWith(args.rollback));
+    if (backups.length === 0) {
+      console.error('No backup found');
+      return;
+    }
+    const latest = backups.sort().pop();
+    fs.copyFileSync(path.join(dir, latest), path.join(process.cwd(), 'components', `${args.rollback}.js`));
+    console.log(`Rolled back ${args.rollback} from ${latest}`);
+    return;
+  }
+  const components = args._.length ? args._ : fs.readdirSync(path.join(process.cwd(), 'components')).map(f => path.basename(f, '.js'));
+  components.forEach(c => upgradeComponent(c, args));
+}
+
+run();

--- a/templates/button/1.0.0/button.js
+++ b/templates/button/1.0.0/button.js
@@ -1,0 +1,8 @@
+/**
+ * @refraction-version 1.0.0
+ * @refraction-component button
+ * @refraction-updated 2024-01-01
+ */
+export function Button({ label }) {
+  return `<button>${label}</button>`;
+}

--- a/templates/button/latest/button.js
+++ b/templates/button/latest/button.js
@@ -1,0 +1,9 @@
+/**
+ * @refraction-version 1.1.0
+ * @refraction-component button
+ * @refraction-updated 2024-07-25
+ */
+export function Button({ label, variant }) {
+  const cls = variant === 'primary' ? 'btn-primary' : 'btn-secondary';
+  return `<button class="${cls}">${label}</button>`;
+}


### PR DESCRIPTION
## Summary
- add a tiny CLI package with an `upgrade` script
- implement diff3 merging, backups and rollback
- include example `button` component and templates

## Testing
- `node packages/cli/upgrade.js --check button`
- `node packages/cli/upgrade.js button`
- `node packages/cli/upgrade.js --rollback button`


------
https://chatgpt.com/codex/tasks/task_b_6883114decc8832c90a95e368073ba33