### PR TITLE
feat(astro): add dialog component

### DIFF
--- a/packages/astro-dialog/src/Dialog.astro
+++ b/packages/astro-dialog/src/Dialog.astro
@@ -1,0 +1,138 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Whether the dialog starts open */
+  defaultOpen?: boolean
+  /** Whether the dialog is modal (default: true) */
+  modal?: boolean
+}
+
+const { defaultOpen = false, modal = true, class: className, ...props } = Astro.props
+---
+
+<div
+  data-rfr-dialog
+  data-rfr-dialog-modal={modal}
+  data-rfr-dialog-default-open={defaultOpen}
+  data-state={defaultOpen ? 'open' : 'closed'}
+  class={cn('contents', className)}
+  {...props}
+>
+  <slot />
+</div>
+
+<script>
+  function initDialogs() {
+    const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+    document.querySelectorAll<HTMLElement>('[data-rfr-dialog]').forEach((root) => {
+      // Prevent re-init
+      if (root.hasAttribute('data-rfr-dialog-init')) return
+      root.setAttribute('data-rfr-dialog-init', '')
+
+      const isModal = root.getAttribute('data-rfr-dialog-modal') !== 'false'
+      const defaultOpen = root.getAttribute('data-rfr-dialog-default-open') === 'true'
+      let isOpen = defaultOpen
+
+      const trigger = root.querySelector<HTMLElement>('[data-rfr-dialog-trigger]')
+      const overlay = root.querySelector<HTMLElement>('[data-rfr-dialog-overlay]')
+      const content = root.querySelector<HTMLElement>('[data-rfr-dialog-content]')
+      const closeBtns = root.querySelectorAll<HTMLElement>('[data-rfr-dialog-close]')
+
+      function setState(open: boolean) {
+        isOpen = open
+        const state = open ? 'open' : 'closed'
+        root.setAttribute('data-state', state)
+        trigger?.setAttribute('aria-expanded', String(open))
+        overlay?.setAttribute('data-state', state)
+        content?.setAttribute('data-state', state)
+
+        if (open) {
+          overlay?.removeAttribute('hidden')
+          content?.removeAttribute('hidden')
+          // Focus the content or first focusable element
+          if (content) {
+            const firstFocusable = content.querySelector<HTMLElement>(FOCUSABLE)
+            if (firstFocusable) {
+              firstFocusable.focus()
+            } else {
+              content.focus()
+            }
+          }
+          // Prevent body scroll for modal
+          if (isModal) {
+            document.body.style.overflow = 'hidden'
+          }
+        } else {
+          overlay?.setAttribute('hidden', '')
+          content?.setAttribute('hidden', '')
+          if (isModal) {
+            document.body.style.overflow = ''
+          }
+          // Return focus to trigger
+          trigger?.focus()
+        }
+
+        root.dispatchEvent(new CustomEvent('rfr-dialog-change', { detail: { open }, bubbles: true }))
+      }
+
+      // Trigger click
+      trigger?.addEventListener('click', () => setState(!isOpen))
+
+      // Close button clicks
+      closeBtns.forEach((btn) => {
+        btn.addEventListener('click', () => setState(false))
+      })
+
+      // Overlay click-to-close
+      overlay?.addEventListener('click', (e) => {
+        if (e.target === overlay) {
+          setState(false)
+        }
+      })
+
+      // Keyboard: Escape to close, Tab trapping for modal
+      root.addEventListener('keydown', (e) => {
+        if (!isOpen) return
+
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          setState(false)
+          return
+        }
+
+        // Focus trap for modal dialogs
+        if (isModal && e.key === 'Tab' && content) {
+          const focusables = content.querySelectorAll<HTMLElement>(FOCUSABLE)
+          if (focusables.length === 0) return
+
+          const first = focusables[0]
+          const last = focusables[focusables.length - 1]
+
+          if (e.shiftKey) {
+            if (document.activeElement === first) {
+              e.preventDefault()
+              last.focus()
+            }
+          } else {
+            if (document.activeElement === last) {
+              e.preventDefault()
+              first.focus()
+            }
+          }
+        }
+      })
+
+      // Set initial state
+      if (!defaultOpen) {
+        overlay?.setAttribute('hidden', '')
+        content?.setAttribute('hidden', '')
+      }
+    })
+  }
+
+  // Run on initial load and after Astro page transitions
+  initDialogs()
+  document.addEventListener('astro:after-swap', initDialogs)
+</script>

--- a/packages/astro-dialog/src/DialogClose.astro
+++ b/packages/astro-dialog/src/DialogClose.astro
@@ -1,0 +1,16 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<button
+  type="button"
+  data-rfr-dialog-close
+  class={cn(className)}
+  {...props}
+>
+  <slot />
+</button>

--- a/packages/astro-dialog/src/DialogContent.astro
+++ b/packages/astro-dialog/src/DialogContent.astro
@@ -1,0 +1,24 @@
+---
+import { dialogContentVariants } from '@refraction-ui/dialog'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Whether the dialog is modal (default: true) */
+  modal?: boolean
+}
+
+const { modal = true, class: className, ...props } = Astro.props
+---
+
+<div
+  data-rfr-dialog-content
+  data-state="closed"
+  role="dialog"
+  aria-modal={modal}
+  tabindex="-1"
+  hidden
+  class={cn(dialogContentVariants(), className)}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-dialog/src/DialogDescription.astro
+++ b/packages/astro-dialog/src/DialogDescription.astro
@@ -1,0 +1,15 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<p
+  data-rfr-dialog-description
+  class={cn('text-sm text-muted-foreground', className)}
+  {...props}
+>
+  <slot />
+</p>

--- a/packages/astro-dialog/src/DialogFooter.astro
+++ b/packages/astro-dialog/src/DialogFooter.astro
@@ -1,0 +1,14 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  class={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-dialog/src/DialogHeader.astro
+++ b/packages/astro-dialog/src/DialogHeader.astro
@@ -1,0 +1,14 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  class={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-dialog/src/DialogOverlay.astro
+++ b/packages/astro-dialog/src/DialogOverlay.astro
@@ -1,0 +1,17 @@
+---
+import { overlayStyles } from '@refraction-ui/dialog'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  data-rfr-dialog-overlay
+  data-state="closed"
+  hidden
+  class={cn(overlayStyles, className)}
+  {...props}
+>
+</div>

--- a/packages/astro-dialog/src/DialogTitle.astro
+++ b/packages/astro-dialog/src/DialogTitle.astro
@@ -1,0 +1,15 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<h2
+  data-rfr-dialog-title
+  class={cn('text-lg font-semibold leading-none tracking-tight', className)}
+  {...props}
+>
+  <slot />
+</h2>

--- a/packages/astro-dialog/src/DialogTrigger.astro
+++ b/packages/astro-dialog/src/DialogTrigger.astro
@@ -1,0 +1,18 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<button
+  type="button"
+  data-rfr-dialog-trigger
+  aria-haspopup="dialog"
+  aria-expanded="false"
+  class={cn(className)}
+  {...props}
+>
+  <slot />
+</button>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-dialog`
- Uses headless `@refraction-ui/dialog` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)