### PR TITLE
feat(astro): add input-group component

### DIFF
--- a/packages/astro-input-group/src/InputGroup.astro
+++ b/packages/astro-input-group/src/InputGroup.astro
@@ -1,0 +1,29 @@
+---
+import {
+  createInputGroup,
+  inputGroupVariants,
+  type InputGroupOrientation,
+} from '@refraction-ui/input-group'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  orientation?: InputGroupOrientation
+}
+
+const { orientation = 'horizontal', class: className, ...props } = Astro.props
+const api = createInputGroup({
+  orientation,
+  id: props.id,
+  'aria-label': props['aria-label'],
+  'aria-labelledby': props['aria-labelledby'],
+})
+---
+
+<div
+  class={cn(inputGroupVariants({ orientation }), className)}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-input-group/src/InputGroupAddon.astro
+++ b/packages/astro-input-group/src/InputGroupAddon.astro
@@ -1,0 +1,14 @@
+---
+import { inputGroupAddonVariants, type InputGroupOrientation } from '@refraction-ui/input-group'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  orientation?: InputGroupOrientation
+}
+
+const { orientation = 'horizontal', class: className, ...props } = Astro.props
+---
+
+<div class={cn(inputGroupAddonVariants({ orientation }), className)} {...props}>
+  <slot />
+</div>

--- a/packages/astro-input-group/src/InputGroupButton.astro
+++ b/packages/astro-input-group/src/InputGroupButton.astro
@@ -1,0 +1,19 @@
+---
+import { inputGroupButtonVariants, type InputGroupOrientation } from '@refraction-ui/input-group'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  orientation?: InputGroupOrientation
+  type?: string
+}
+
+const { orientation = 'horizontal', type, class: className, ...props } = Astro.props
+---
+
+<button
+  type={(type ?? 'button') as any}
+  class={cn(inputGroupButtonVariants({ orientation }), className)}
+  {...props}
+>
+  <slot />
+</button>

--- a/packages/astro-input-group/src/InputGroupText.astro
+++ b/packages/astro-input-group/src/InputGroupText.astro
@@ -1,0 +1,11 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<span class={cn('flex items-center px-3 text-sm text-muted-foreground', className)} {...props}>
+  <slot />
+</span>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-input-group`
- Uses headless `@refraction-ui/input-group` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)