### PR TITLE
feat(astro): add card component

### DIFF
--- a/packages/astro-card/src/Card.astro
+++ b/packages/astro-card/src/Card.astro
@@ -1,0 +1,20 @@
+---
+import { createCard, cardVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  padding?: 'none' | 'default' | 'compact'
+}
+
+const { padding, class: className, ...props } = Astro.props
+const api = createCard(props)
+---
+
+<div
+  class={cn(cardVariants({ padding }), className)}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-card/src/CardContent.astro
+++ b/packages/astro-card/src/CardContent.astro
@@ -1,0 +1,13 @@
+---
+import { createCardContent, cardContentVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createCardContent()
+---
+
+<div class={cn(cardContentVariants(), className)} {...api.dataAttributes} {...props}>
+  <slot />
+</div>

--- a/packages/astro-card/src/CardDescription.astro
+++ b/packages/astro-card/src/CardDescription.astro
@@ -1,0 +1,13 @@
+---
+import { createCardDescription, cardDescriptionVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createCardDescription()
+---
+
+<p class={cn(cardDescriptionVariants(), className)} {...api.dataAttributes} {...props}>
+  <slot />
+</p>

--- a/packages/astro-card/src/CardFooter.astro
+++ b/packages/astro-card/src/CardFooter.astro
@@ -1,0 +1,13 @@
+---
+import { createCardFooter, cardFooterVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createCardFooter()
+---
+
+<div class={cn(cardFooterVariants(), className)} {...api.dataAttributes} {...props}>
+  <slot />
+</div>

--- a/packages/astro-card/src/CardHeader.astro
+++ b/packages/astro-card/src/CardHeader.astro
@@ -1,0 +1,13 @@
+---
+import { createCardHeader, cardHeaderVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createCardHeader()
+---
+
+<div class={cn(cardHeaderVariants(), className)} {...api.dataAttributes} {...props}>
+  <slot />
+</div>

--- a/packages/astro-card/src/CardTitle.astro
+++ b/packages/astro-card/src/CardTitle.astro
@@ -1,0 +1,15 @@
+---
+import { createCardTitle, cardTitleVariants } from '@refraction-ui/card'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  size?: 'sm' | 'default' | 'lg'
+}
+
+const { size, class: className, ...props } = Astro.props
+const api = createCardTitle()
+---
+
+<h3 class={cn(cardTitleVariants({ size }), className)} {...api.dataAttributes} {...props}>
+  <slot />
+</h3>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-card`
- Uses headless `@refraction-ui/card` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)