### PR TITLE
feat(astro): add bottom-nav component

### DIFF
--- a/packages/astro-bottom-nav/src/BottomNav.astro
+++ b/packages/astro-bottom-nav/src/BottomNav.astro
@@ -1,0 +1,40 @@
+---
+import {
+  createBottomNav,
+  bottomNavVariants,
+  bottomNavTabVariants,
+  type NavTab,
+} from '@refraction-ui/bottom-nav'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  tabs?: NavTab[]
+  currentPath?: string
+}
+
+const { tabs = [], currentPath, class: className, ...props } = Astro.props
+const api = createBottomNav({ tabs, currentPath })
+const classes = cn(bottomNavVariants(), className)
+---
+
+<nav class={classes} {...api.ariaProps} {...props}>
+  <div class="flex">
+    {tabs.map((tab) => {
+      const active = api.isActive(tab.href)
+      return (
+        <a
+          href={tab.href}
+          class={bottomNavTabVariants({ active: active ? 'true' : 'false' })}
+          {...api.tabAriaProps(tab.href)}
+        >
+          {tab.icon && (
+            <span aria-hidden="true">
+              {active && tab.activeIcon ? tab.activeIcon : tab.icon}
+            </span>
+          )}
+          <span>{tab.label}</span>
+        </a>
+      )
+    })}
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-bottom-nav`
- Uses headless `@refraction-ui/bottom-nav` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)