### PR TITLE
Add simple docs site

### DIFF
--- a/site/cli.html
+++ b/site/cli.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CLI - Refraction UI</title>
+  <meta name="description" content="CLI documentation" />
+  <meta property="og:title" content="Refraction UI" />
+  <meta property="og:description" content="Refraction UI documentation" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Getting Started</a>
+      <a href="components.html">Components</a>
+      <a href="cli.html">CLI</a>
+      <a href="playground.html">Token Playground</a>
+    </nav>
+  </header>
+  <div class="container">
+    <h1>CLI Documentation</h1>
+    <pre><code>refraction-ui init
+refraction-ui add <component>
+refraction-ui tokens build
+</code></pre>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/components.html
+++ b/site/components.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Components - Refraction UI</title>
+  <meta name="description" content="Component API documentation" />
+  <meta property="og:title" content="Refraction UI" />
+  <meta property="og:description" content="Refraction UI documentation" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Getting Started</a>
+      <a href="components.html">Components</a>
+      <a href="cli.html">CLI</a>
+      <a href="playground.html">Token Playground</a>
+    </nav>
+  </header>
+  <div class="container">
+    <h1>Component API</h1>
+    <p>Documentation for each component will go here.</p>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Getting Started - Refraction UI</title>
+  <meta name="description" content="Getting started with Refraction UI" />
+  <meta property="og:title" content="Refraction UI" />
+  <meta property="og:description" content="Refraction UI documentation" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Getting Started</a>
+      <a href="components.html">Components</a>
+      <a href="cli.html">CLI</a>
+      <a href="playground.html">Token Playground</a>
+    </nav>
+  </header>
+  <div class="container">
+    <h1>Getting Started</h1>
+    <p>Install the CLI and components:</p>
+    <pre><code>npm install @refraction-ui/react
+npx refraction-ui init
+</code></pre>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Refraction UI Docs</title>
+  <meta name="description" content="Refraction UI documentation" />
+  <meta property="og:title" content="Refraction UI" />
+  <meta property="og:description" content="Refraction UI documentation" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Getting Started</a>
+      <a href="components.html">Components</a>
+      <a href="cli.html">CLI</a>
+      <a href="playground.html">Token Playground</a>
+      <input id="search" placeholder="Search" oninput="searchDocs()" />
+      <button onclick="toggleTheme()">Toggle Theme</button>
+    </nav>
+  </header>
+  <div class="container">
+    <h1>Welcome to Refraction UI</h1>
+    <p>Modern theming-first React component library.</p>
+    <article>
+      <nav>
+        <a href="getting-started.html">Getting Started guide</a><br/>
+        <a href="components.html">Component API</a><br/>
+        <a href="cli.html">CLI Documentation</a><br/>
+        <a href="playground.html">Token Playground</a>
+      </nav>
+    </article>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/playground.html
+++ b/site/playground.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Token Playground - Refraction UI</title>
+  <meta name="description" content="Interactive token playground" />
+  <meta property="og:title" content="Refraction UI" />
+  <meta property="og:description" content="Refraction UI documentation" />
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    textarea { width: 100%; height: 150px; }
+    #cssOutput { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="getting-started.html">Getting Started</a>
+      <a href="components.html">Components</a>
+      <a href="cli.html">CLI</a>
+      <a href="playground.html">Token Playground</a>
+    </nav>
+  </header>
+  <div class="container">
+    <h1>Token Playground</h1>
+    <p>Edit tokens JSON to see generated CSS variables.</p>
+    <textarea id="tokens" aria-label="tokens"></textarea>
+    <button onclick="buildCSS()">Build CSS</button>
+    <pre id="cssOutput"></pre>
+  </div>
+  <script src="script.js"></script>
+  <script>
+  function buildCSS() {
+    try {
+      const data = JSON.parse(document.getElementById('tokens').value);
+      const lines = [];
+      for (const [key, value] of Object.entries(data)) {
+        lines.push(`--${key}: ${value};`);
+      }
+      document.getElementById('cssOutput').textContent = ':root {\n  ' + lines.join('\n  ') + '\n}';
+    } catch (e) {
+      document.getElementById('cssOutput').textContent = 'Invalid JSON';
+    }
+  }
+  </script>
+</body>
+</html>

--- a/site/script.js
+++ b/site/script.js
@@ -1,0 +1,13 @@
+function toggleTheme() {
+  const body = document.body;
+  body.classList.toggle('dark');
+}
+
+function searchDocs() {
+  const term = document.getElementById('search').value.toLowerCase();
+  const links = document.querySelectorAll('article nav a');
+  links.forEach(a => {
+    const text = a.textContent.toLowerCase();
+    a.style.display = text.includes(term) ? '' : 'none';
+  });
+}

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+header {
+  background: #5c6ac4;
+  color: white;
+  padding: 1rem;
+}
+nav a {
+  color: white;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+@media (max-width: 600px) {
+  .container { padding: .5rem; }
+  nav a { display: block; margin: .5rem 0; }
+}
+pre {
+  background: #f5f5f5;
+  padding: 1rem;
+  overflow: auto;
+}
+body.dark {
+  background: #121212;
+  color: #f0f0f0;
+}
+body.dark a { color: #9bb0ff; }


### PR DESCRIPTION
## Summary
- add a `site` folder with basic HTML docs
- provide getting started, component and CLI pages
- include a token playground page with live CSS output
- implement search, theme switcher, responsive layout and SEO tags

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6883116d5940832cb382edb9dba7ca41