### PR TITLE
feat(astro): add animated-text component

### DIFF
--- a/packages/astro-animated-text/src/AnimatedText.astro
+++ b/packages/astro-animated-text/src/AnimatedText.astro
@@ -1,0 +1,81 @@
+---
+import { animatedTextVariants } from '@refraction-ui/animated-text'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Array of words to cycle through */
+  words: string[]
+  /** Interval between word changes in ms. Default: 2500 */
+  interval?: number
+  /** Duration of the transition in ms. Default: 1000 */
+  transitionDuration?: number
+}
+
+const {
+  words,
+  interval = 2500,
+  transitionDuration = 1000,
+  class: className,
+  ...props
+} = Astro.props
+
+const classes = cn(animatedTextVariants({ state: 'idle' }), className)
+---
+
+<span
+  data-rfr-animated-text
+  data-rfr-animated-words={JSON.stringify(words)}
+  data-rfr-animated-interval={interval}
+  data-rfr-animated-transition-duration={transitionDuration}
+  class={classes}
+  aria-live="polite"
+  aria-atomic="true"
+  {...props}
+>
+  {words.length > 0 ? words[0] : ''}
+</span>
+
+<script>
+  function initAnimatedTexts() {
+    document.querySelectorAll<HTMLElement>('[data-rfr-animated-text]').forEach((el) => {
+      if (el.hasAttribute('data-rfr-animated-text-init')) return
+      el.setAttribute('data-rfr-animated-text-init', '')
+
+      const words: string[] = JSON.parse(el.getAttribute('data-rfr-animated-words') || '[]')
+      const interval = Number(el.getAttribute('data-rfr-animated-interval') || 2500)
+      const transitionDuration = Number(el.getAttribute('data-rfr-animated-transition-duration') || 1000)
+
+      if (words.length <= 1) return
+
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      let currentIndex = 0
+
+      const tick = setInterval(() => {
+        if (prefersReducedMotion) {
+          currentIndex = (currentIndex + 1) % words.length
+          el.textContent = words[currentIndex]
+        } else {
+          // Exit transition
+          el.style.opacity = '0'
+          setTimeout(() => {
+            currentIndex = (currentIndex + 1) % words.length
+            el.textContent = words[currentIndex]
+            // Enter transition
+            el.style.opacity = '1'
+          }, transitionDuration / 2)
+        }
+      }, interval)
+
+      // Set transition style if motion is allowed
+      if (!prefersReducedMotion) {
+        el.style.transition = `opacity ${transitionDuration / 2}ms ease`
+      }
+
+      // Cleanup on removal (Astro page transitions)
+      el.addEventListener('astro:before-swap', () => clearInterval(tick), { once: true })
+    })
+  }
+
+  initAnimatedTexts()
+  document.addEventListener('astro:after-swap', initAnimatedTexts)
+</script>

--- a/packages/astro-animated-text/src/TypewriterText.astro
+++ b/packages/astro-animated-text/src/TypewriterText.astro
@@ -1,0 +1,90 @@
+---
+import { typewriterVariants } from '@refraction-ui/animated-text'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** The text to type out */
+  text: string
+  /** Typing speed in ms per character. Default: 50 */
+  speed?: number
+  /** Delay before starting in ms. Default: 0 */
+  startDelay?: number
+}
+
+const {
+  text,
+  speed = 50,
+  startDelay = 0,
+  class: className,
+  ...props
+} = Astro.props
+
+const classes = cn(typewriterVariants({ cursor: 'blinking' }), className)
+---
+
+<span
+  data-rfr-typewriter
+  data-rfr-typewriter-text={text}
+  data-rfr-typewriter-speed={speed}
+  data-rfr-typewriter-start-delay={startDelay}
+  class={classes}
+  aria-label={text}
+  {...props}
+></span>
+
+<script>
+  function initTypewriters() {
+    document.querySelectorAll<HTMLElement>('[data-rfr-typewriter]').forEach((el) => {
+      if (el.hasAttribute('data-rfr-typewriter-init')) return
+      el.setAttribute('data-rfr-typewriter-init', '')
+
+      const text = el.getAttribute('data-rfr-typewriter-text') || ''
+      const speed = Number(el.getAttribute('data-rfr-typewriter-speed') || 50)
+      const startDelay = Number(el.getAttribute('data-rfr-typewriter-start-delay') || 0)
+
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+      if (prefersReducedMotion) {
+        el.textContent = text
+        // Remove cursor classes when complete
+        el.className = el.className
+          .replace(/after:inline-block/g, '')
+          .replace(/after:w-\[2px\]/g, '')
+          .replace(/after:h-\[1em\]/g, '')
+          .replace(/after:bg-current/g, '')
+          .replace(/after:ml-\[1px\]/g, '')
+          .replace(/after:animate-blink/g, '')
+          .replace(/after:align-text-bottom/g, '')
+        return
+      }
+
+      let currentIndex = 0
+
+      const startTimeout = setTimeout(() => {
+        function tick() {
+          if (currentIndex < text.length) {
+            currentIndex += 1
+            el.textContent = text.slice(0, currentIndex)
+            setTimeout(tick, speed)
+          } else {
+            // Typing complete — remove cursor
+            el.className = el.className
+              .replace(/after:inline-block/g, '')
+              .replace(/after:w-\[2px\]/g, '')
+              .replace(/after:h-\[1em\]/g, '')
+              .replace(/after:bg-current/g, '')
+              .replace(/after:ml-\[1px\]/g, '')
+              .replace(/after:animate-blink/g, '')
+              .replace(/after:align-text-bottom/g, '')
+          }
+        }
+        tick()
+      }, startDelay)
+
+      el.addEventListener('astro:before-swap', () => clearTimeout(startTimeout), { once: true })
+    })
+  }
+
+  initTypewriters()
+  document.addEventListener('astro:after-swap', initTypewriters)
+</script>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-animated-text`
- Uses headless `@refraction-ui/animated-text` core for logic, variants, and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)