### PR TITLE
Implement minimal MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,15 @@ Details: see `docs/contracts/cli-spec.md`.
 
 ## 🤖 MCP server
 
-Run:
+Run the server with Node. Set `MCP_TOKEN` for authentication. Use the `ws` flag to enable the WebSocket transport.
 
 ```bash
-pnpm --filter @refraction-ui/mcp-server dev
+MCP_TOKEN=secret node packages/mcp-server/src/index.js       # stdio mode
+MCP_TOKEN=secret node packages/mcp-server/src/index.js ws    # WebSocket on :8123
 ```
 
-Tools: `generate_component`, `scaffold_flow` (auth), `convert_tokens`, `a11y_check`, `upgrade_component`, `docs_lookup`.  
+Tools exposed via JSON-RPC:
+`add_component`, `upgrade_component`, `build_tokens`, `validate_tokens`, `init_project`, `a11y_test`.
 Schemas live in `docs/contracts/schemas/`.
 
 ## ♿ Accessibility

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-server",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^8.18.3",
+        "zod": "^4.0.10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.10.tgz",
+      "integrity": "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "node --test",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "ws": "^8.18.3",
+    "zod": "^4.0.10"
+  },
+  "type": "module"
+}

--- a/packages/mcp-server/src/cli-tools.js
+++ b/packages/mcp-server/src/cli-tools.js
@@ -1,0 +1,29 @@
+export async function add_component(params) {
+  console.log('Executing add_component with', params);
+  return { success: true, files: [] };
+}
+
+export async function upgrade_component(params) {
+  console.log('Executing upgrade_component with', params);
+  return { success: true, files: [] };
+}
+
+export async function build_tokens(params) {
+  console.log('Executing build_tokens with', params);
+  return { success: true };
+}
+
+export async function validate_tokens(params) {
+  console.log('Executing validate_tokens with', params);
+  return { valid: true };
+}
+
+export async function init_project(params) {
+  console.log('Executing init_project with', params);
+  return { success: true };
+}
+
+export async function a11y_test(params) {
+  console.log('Executing a11y_test with', params);
+  return { success: true, violations: [] };
+}

--- a/packages/mcp-server/src/index.js
+++ b/packages/mcp-server/src/index.js
@@ -1,0 +1,91 @@
+import { createInterface } from 'node:readline';
+import { WebSocketServer } from 'ws';
+import {
+  add_component,
+  upgrade_component,
+  build_tokens,
+  validate_tokens,
+  init_project,
+  a11y_test,
+} from './cli-tools.js';
+import {
+  addComponentSchema,
+  upgradeComponentSchema,
+  buildTokensSchema,
+  validateTokensSchema,
+  initProjectSchema,
+  a11yTestSchema,
+} from './schemas.js';
+
+const AUTH_TOKEN = process.env.MCP_TOKEN || 'secret';
+
+const methods = {
+  add_component: [addComponentSchema, add_component],
+  upgrade_component: [upgradeComponentSchema, upgrade_component],
+  build_tokens: [buildTokensSchema, build_tokens],
+  validate_tokens: [validateTokensSchema, validate_tokens],
+  init_project: [initProjectSchema, init_project],
+  a11y_test: [a11yTestSchema, a11y_test],
+};
+
+function handleRpc(request, respond) {
+  if (request.jsonrpc !== '2.0' || !request.method) {
+    return respond({ jsonrpc: '2.0', id: request.id || null, error: { code: -32600, message: 'Invalid Request' } });
+  }
+  const entry = methods[request.method];
+  if (!entry) {
+    return respond({ jsonrpc: '2.0', id: request.id || null, error: { code: -32601, message: 'Method not found' } });
+  }
+  const [schema, fn] = entry;
+  try {
+    const params = schema.parse(request.params);
+    if (params.authToken !== AUTH_TOKEN) {
+      return respond({ jsonrpc: '2.0', id: request.id || null, error: { code: -32000, message: 'Unauthorized' } });
+    }
+    fn(params).then(result => {
+      respond({ jsonrpc: '2.0', id: request.id || null, result });
+    }).catch(err => {
+      respond({ jsonrpc: '2.0', id: request.id || null, error: { code: -32001, message: err.message } });
+    });
+  } catch (e) {
+    respond({ jsonrpc: '2.0', id: request.id || null, error: { code: -32602, message: e.message } });
+  }
+}
+
+export function startStdioServer() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+  rl.on('line', line => {
+    if (!line.trim()) return;
+    try {
+      const msg = JSON.parse(line);
+      handleRpc(msg, resp => {
+        process.stdout.write(JSON.stringify(resp) + '\n');
+      });
+    } catch (err) {
+      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }) + '\n');
+    }
+  });
+  console.log('MCP stdio server ready');
+}
+
+export function startWebSocketServer(port = 8123) {
+  const wss = new WebSocketServer({ port });
+  wss.on('connection', ws => {
+    ws.on('message', data => {
+      try {
+        const msg = JSON.parse(data.toString());
+        handleRpc(msg, resp => ws.send(JSON.stringify(resp)));
+      } catch {
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
+      }
+    });
+  });
+  console.log('MCP WebSocket server listening on', port);
+  return wss;
+}
+
+if (process.argv[2] === 'ws') {
+  startWebSocketServer(process.env.PORT ? Number(process.env.PORT) : 8123);
+} else {
+  startStdioServer();
+}

--- a/packages/mcp-server/src/schemas.js
+++ b/packages/mcp-server/src/schemas.js
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const authSchema = z.object({
+  authToken: z.string(),
+});
+
+export const addComponentSchema = authSchema.merge(z.object({
+  component: z.string(),
+  variant: z.string().optional(),
+  size: z.string().optional(),
+  output: z.string().optional(),
+}));
+
+export const upgradeComponentSchema = authSchema.merge(z.object({
+  path: z.string(),
+  targetVersion: z.string().optional(),
+}));
+
+export const buildTokensSchema = authSchema.merge(z.object({}));
+
+export const validateTokensSchema = authSchema.merge(z.object({}));
+
+export const initProjectSchema = authSchema.merge(z.object({}));
+
+export const a11yTestSchema = authSchema.merge(z.object({}));

--- a/packages/mcp-server/test/basic.test.js
+++ b/packages/mcp-server/test/basic.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import readline from 'node:readline';
+
+test('add_component via stdio', async (t) => {
+  const child = spawn('node', ['src/index.js'], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+    env: { ...process.env, MCP_TOKEN: 'secret' }
+  });
+  const rl = readline.createInterface({ input: child.stdout });
+  const msg = { jsonrpc: '2.0', id: 1, method: 'add_component', params: { component: 'Button', authToken: 'secret' } };
+  const lines = [];
+  rl.on('line', line => lines.push(line));
+  await once(rl, 'line'); // server ready
+  child.stdin.write(JSON.stringify(msg) + '\n');
+  await once(rl, 'line');
+  await once(rl, 'line');
+  const response = JSON.parse(lines[2]);
+  assert.equal(response.result.success, true);
+  child.kill();
+  await once(child, 'exit');
+});


### PR DESCRIPTION
## Summary
- add new `mcp-server` package
- implement JSON-RPC server with stdio and WebSocket transports
- validate requests with Zod schemas and support token auth
- expose stub CLI methods
- document server usage in README
- add basic test for stdio server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688311711bb8832cb65264c97f922c21