### PR TITLE
feat(astro): add breadcrumbs component

### DIFF
--- a/packages/astro-breadcrumbs/src/Breadcrumbs.astro
+++ b/packages/astro-breadcrumbs/src/Breadcrumbs.astro
@@ -1,0 +1,56 @@
+---
+import {
+  createBreadcrumbs,
+  breadcrumbsVariants,
+  breadcrumbItemVariants,
+  breadcrumbSeparatorStyles,
+  type BreadcrumbItem,
+} from '@refraction-ui/breadcrumbs'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  pathname?: string
+  items?: BreadcrumbItem[]
+  labels?: Record<string, string>
+  separator?: string
+  maxItems?: number
+}
+
+const { pathname, items, labels, separator, maxItems, class: className, ...props } = Astro.props
+const api = createBreadcrumbs({ pathname, items, labels, separator, maxItems })
+const classes = cn(breadcrumbsVariants(), className)
+---
+
+<nav class={classes} {...api.ariaProps} {...props}>
+  <ol class="flex items-center gap-1.5">
+    {api.items.map((item, index) => {
+      const isLast = api.isLast(index)
+      return (
+        <li class="flex items-center gap-1.5">
+          {index > 0 && (
+            <span class={breadcrumbSeparatorStyles} aria-hidden="true">
+              {api.separator}
+            </span>
+          )}
+          {item.href && !isLast ? (
+            <a
+              href={item.href}
+              class={breadcrumbItemVariants({ active: 'false' })}
+            >
+              {item.label}
+            </a>
+          ) : (
+            <span
+              class={breadcrumbItemVariants({
+                active: isLast ? 'true' : 'false',
+              })}
+              {...api.itemAriaProps(index)}
+            >
+              {item.label}
+            </span>
+          )}
+        </li>
+      )
+    })}
+  </ol>
+</nav>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-breadcrumbs`
- Uses headless `@refraction-ui/breadcrumbs` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)