### PR TITLE
feat(astro): add badge component

### DIFF
--- a/packages/astro-badge/src/Badge.astro
+++ b/packages/astro-badge/src/Badge.astro
@@ -1,0 +1,27 @@
+---
+import {
+  createBadge,
+  badgeVariants,
+  type BadgeVariant,
+  type BadgeSize,
+} from '@refraction-ui/badge'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  variant?: BadgeVariant
+  size?: BadgeSize
+}
+
+const { variant, size, class: className, ...props } = Astro.props
+const api = createBadge({ variant, size })
+const classes = cn(badgeVariants({ variant, size }), className)
+---
+
+<div
+  class={classes}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-badge`
- Uses headless `@refraction-ui/badge` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)