### PR TITLE
feat(astro): add charts component

### DIFF
--- a/packages/astro-charts/src/Bars.astro
+++ b/packages/astro-charts/src/Bars.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * Bars — bar chart rectangles, server-rendered as SVG <rect> elements.
+ * Accepts pre-computed labels and values arrays.
+ */
+import { createBandScale, createLinearScale, computeExtent } from '@refraction-ui/charts'
+
+interface Props {
+  /** Category labels for each bar */
+  labels: string[]
+  /** Numeric values for each bar */
+  values: number[]
+  /** Bounded width of the chart area */
+  boundedWidth: number
+  /** Bounded height of the chart area */
+  boundedHeight: number
+  /** Fill color (default 'currentColor') */
+  fill?: string
+  /** Band padding ratio (default 0.1) */
+  padding?: number
+}
+
+const {
+  labels,
+  values,
+  boundedWidth,
+  boundedHeight,
+  fill = 'currentColor',
+  padding = 0.1,
+} = Astro.props
+
+const [, maxVal] = computeExtent(values)
+const xScale = createBandScale(labels, [0, boundedWidth], padding)
+const yScale = createLinearScale([0, maxVal], [boundedHeight, 0])
+---
+
+<g data-rfr-chart-bars>
+  {labels.map((label, i) => {
+    const barX = xScale(label)
+    const barY = yScale(values[i])
+    const barHeight = boundedHeight - barY
+    const barWidth = xScale.bandwidth()
+    return (
+      <rect
+        x={barX}
+        y={barY}
+        width={barWidth}
+        height={barHeight}
+        fill={fill}
+      />
+    )
+  })}
+</g>

--- a/packages/astro-charts/src/Chart.astro
+++ b/packages/astro-charts/src/Chart.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * Chart — root SVG container for chart compositions.
+ * Provides chart dimensions via data attributes for sub-components.
+ */
+import { combineDimensions, type Margin } from '@refraction-ui/charts'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  width?: number
+  height?: number
+  margin?: Partial<Margin>
+}
+
+const { width = 600, height = 400, margin, class: className, ...props } = Astro.props
+
+const dimensions = combineDimensions({ width, height, margin })
+const dimensionsJSON = JSON.stringify(dimensions)
+---
+
+<svg
+  width={width}
+  height={height}
+  class={className}
+  data-rfr-chart
+  data-rfr-chart-dimensions={dimensionsJSON}
+  {...props}
+>
+  <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
+    <slot />
+  </g>
+</svg>

--- a/packages/astro-charts/src/Circles.astro
+++ b/packages/astro-charts/src/Circles.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * Circles — circle markers for scatter/bubble chart overlays.
+ * Accepts pre-computed x/y value arrays.
+ */
+import { createLinearScale, computeExtent } from '@refraction-ui/charts'
+
+interface Props {
+  /** X values for each data point */
+  xValues: number[]
+  /** Y values for each data point */
+  yValues: number[]
+  /** Bounded width of the chart area */
+  boundedWidth: number
+  /** Bounded height of the chart area */
+  boundedHeight: number
+  /** Circle radius (default 4) */
+  r?: number
+  /** Fill color (default 'currentColor') */
+  fill?: string
+}
+
+const {
+  xValues,
+  yValues,
+  boundedWidth,
+  boundedHeight,
+  r = 4,
+  fill = 'currentColor',
+} = Astro.props
+
+const [xMin, xMax] = computeExtent(xValues)
+const [yMin, yMax] = computeExtent(yValues)
+
+const xScale = createLinearScale([xMin, xMax], [0, boundedWidth])
+const yScale = createLinearScale([yMin, yMax], [boundedHeight, 0])
+---
+
+<g data-rfr-chart-circles>
+  {xValues.map((xv, i) => (
+    <circle
+      cx={xScale(xv)}
+      cy={yScale(yValues[i])}
+      r={r}
+      fill={fill}
+    />
+  ))}
+</g>

--- a/packages/astro-charts/src/Gradient.astro
+++ b/packages/astro-charts/src/Gradient.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Gradient — SVG linear gradient definition.
+ * Use inside a Chart or any SVG element; reference via `url(#id)` in fill/stroke.
+ */
+
+interface Props {
+  /** Gradient ID for referencing */
+  id: string
+  /** Start color */
+  from: string
+  /** End color */
+  to: string
+  /** Direction (default 'vertical') */
+  direction?: 'vertical' | 'horizontal'
+}
+
+const { id, from, to, direction = 'vertical' } = Astro.props
+
+const isVertical = direction === 'vertical'
+---
+
+<defs>
+  <linearGradient
+    id={id}
+    x1="0"
+    y1="0"
+    x2={isVertical ? '0' : '1'}
+    y2={isVertical ? '1' : '0'}
+  >
+    <stop offset="0%" stop-color={from} />
+    <stop offset="100%" stop-color={to} />
+  </linearGradient>
+</defs>

--- a/packages/astro-charts/src/Histogram.astro
+++ b/packages/astro-charts/src/Histogram.astro
@@ -1,0 +1,107 @@
+---
+/**
+ * Histogram — standalone histogram chart.
+ * Accepts raw numeric data and renders binned bars with axes.
+ */
+import {
+  computeHistogramBins,
+  createLinearScale,
+  createBandScale,
+  combineDimensions,
+  formatTick,
+  type Margin,
+} from '@refraction-ui/charts'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Raw numeric data */
+  data: number[]
+  /** Width of the SVG (default 600) */
+  width?: number
+  /** Height of the SVG (default 400) */
+  height?: number
+  /** Number of bins (default 10) */
+  bins?: number
+  /** Fill color (default 'steelblue') */
+  fill?: string
+  /** Custom margin */
+  margin?: Partial<Margin>
+}
+
+const {
+  data,
+  width = 600,
+  height = 400,
+  bins: binCount = 10,
+  fill = 'steelblue',
+  margin,
+  class: className,
+  ...props
+} = Astro.props
+
+const dimensions = combineDimensions({ width, height, margin })
+const { boundedWidth, boundedHeight } = dimensions
+
+const histBins = computeHistogramBins(data, binCount)
+const maxCount = Math.max(...histBins.map((b) => b.count))
+
+const labels = histBins.map((b) => `${formatTick(b.x0, 'number')}-${formatTick(b.x1, 'number')}`)
+const xScale = createBandScale(labels, [0, boundedWidth], 0.05)
+const yScale = createLinearScale([0, maxCount], [boundedHeight, 0])
+
+const yTicks = yScale.ticks(5)
+---
+
+<svg
+  width={width}
+  height={height}
+  class={className}
+  data-rfr-chart-histogram
+  {...props}
+>
+  <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
+    {histBins.map((bin, i) => {
+      const label = labels[i]
+      const barX = xScale(label)
+      const barY = yScale(bin.count)
+      const barHeight = boundedHeight - barY
+      const barWidth = xScale.bandwidth()
+      return (
+        <rect
+          x={barX}
+          y={barY}
+          width={barWidth}
+          height={barHeight}
+          fill={fill}
+        />
+      )
+    })}
+    {/* X Axis */}
+    <g transform={`translate(0,${boundedHeight})`}>
+      {labels.map((label, i) => {
+        const x = xScale(label) + xScale.bandwidth() / 2
+        return (
+          <g transform={`translate(${x},0)`}>
+            <line y2={6} stroke="currentColor" />
+            <text y={18} text-anchor="middle" font-size={10} fill="currentColor">
+              {label}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+    {/* Y Axis */}
+    <g>
+      {yTicks.map((tick) => {
+        const y = yScale(tick)
+        return (
+          <g transform={`translate(0,${y})`}>
+            <line x2={-6} stroke="currentColor" />
+            <text x={-9} dy="0.32em" text-anchor="end" font-size={10} fill="currentColor">
+              {formatTick(tick, 'number')}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+  </g>
+</svg>

--- a/packages/astro-charts/src/Line.astro
+++ b/packages/astro-charts/src/Line.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Line — line/area chart path, server-rendered as an SVG <path>.
+ * Accepts pre-computed x/y value arrays.
+ */
+import { createLinearScale, computeExtent, linePath } from '@refraction-ui/charts'
+
+interface Props {
+  /** X values for each data point */
+  xValues: number[]
+  /** Y values for each data point */
+  yValues: number[]
+  /** Bounded width of the chart area */
+  boundedWidth: number
+  /** Bounded height of the chart area */
+  boundedHeight: number
+  /** Stroke color (default 'currentColor') */
+  stroke?: string
+  /** Stroke width (default 2) */
+  strokeWidth?: number
+  /** Fill (default 'none') */
+  fill?: string
+}
+
+const {
+  xValues,
+  yValues,
+  boundedWidth,
+  boundedHeight,
+  stroke = 'currentColor',
+  strokeWidth = 2,
+  fill = 'none',
+} = Astro.props
+
+const [xMin, xMax] = computeExtent(xValues)
+const [yMin, yMax] = computeExtent(yValues)
+
+const xScale = createLinearScale([xMin, xMax], [0, boundedWidth])
+const yScale = createLinearScale([yMin, yMax], [boundedHeight, 0])
+
+const points = xValues.map((xv, i) => ({
+  x: xScale(xv),
+  y: yScale(yValues[i]),
+}))
+
+const d = linePath(points)
+---
+
+<path
+  d={d}
+  stroke={stroke}
+  stroke-width={strokeWidth}
+  fill={fill}
+  data-rfr-chart-line
+/>

--- a/packages/astro-charts/src/PieChart.astro
+++ b/packages/astro-charts/src/PieChart.astro
@@ -1,0 +1,63 @@
+---
+/**
+ * PieChart — standalone pie/donut chart rendered as SVG arcs.
+ */
+import { arcPath } from '@refraction-ui/charts'
+
+const DEFAULT_COLORS = [
+  '#4e79a7', '#f28e2b', '#e15759', '#76b7b2',
+  '#59a14f', '#edc948', '#b07aa1', '#ff9da7',
+  '#9c755f', '#bab0ac',
+]
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Numeric values for each slice */
+  values: number[]
+  /** Width of the SVG (default 300) */
+  width?: number
+  /** Height of the SVG (default 300) */
+  height?: number
+  /** Slice colors */
+  colors?: string[]
+}
+
+const {
+  values,
+  width = 300,
+  height = 300,
+  colors = DEFAULT_COLORS,
+  class: className,
+  ...props
+} = Astro.props
+
+const cx = width / 2
+const cy = height / 2
+const radius = Math.min(cx, cy) - 10
+
+const total = values.reduce((sum, v) => sum + v, 0)
+
+let currentAngle = -Math.PI / 2
+
+const arcs = values.map((val, i) => {
+  const sliceAngle = (val / total) * Math.PI * 2
+  const startAngle = currentAngle
+  const endAngle = currentAngle + sliceAngle
+  currentAngle = endAngle
+  return { startAngle, endAngle, color: colors[i % colors.length] }
+})
+---
+
+<svg
+  width={width}
+  height={height}
+  class={className}
+  data-rfr-chart-pie
+  {...props}
+>
+  {arcs.map((arc) => (
+    <path
+      d={arcPath(cx, cy, radius, arc.startAngle, arc.endAngle)}
+      fill={arc.color}
+    />
+  ))}
+</svg>

--- a/packages/astro-charts/src/ScatterPlot.astro
+++ b/packages/astro-charts/src/ScatterPlot.astro
@@ -1,0 +1,95 @@
+---
+/**
+ * ScatterPlot — standalone scatter plot chart.
+ * Accepts pre-computed x/y arrays and renders circles with axes.
+ */
+import { createLinearScale, computeExtent, combineDimensions, formatTick, type Margin } from '@refraction-ui/charts'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** X values for each data point */
+  xValues: number[]
+  /** Y values for each data point */
+  yValues: number[]
+  /** Width of the SVG (default 600) */
+  width?: number
+  /** Height of the SVG (default 400) */
+  height?: number
+  /** Circle radius (default 4) */
+  r?: number
+  /** Fill color (default 'steelblue') */
+  fill?: string
+  /** Custom margin */
+  margin?: Partial<Margin>
+}
+
+const {
+  xValues,
+  yValues,
+  width = 600,
+  height = 400,
+  r = 4,
+  fill = 'steelblue',
+  margin,
+  class: className,
+  ...props
+} = Astro.props
+
+const dimensions = combineDimensions({ width, height, margin })
+const { boundedWidth, boundedHeight } = dimensions
+
+const [xMin, xMax] = computeExtent(xValues)
+const [yMin, yMax] = computeExtent(yValues)
+
+const xScale = createLinearScale([xMin, xMax], [0, boundedWidth])
+const yScale = createLinearScale([yMin, yMax], [boundedHeight, 0])
+
+const xTicks = xScale.ticks(5)
+const yTicks = yScale.ticks(5)
+---
+
+<svg
+  width={width}
+  height={height}
+  class={className}
+  data-rfr-chart-scatter
+  {...props}
+>
+  <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
+    {xValues.map((xv, i) => (
+      <circle
+        cx={xScale(xv)}
+        cy={yScale(yValues[i])}
+        r={r}
+        fill={fill}
+      />
+    ))}
+    {/* X Axis */}
+    <g transform={`translate(0,${boundedHeight})`}>
+      {xTicks.map((tick) => {
+        const px = xScale(tick)
+        return (
+          <g transform={`translate(${px},0)`}>
+            <line y2={6} stroke="currentColor" />
+            <text y={18} text-anchor="middle" font-size={10} fill="currentColor">
+              {formatTick(tick, 'number')}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+    {/* Y Axis */}
+    <g>
+      {yTicks.map((tick) => {
+        const py = yScale(tick)
+        return (
+          <g transform={`translate(0,${py})`}>
+            <line x2={-6} stroke="currentColor" />
+            <text x={-9} dy="0.32em" text-anchor="end" font-size={10} fill="currentColor">
+              {formatTick(tick, 'number')}
+            </text>
+          </g>
+        )
+      })}
+    </g>
+  </g>
+</svg>

--- a/packages/astro-charts/src/XAxis.astro
+++ b/packages/astro-charts/src/XAxis.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * XAxis — horizontal axis with tick marks and labels.
+ * Designed to be used inside a Chart's <g> element.
+ */
+
+interface Props {
+  /** Tick values (strings or numbers) */
+  ticks: (number | string)[]
+  /** Pixel positions for each tick value */
+  positions: number[]
+  /** Distance from top of bounded area to axis line */
+  height: number
+  /** Tick mark length (default 6) */
+  tickSize?: number
+  /** Font size for labels (default 12) */
+  fontSize?: number
+}
+
+const {
+  ticks,
+  positions,
+  height,
+  tickSize = 6,
+  fontSize = 12,
+} = Astro.props
+---
+
+<g transform={`translate(0,${height})`} data-rfr-chart-xaxis>
+  {ticks.map((tick, i) => {
+    const x = positions[i]
+    return (
+      <g transform={`translate(${x},0)`}>
+        <line y2={tickSize} stroke="currentColor" />
+        <text
+          y={tickSize + 9}
+          text-anchor="middle"
+          font-size={fontSize}
+          fill="currentColor"
+        >
+          {String(tick)}
+        </text>
+      </g>
+    )
+  })}
+</g>

--- a/packages/astro-charts/src/YAxis.astro
+++ b/packages/astro-charts/src/YAxis.astro
@@ -1,0 +1,44 @@
+---
+/**
+ * YAxis — vertical axis with tick marks and labels.
+ * Designed to be used inside a Chart's <g> element.
+ */
+
+interface Props {
+  /** Tick values (strings or numbers) */
+  ticks: (number | string)[]
+  /** Pixel positions for each tick value */
+  positions: number[]
+  /** Tick mark length (default 6) */
+  tickSize?: number
+  /** Font size for labels (default 12) */
+  fontSize?: number
+}
+
+const {
+  ticks,
+  positions,
+  tickSize = 6,
+  fontSize = 12,
+} = Astro.props
+---
+
+<g data-rfr-chart-yaxis>
+  {ticks.map((tick, i) => {
+    const y = positions[i]
+    return (
+      <g transform={`translate(0,${y})`}>
+        <line x2={-tickSize} stroke="currentColor" />
+        <text
+          x={-tickSize - 4}
+          dy="0.32em"
+          text-anchor="end"
+          font-size={fontSize}
+          fill="currentColor"
+        >
+          {String(tick)}
+        </text>
+      </g>
+    )
+  })}
+</g>

--- a/packages/astro-charts/src/index.ts
+++ b/packages/astro-charts/src/index.ts
@@ -1,1 +1,26 @@
-export {}
+export { default as Chart } from './Chart.astro'
+export { default as Bars } from './Bars.astro'
+export { default as Line } from './Line.astro'
+export { default as PieChart } from './PieChart.astro'
+export { default as ScatterPlot } from './ScatterPlot.astro'
+export { default as Histogram } from './Histogram.astro'
+export { default as XAxis } from './XAxis.astro'
+export { default as YAxis } from './YAxis.astro'
+export { default as Gradient } from './Gradient.astro'
+export { default as Circles } from './Circles.astro'
+
+// Re-export core types and utilities
+export {
+  combineDimensions,
+  createLinearScale,
+  createBandScale,
+  computeExtent,
+  computeHistogramBins,
+  linePath,
+  areaPath,
+  arcPath,
+  formatTick,
+  generateTicks,
+  COLORBLIND_SAFE_PALETTE,
+  getChartColor,
+} from '@refraction-ui/charts'


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-charts`
- Uses headless `@refraction-ui/charts` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)