### PR TITLE
feat(astro): add language-selector component

### DIFF
--- a/packages/astro-language-selector/src/LanguageSelector.astro
+++ b/packages/astro-language-selector/src/LanguageSelector.astro
@@ -1,0 +1,247 @@
+---
+import {
+  createLanguageSelector,
+  selectorVariants,
+  optionVariants,
+  type LanguageOption,
+} from '@refraction-ui/language-selector'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  value?: string | string[]
+  options: LanguageOption[]
+  multiple?: boolean
+  placeholder?: string
+}
+
+const {
+  value: controlledValue,
+  options,
+  multiple = false,
+  placeholder = 'Select language...',
+  class: className,
+  ...props
+} = Astro.props
+
+const initialValues = Array.isArray(controlledValue)
+  ? controlledValue
+  : controlledValue
+    ? [controlledValue]
+    : []
+
+const api = createLanguageSelector({
+  value: multiple ? initialValues : initialValues[0],
+  options,
+  multiple,
+})
+
+const displayLabel = initialValues.length > 0
+  ? options
+      .filter((o) => initialValues.includes(o.value))
+      .map((o) => o.label)
+      .join(', ')
+  : placeholder
+
+// Group options
+const groups = new Map<string, LanguageOption[]>()
+const ungrouped: LanguageOption[] = []
+for (const opt of options) {
+  if (opt.group) {
+    const list = groups.get(opt.group) ?? []
+    list.push(opt)
+    groups.set(opt.group, list)
+  } else {
+    ungrouped.push(opt)
+  }
+}
+---
+
+<div
+  class={cn('rfr-language-selector relative inline-block', className)}
+  data-rfr-language-selector
+  data-rfr-lang-options={JSON.stringify(options)}
+  data-rfr-lang-value={JSON.stringify(initialValues)}
+  data-rfr-lang-multiple={String(multiple)}
+  data-rfr-lang-placeholder={placeholder}
+  {...props}
+>
+  <!-- Trigger button -->
+  <button
+    type="button"
+    role={api.triggerProps.role}
+    aria-expanded="false"
+    aria-controls={api.triggerProps['aria-controls']}
+    aria-haspopup={api.triggerProps['aria-haspopup']}
+    class={selectorVariants()}
+    data-rfr-lang-trigger
+  >
+    <span data-rfr-lang-label>{displayLabel}</span>
+    <span aria-hidden="true" class="ml-2">&#x25BE;</span>
+  </button>
+
+  <!-- Dropdown -->
+  <ul
+    role={api.contentProps.role}
+    id={api.contentProps.id}
+    class="absolute top-full left-0 w-full mt-1 rounded-md border bg-popover text-popover-foreground shadow-md z-50 overflow-auto max-h-60"
+    style="display:none"
+    data-rfr-lang-dropdown
+    {...(multiple ? { 'aria-multiselectable': 'true' } : {})}
+  >
+    {/* Grouped options */}
+    {[...groups.entries()].map(([group, opts]) => (
+      <li role="presentation">
+        <div class="px-3 py-1 text-xs font-semibold text-muted-foreground uppercase">
+          {group}
+        </div>
+        <ul role="group" aria-label={group}>
+          {opts.map((opt) => {
+            const optProps = api.getOptionProps(opt.value)
+            const isSelected = initialValues.includes(opt.value)
+            return (
+              <li
+                role={optProps.role}
+                aria-selected={optProps['aria-selected']}
+                data-value={opt.value}
+                class={optionVariants({ selected: isSelected ? 'true' : 'false' })}
+                data-rfr-lang-option
+              >
+                {isSelected && <span aria-hidden="true">&#x2713;</span>}
+                <span>{opt.label}</span>
+              </li>
+            )
+          })}
+        </ul>
+      </li>
+    ))}
+
+    {/* Ungrouped options */}
+    {ungrouped.map((opt) => {
+      const optProps = api.getOptionProps(opt.value)
+      const isSelected = initialValues.includes(opt.value)
+      return (
+        <li
+          role={optProps.role}
+          aria-selected={optProps['aria-selected']}
+          data-value={opt.value}
+          class={optionVariants({ selected: isSelected ? 'true' : 'false' })}
+          data-rfr-lang-option
+        >
+          {isSelected && <span aria-hidden="true">&#x2713;</span>}
+          <span>{opt.label}</span>
+        </li>
+      )
+    })}
+  </ul>
+</div>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-rfr-language-selector]').forEach((root) => {
+    const allOptions: Array<{ value: string; label: string; group?: string }> = JSON.parse(
+      root.getAttribute('data-rfr-lang-options') || '[]',
+    )
+    const multiple = root.getAttribute('data-rfr-lang-multiple') === 'true'
+    const placeholder = root.getAttribute('data-rfr-lang-placeholder') || 'Select language...'
+
+    const trigger = root.querySelector<HTMLButtonElement>('[data-rfr-lang-trigger]')!
+    const dropdown = root.querySelector<HTMLElement>('[data-rfr-lang-dropdown]')!
+    const label = root.querySelector<HTMLElement>('[data-rfr-lang-label]')!
+    const optionEls = root.querySelectorAll<HTMLElement>('[data-rfr-lang-option]')
+
+    let isOpen = false
+    let selectedValues: string[] = JSON.parse(root.getAttribute('data-rfr-lang-value') || '[]')
+
+    function setOpen(open: boolean) {
+      isOpen = open
+      dropdown.style.display = isOpen ? '' : 'none'
+      trigger.setAttribute('aria-expanded', String(isOpen))
+    }
+
+    function updateLabel() {
+      if (selectedValues.length > 0) {
+        label.textContent = allOptions
+          .filter((o) => selectedValues.includes(o.value))
+          .map((o) => o.label)
+          .join(', ')
+      } else {
+        label.textContent = placeholder
+      }
+    }
+
+    function updateOptionStates() {
+      optionEls.forEach((optEl) => {
+        const val = optEl.getAttribute('data-value') || ''
+        const isSel = selectedValues.includes(val)
+        optEl.setAttribute('aria-selected', String(isSel))
+
+        // Toggle selected styling
+        if (isSel) {
+          optEl.classList.add('bg-accent/50', 'font-medium')
+        } else {
+          optEl.classList.remove('bg-accent/50', 'font-medium')
+        }
+
+        // Toggle checkmark
+        let checkmark = optEl.querySelector('[aria-hidden="true"]')
+        if (isSel && !checkmark) {
+          checkmark = document.createElement('span')
+          checkmark.setAttribute('aria-hidden', 'true')
+          checkmark.textContent = '\u2713'
+          optEl.insertBefore(checkmark, optEl.firstChild)
+        } else if (!isSel && checkmark) {
+          checkmark.remove()
+        }
+      })
+    }
+
+    function toggle(value: string) {
+      if (multiple) {
+        const index = selectedValues.indexOf(value)
+        if (index >= 0) {
+          selectedValues.splice(index, 1)
+        } else {
+          selectedValues.push(value)
+        }
+      } else {
+        selectedValues = [value]
+        setOpen(false)
+      }
+
+      root.setAttribute('data-rfr-lang-value', JSON.stringify(selectedValues))
+      updateLabel()
+      updateOptionStates()
+
+      const emittedValue = multiple ? [...selectedValues] : selectedValues[0] || ''
+      root.dispatchEvent(new CustomEvent('change', { detail: { value: emittedValue }, bubbles: true }))
+    }
+
+    trigger.addEventListener('click', () => setOpen(!isOpen))
+
+    optionEls.forEach((optEl) => {
+      optEl.addEventListener('click', () => {
+        const value = optEl.getAttribute('data-value') || ''
+        toggle(value)
+      })
+    })
+
+    trigger.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        setOpen(false)
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        setOpen(!isOpen)
+      } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        if (!isOpen) {
+          setOpen(true)
+        }
+      }
+    })
+
+    // Click outside to close
+    document.addEventListener('mousedown', (e) => {
+      if (isOpen && !root.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    })
+  })
+</script>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-language-selector`
- Uses headless `@refraction-ui/language-selector` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)