### PR TITLE
feat(astro): add button component

### DIFF
--- a/packages/astro-button/src/Button.astro
+++ b/packages/astro-button/src/Button.astro
@@ -1,0 +1,55 @@
+---
+import {
+  createButton,
+  buttonVariants,
+  getButtonType,
+  type ButtonVariant,
+  type ButtonSize,
+} from '@refraction-ui/button'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  disabled?: boolean
+}
+
+const { variant, size, loading, disabled, class: className, ...props } = Astro.props
+const api = createButton({ variant, size, disabled, loading, type: props.type as string })
+const classes = cn(buttonVariants({ variant, size }), className)
+---
+
+<button
+  type={getButtonType({ type: props.type as string }) as any}
+  class={classes}
+  disabled={disabled || loading}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  {loading && (
+    <svg
+      class="animate-spin h-4 w-4"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        class="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        stroke-width="4"
+      />
+      <path
+        class="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  )}
+  <slot />
+</button>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-button`
- Uses headless `@refraction-ui/button` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)