### PR TITLE
feat(astro): add app-shell component

### DIFF
--- a/packages/astro-app-shell/src/AppShell.astro
+++ b/packages/astro-app-shell/src/AppShell.astro
@@ -1,0 +1,195 @@
+---
+/**
+ * AppShell — root layout container for app-style layouts with sidebar, header, and main content.
+ * Includes a client-side script for responsive breakpoint detection and sidebar toggling.
+ */
+import { createAppShell, type AppShellConfig } from '@refraction-ui/app-shell'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Sidebar width when expanded (default '16rem') */
+  sidebarWidth?: string
+  /** Sidebar width when collapsed (default '4rem') */
+  sidebarCollapsedWidth?: string
+  /** Header height (default '3.5rem') */
+  headerHeight?: string
+  /** Breakpoint below which layout is mobile (default 768) */
+  mobileBreakpoint?: number
+  /** Breakpoint below which layout is tablet (default 1024) */
+  tabletBreakpoint?: number
+  /** Sidebar position (default 'left') */
+  sidebarPosition?: 'left' | 'right'
+  /** Whether sidebar can collapse on desktop (default true) */
+  sidebarCollapsible?: boolean
+  /** Whether sidebar starts collapsed (default false) */
+  sidebarDefaultCollapsed?: boolean
+  /** Mobile nav position (default 'bottom') */
+  mobileNavPosition?: 'bottom' | 'none'
+}
+
+const {
+  sidebarWidth,
+  sidebarCollapsedWidth,
+  headerHeight,
+  mobileBreakpoint,
+  tabletBreakpoint,
+  sidebarPosition,
+  sidebarCollapsible,
+  sidebarDefaultCollapsed,
+  mobileNavPosition,
+  class: className,
+  ...props
+} = Astro.props
+
+const config: AppShellConfig = {
+  sidebarWidth,
+  sidebarCollapsedWidth,
+  headerHeight,
+  mobileBreakpoint,
+  tabletBreakpoint,
+  sidebarPosition,
+  sidebarCollapsible,
+  sidebarDefaultCollapsed,
+  mobileNavPosition,
+}
+
+const api = createAppShell(config)
+const cssVars = api.getCSSVariables()
+const styleStr = Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')
+
+const configJSON = JSON.stringify(api.config)
+---
+
+<div
+  class={cn('flex h-screen w-full overflow-hidden', className)}
+  style={styleStr}
+  data-rfr-shell
+  data-rfr-shell-config={configJSON}
+  {...props}
+>
+  <slot />
+</div>
+
+<script is:inline>
+  ;(function () {
+    var shell = document.querySelector('[data-rfr-shell]')
+    if (!shell) return
+
+    var config = {}
+    try { config = JSON.parse(shell.getAttribute('data-rfr-shell-config') || '{}') } catch (_) { /* */ }
+
+    var mobileBp = config.mobileBreakpoint || 768
+    var tabletBp = config.tabletBreakpoint || 1024
+    var sidebarCollapsible = config.sidebarCollapsible !== false
+    var sidebarWidth = config.sidebarWidth || '16rem'
+    var sidebarCollapsedWidth = config.sidebarCollapsedWidth || '4rem'
+    var sidebarPosition = config.sidebarPosition || 'left'
+
+    var state = {
+      breakpoint: 'desktop',
+      sidebarOpen: false,
+      sidebarCollapsed: config.sidebarDefaultCollapsed || false,
+    }
+
+    function isMobile() { return state.breakpoint === 'mobile' }
+
+    function updateBreakpoint() {
+      var w = window.innerWidth
+      var bp = w < mobileBp ? 'mobile' : w < tabletBp ? 'tablet' : 'desktop'
+      if (bp !== state.breakpoint) {
+        state.breakpoint = bp
+        if (bp !== 'mobile') state.sidebarOpen = false
+        applyState()
+      }
+    }
+
+    function toggleSidebar() {
+      if (isMobile()) {
+        state.sidebarOpen = !state.sidebarOpen
+      } else if (sidebarCollapsible) {
+        state.sidebarCollapsed = !state.sidebarCollapsed
+      }
+      applyState()
+    }
+
+    function closeSidebar() {
+      state.sidebarOpen = false
+      applyState()
+    }
+
+    function applyState() {
+      var sidebar = shell.querySelector('[data-rfr-shell-sidebar]')
+      var overlay = shell.querySelector('[data-rfr-shell-overlay]')
+      var mobileNav = shell.querySelector('[data-rfr-shell-mobile-nav]')
+      var hamburgers = shell.querySelectorAll('[data-rfr-shell-toggle]')
+
+      // Update CSS variable for sidebar width
+      var currentWidth = state.sidebarCollapsed ? sidebarCollapsedWidth : sidebarWidth
+      shell.style.setProperty('--shell-sidebar-width', currentWidth)
+
+      if (sidebar) {
+        if (isMobile()) {
+          sidebar.style.position = 'fixed'
+          sidebar.style.top = '0'
+          sidebar.style.zIndex = '40'
+          sidebar.style.width = sidebarWidth
+          sidebar.style[sidebarPosition === 'right' ? 'right' : 'left'] = '0'
+          sidebar.style.transform = state.sidebarOpen
+            ? 'translateX(0)'
+            : sidebarPosition === 'right' ? 'translateX(100%)' : 'translateX(-100%)'
+          sidebar.removeAttribute('data-collapsed')
+        } else {
+          sidebar.style.position = 'relative'
+          sidebar.style.transform = ''
+          sidebar.style.width = currentWidth
+          if (state.sidebarCollapsed) {
+            sidebar.setAttribute('data-collapsed', '')
+          } else {
+            sidebar.removeAttribute('data-collapsed')
+          }
+        }
+        if (state.sidebarOpen) {
+          sidebar.setAttribute('data-open', '')
+        } else {
+          sidebar.removeAttribute('data-open')
+        }
+      }
+
+      if (overlay) {
+        if (isMobile() && state.sidebarOpen) {
+          overlay.style.display = ''
+        } else {
+          overlay.style.display = 'none'
+        }
+      }
+
+      if (mobileNav) {
+        mobileNav.style.display = isMobile() ? '' : 'none'
+      }
+
+      hamburgers.forEach(function (btn) {
+        btn.setAttribute('aria-expanded', String(state.sidebarOpen))
+      })
+    }
+
+    // Bind toggle buttons
+    shell.addEventListener('click', function (e) {
+      var toggle = e.target.closest('[data-rfr-shell-toggle]')
+      if (toggle) {
+        toggleSidebar()
+        return
+      }
+      var overlayClick = e.target.closest('[data-rfr-shell-overlay]')
+      if (overlayClick) {
+        closeSidebar()
+      }
+    })
+
+    // Expose API for external scripts
+    window.__rfr_shell = { toggleSidebar: toggleSidebar, closeSidebar: closeSidebar, state: state }
+
+    // Responsive listener
+    window.addEventListener('resize', updateBreakpoint)
+    updateBreakpoint()
+  })()
+</script>

--- a/packages/astro-app-shell/src/AppShellContent.astro
+++ b/packages/astro-app-shell/src/AppShellContent.astro
@@ -1,0 +1,29 @@
+---
+/**
+ * AppShellContent — scrollable content area within AppShellMain.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Tailwind max-width class suffix, e.g. '6xl' -> max-w-6xl */
+  maxWidth?: string
+}
+
+const { maxWidth, class: className, ...props } = Astro.props
+
+const mwClass = maxWidth ? `max-w-${maxWidth} mx-auto w-full` : ''
+---
+
+<main
+  role="main"
+  class={cn(
+    'flex-1 overflow-y-auto',
+    mwClass,
+    'px-4 sm:px-6 lg:px-8 py-6',
+    className,
+  )}
+  data-rfr-shell-content
+  {...props}
+>
+  <slot />
+</main>

--- a/packages/astro-app-shell/src/AppShellHeader.astro
+++ b/packages/astro-app-shell/src/AppShellHeader.astro
@@ -1,0 +1,54 @@
+---
+/**
+ * AppShellHeader — header area within the AppShell.
+ * On mobile, automatically renders a hamburger toggle button.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Hide the hamburger menu button */
+  hideToggle?: boolean
+}
+
+const { hideToggle, class: className, ...props } = Astro.props
+---
+
+<header
+  role="banner"
+  class={cn(
+    'sticky top-0 z-30 flex items-center shrink-0',
+    'h-[var(--shell-header-height)]',
+    'border-b bg-background px-4',
+    className,
+  )}
+  data-rfr-shell-header
+  {...props}
+>
+  {!hideToggle && (
+    <button
+      type="button"
+      aria-label="Toggle sidebar"
+      aria-expanded="false"
+      class="inline-flex items-center justify-center p-2 mr-2 md:hidden"
+      data-rfr-shell-toggle
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <line x1="3" y1="18" x2="21" y2="18" />
+      </svg>
+    </button>
+  )}
+  <slot />
+</header>

--- a/packages/astro-app-shell/src/AppShellMain.astro
+++ b/packages/astro-app-shell/src/AppShellMain.astro
@@ -1,0 +1,18 @@
+---
+/**
+ * AppShellMain — main content area wrapper (flex column).
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  class={cn('flex flex-1 flex-col min-w-0 h-full', className)}
+  data-rfr-shell-main
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-app-shell/src/AppShellMobileNav.astro
+++ b/packages/astro-app-shell/src/AppShellMobileNav.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * AppShellMobileNav — fixed bottom navigation bar, visible only on mobile.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<nav
+  role="navigation"
+  aria-label="Mobile navigation"
+  class={cn(
+    'fixed bottom-0 left-0 right-0 z-30',
+    'flex items-center justify-around',
+    'border-t bg-background',
+    'h-14',
+    className,
+  )}
+  style="display:none;"
+  data-rfr-shell-mobile-nav
+  {...props}
+>
+  <slot />
+</nav>

--- a/packages/astro-app-shell/src/AppShellOverlay.astro
+++ b/packages/astro-app-shell/src/AppShellOverlay.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * AppShellOverlay — backdrop overlay shown when mobile sidebar is open.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  aria-hidden="true"
+  class={cn(
+    'fixed inset-0 z-30 bg-black/50 transition-opacity',
+    className,
+  )}
+  style="display:none;"
+  data-rfr-shell-overlay
+  {...props}
+/>

--- a/packages/astro-app-shell/src/AppShellSidebar.astro
+++ b/packages/astro-app-shell/src/AppShellSidebar.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * AppShellSidebar — sidebar navigation area within the AppShell.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<aside
+  role="navigation"
+  aria-label="Sidebar"
+  class={cn(
+    'flex flex-col shrink-0 overflow-y-auto overflow-x-hidden',
+    'bg-background border-r',
+    'transition-[width,transform] duration-200 ease-in-out',
+    'h-full relative w-[var(--shell-sidebar-width)]',
+    className,
+  )}
+  data-rfr-shell-sidebar
+  {...props}
+>
+  <slot />
+</aside>

--- a/packages/astro-app-shell/src/AuthShell.astro
+++ b/packages/astro-app-shell/src/AuthShell.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * AuthShell — centered layout for authentication pages (sign-in, sign-up, etc.).
+ */
+import { createAuthShell, type AuthShellConfig } from '@refraction-ui/app-shell'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Card max-width preset (default 'sm') */
+  maxWidth?: 'xs' | 'sm' | 'md'
+  /** Card position (default 'center') */
+  position?: 'center' | 'left'
+  /** Show decorative background (default true) */
+  showBackground?: boolean
+}
+
+const { maxWidth, position, showBackground, class: className, ...props } = Astro.props
+
+const config: AuthShellConfig = { maxWidth, position, showBackground }
+const api = createAuthShell(config)
+---
+
+<div
+  role="main"
+  aria-label="Authentication"
+  class={cn(api.containerClasses, className)}
+  data-rfr-auth-shell
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-app-shell/src/AuthShellCard.astro
+++ b/packages/astro-app-shell/src/AuthShellCard.astro
@@ -1,0 +1,24 @@
+---
+/**
+ * AuthShellCard — card container within AuthShell for form content.
+ */
+import { createAuthShell, type AuthShellConfig } from '@refraction-ui/app-shell'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Card max-width preset (default 'sm') */
+  maxWidth?: 'xs' | 'sm' | 'md'
+}
+
+const { maxWidth, class: className, ...props } = Astro.props
+
+const api = createAuthShell({ maxWidth })
+---
+
+<div
+  class={cn(api.cardClasses, className)}
+  data-rfr-auth-card
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-app-shell/src/PageShell.astro
+++ b/packages/astro-app-shell/src/PageShell.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * PageShell — root layout for marketing/landing pages with nav, sections, footer.
+ */
+import { createPageShell, type PageShellConfig } from '@refraction-ui/app-shell'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Max width for contained sections (default '80rem') */
+  maxWidth?: string
+  /** Navigation bar height (default '4rem') */
+  navHeight?: string
+  /** Whether nav is transparent (default false) */
+  navTransparent?: boolean
+  /** Whether nav is sticky (default true) */
+  navSticky?: boolean
+  /** Number of footer columns (default 4) */
+  footerColumns?: number
+}
+
+const { maxWidth, navHeight, navTransparent, navSticky, footerColumns, class: className, ...props } = Astro.props
+
+const config: PageShellConfig = { maxWidth, navHeight, navTransparent, navSticky, footerColumns }
+const api = createPageShell(config)
+const cssVars = api.getCSSVariables()
+const styleStr = Object.entries(cssVars).map(([k, v]) => `${k}:${v}`).join(';')
+---
+
+<div
+  class={cn('flex min-h-screen flex-col', className)}
+  style={styleStr}
+  data-rfr-page-shell
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-app-shell/src/PageShellFooter.astro
+++ b/packages/astro-app-shell/src/PageShellFooter.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * PageShellFooter — footer area within PageShell.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Number of grid columns (default 4) */
+  columns?: number
+}
+
+const { columns = 4, class: className, ...props } = Astro.props
+---
+
+<footer
+  role="contentinfo"
+  class={cn(
+    'border-t bg-muted py-12 px-4 sm:px-6 lg:px-8',
+    className,
+  )}
+  data-rfr-page-footer
+  {...props}
+>
+  <div
+    class="mx-auto max-w-[var(--page-max-width)] grid gap-8"
+    style={`grid-template-columns: repeat(${columns}, minmax(0, 1fr));`}
+  >
+    <slot />
+  </div>
+</footer>

--- a/packages/astro-app-shell/src/PageShellNav.astro
+++ b/packages/astro-app-shell/src/PageShellNav.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * PageShellNav — navigation bar within PageShell.
+ */
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Whether nav is sticky (default true) */
+  sticky?: boolean
+  /** Whether nav is transparent (default false) */
+  transparent?: boolean
+}
+
+const { sticky = true, transparent = false, class: className, ...props } = Astro.props
+
+const stickyClass = sticky ? 'sticky top-0 z-40' : ''
+const transparentClass = transparent ? 'bg-transparent' : 'bg-background border-b'
+---
+
+<nav
+  role="navigation"
+  aria-label="Main navigation"
+  class={cn(
+    'flex items-center h-[var(--page-nav-height)] px-4 sm:px-6 lg:px-8',
+    stickyClass,
+    transparentClass,
+    className,
+  )}
+  data-rfr-page-nav
+  {...props}
+>
+  <slot />
+</nav>

--- a/packages/astro-app-shell/src/PageShellSection.astro
+++ b/packages/astro-app-shell/src/PageShellSection.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * PageShellSection — a content section within PageShell.
+ */
+import { createPageShell } from '@refraction-ui/app-shell'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Whether section spans edge-to-edge (default false) */
+  fullWidth?: boolean
+  /** Override max-width for this section */
+  maxWidth?: string
+  /** Whether section has padding (default true) */
+  padding?: boolean
+  /** Background variant */
+  background?: 'default' | 'muted' | 'primary' | 'none'
+}
+
+const { fullWidth, maxWidth, padding, background, class: className, ...props } = Astro.props
+
+// Use the default page shell to get section classes
+const api = createPageShell()
+const sectionClasses = api.getSectionClasses({ fullWidth, maxWidth, padding, background })
+---
+
+<section
+  class={cn('py-12', sectionClasses, className)}
+  data-rfr-page-section
+  {...props}
+>
+  <slot />
+</section>

--- a/packages/astro-app-shell/src/index.ts
+++ b/packages/astro-app-shell/src/index.ts
@@ -1,1 +1,21 @@
-export {}
+// AppShell compound components
+export { default as AppShell } from './AppShell.astro'
+export { default as AppShellSidebar } from './AppShellSidebar.astro'
+export { default as AppShellHeader } from './AppShellHeader.astro'
+export { default as AppShellMain } from './AppShellMain.astro'
+export { default as AppShellContent } from './AppShellContent.astro'
+export { default as AppShellMobileNav } from './AppShellMobileNav.astro'
+export { default as AppShellOverlay } from './AppShellOverlay.astro'
+
+// PageShell compound components
+export { default as PageShell } from './PageShell.astro'
+export { default as PageShellNav } from './PageShellNav.astro'
+export { default as PageShellSection } from './PageShellSection.astro'
+export { default as PageShellFooter } from './PageShellFooter.astro'
+
+// AuthShell compound components
+export { default as AuthShell } from './AuthShell.astro'
+export { default as AuthShellCard } from './AuthShellCard.astro'
+
+// Re-export core types
+export { createAppShell, createPageShell, createAuthShell } from '@refraction-ui/app-shell'


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-app-shell`
- Uses headless `@refraction-ui/app-shell` core for logic, variants, and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)