### PR TITLE
feat(astro): add avatar component

### DIFF
--- a/packages/astro-avatar/src/Avatar.astro
+++ b/packages/astro-avatar/src/Avatar.astro
@@ -1,0 +1,22 @@
+---
+import { createAvatar, avatarVariants, type AvatarSize } from '@refraction-ui/avatar'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  size?: AvatarSize
+}
+
+const { size = 'md', class: className, ...props } = Astro.props
+const api = createAvatar({ size })
+---
+
+<span
+  class={cn(avatarVariants({ size }), className)}
+  data-rfr-avatar
+  data-rfr-avatar-size={size}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</span>

--- a/packages/astro-avatar/src/AvatarFallback.astro
+++ b/packages/astro-avatar/src/AvatarFallback.astro
@@ -1,0 +1,18 @@
+---
+import { avatarFallbackVariants, type AvatarSize } from '@refraction-ui/avatar'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  size?: AvatarSize
+}
+
+const { size = 'md', class: className, ...props } = Astro.props
+---
+
+<span
+  class={cn(avatarFallbackVariants({ size }), className)}
+  data-rfr-avatar-fallback
+  {...props}
+>
+  <slot />
+</span>

--- a/packages/astro-avatar/src/AvatarImage.astro
+++ b/packages/astro-avatar/src/AvatarImage.astro
@@ -1,0 +1,48 @@
+---
+import { avatarImageVariants } from '@refraction-ui/avatar'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  src?: string
+  alt?: string
+}
+
+const { src, alt = '', class: className, ...props } = Astro.props
+---
+
+<img
+  class={cn(avatarImageVariants(), className)}
+  src={src}
+  alt={alt}
+  data-rfr-avatar-image
+  {...props}
+/>
+
+<script>
+  document.querySelectorAll('[data-rfr-avatar-image]').forEach((img) => {
+    const imgEl = img as HTMLImageElement
+    const parent = imgEl.closest('[data-rfr-avatar]')
+    const fallback = parent?.querySelector('[data-rfr-avatar-fallback]') as HTMLElement | null
+
+    // Handle already-loaded images (cached)
+    if (imgEl.complete && imgEl.naturalWidth > 0) {
+      imgEl.style.display = ''
+      if (fallback) fallback.style.display = 'none'
+      return
+    }
+
+    // Hide image until loaded
+    imgEl.style.display = 'none'
+    if (fallback) fallback.style.display = ''
+
+    imgEl.addEventListener('load', () => {
+      imgEl.style.display = ''
+      if (fallback) fallback.style.display = 'none'
+    })
+
+    imgEl.addEventListener('error', () => {
+      imgEl.style.display = 'none'
+      if (fallback) fallback.style.display = ''
+    })
+  })
+</script>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-avatar`
- Uses headless `@refraction-ui/avatar` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)