### PR TITLE
feat(astro): add ai component

### DIFF
--- a/packages/astro-ai/src/AIScript.astro
+++ b/packages/astro-ai/src/AIScript.astro
@@ -1,0 +1,69 @@
+---
+/**
+ * AIScript — injects a <script> that initializes the AI client on the page.
+ * Exposes `window.__rfr_ai` for other scripts to call generateText / generateJSON.
+ *
+ * Props mirror AIConfig from @refraction-ui/ai.
+ */
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Default provider name */
+  default?: string
+  /** Fallback chain of provider names */
+  fallback?: string[]
+}
+
+const { default: defaultProvider, fallback, ...props } = Astro.props
+
+const configJSON = JSON.stringify({
+  default: defaultProvider,
+  fallback,
+})
+---
+
+<script
+  data-rfr-ai-config={configJSON}
+  {...props}
+  is:inline
+>
+  ;(function () {
+    // Only initialize once
+    if (window.__rfr_ai) return
+
+    // We cannot import ES modules from an inline script, so we stash the config
+    // and let the consumer call the init function from their own module script.
+    // This inline script sets up the namespace and a deferred init helper.
+    var configEl = document.querySelector('[data-rfr-ai-config]')
+    var config = {}
+    if (configEl) {
+      try { config = JSON.parse(configEl.getAttribute('data-rfr-ai-config') || '{}') } catch (_) { /* */ }
+    }
+
+    // Placeholder that will be replaced once createAI is called
+    window.__rfr_ai = {
+      _config: config,
+      _api: null,
+      _ready: false,
+      init: function (createAI, providers) {
+        var api = createAI(config)
+        if (providers) {
+          Object.keys(providers).forEach(function (name) {
+            api.addProvider(name, providers[name])
+          })
+        }
+        window.__rfr_ai._api = api
+        window.__rfr_ai._ready = true
+        window.__rfr_ai.generateText = api.generateText.bind(api)
+        window.__rfr_ai.generateJSON = api.generateJSON.bind(api)
+        window.__rfr_ai.addProvider = api.addProvider.bind(api)
+        window.__rfr_ai.removeProvider = api.removeProvider.bind(api)
+        window.__rfr_ai.providers = api.providers
+      },
+      generateText: function () { throw new Error('AI not initialized. Call window.__rfr_ai.init(createAI, providers) first.') },
+      generateJSON: function () { throw new Error('AI not initialized. Call window.__rfr_ai.init(createAI, providers) first.') },
+      addProvider: function () { throw new Error('AI not initialized.') },
+      removeProvider: function () { throw new Error('AI not initialized.') },
+      providers: [],
+    }
+  })()
+</script>

--- a/packages/astro-ai/src/TTSScript.astro
+++ b/packages/astro-ai/src/TTSScript.astro
@@ -1,0 +1,60 @@
+---
+/**
+ * TTSScript — injects a <script> that initializes TTS on the page.
+ * Exposes `window.__rfr_tts` for other scripts to call speak / stop.
+ *
+ * Props mirror TTSConfig from @refraction-ui/ai.
+ */
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Default TTS provider name */
+  default?: string
+}
+
+const { default: defaultProvider, ...props } = Astro.props
+
+const configJSON = JSON.stringify({
+  default: defaultProvider,
+})
+---
+
+<script
+  data-rfr-tts-config={configJSON}
+  {...props}
+  is:inline
+>
+  ;(function () {
+    if (window.__rfr_tts) return
+
+    var configEl = document.querySelector('[data-rfr-tts-config]')
+    var config = {}
+    if (configEl) {
+      try { config = JSON.parse(configEl.getAttribute('data-rfr-tts-config') || '{}') } catch (_) { /* */ }
+    }
+
+    window.__rfr_tts = {
+      _config: config,
+      _api: null,
+      _ready: false,
+      init: function (createTTS, providers) {
+        var api = createTTS(config)
+        if (providers) {
+          Object.keys(providers).forEach(function (name) {
+            api.addProvider(name, providers[name])
+          })
+        }
+        window.__rfr_tts._api = api
+        window.__rfr_tts._ready = true
+        window.__rfr_tts.speak = api.speak.bind(api)
+        window.__rfr_tts.stop = api.stop.bind(api)
+        window.__rfr_tts.addProvider = api.addProvider.bind(api)
+        window.__rfr_tts.providers = api.providers
+      },
+      speak: function () { throw new Error('TTS not initialized. Call window.__rfr_tts.init(createTTS, providers) first.') },
+      stop: function () { throw new Error('TTS not initialized.') },
+      addProvider: function () { throw new Error('TTS not initialized.') },
+      providers: [],
+      isSpeaking: false,
+    }
+  })()
+</script>

--- a/packages/astro-ai/src/index.ts
+++ b/packages/astro-ai/src/index.ts
@@ -1,1 +1,16 @@
-export {}
+export { default as AIScript } from './AIScript.astro'
+export { default as TTSScript } from './TTSScript.astro'
+
+// Re-export core types and factories for convenience
+export {
+  createAI,
+  createTTS,
+  type AIConfig,
+  type TTSConfig,
+  type AIAPI,
+  type TTSAPI,
+  type AIProvider,
+  type TTSProvider,
+  type GenerateOptions,
+  type TTSOptions,
+} from '@refraction-ui/ai'


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-ai`
- Uses headless `@refraction-ui/ai` core for logic, variants, and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)