### PR TITLE
feat(astro): add mobile-nav component

### DIFF
--- a/packages/astro-mobile-nav/src/MobileNav.astro
+++ b/packages/astro-mobile-nav/src/MobileNav.astro
@@ -1,0 +1,84 @@
+---
+import { mobileNavVariants } from '@refraction-ui/mobile-nav'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Whether the nav starts open */
+  defaultOpen?: boolean
+}
+
+const { defaultOpen = false, class: className, ...props } = Astro.props
+---
+
+<nav
+  data-rfr-mobile-nav
+  data-rfr-mobile-nav-default-open={defaultOpen}
+  data-state={defaultOpen ? 'open' : 'closed'}
+  class={cn(mobileNavVariants(), className)}
+  {...props}
+>
+  <slot />
+</nav>
+
+<script>
+  function initMobileNavs() {
+    document.querySelectorAll<HTMLElement>('[data-rfr-mobile-nav]').forEach((root) => {
+      if (root.hasAttribute('data-rfr-mobile-nav-init')) return
+      root.setAttribute('data-rfr-mobile-nav-init', '')
+
+      const defaultOpen = root.getAttribute('data-rfr-mobile-nav-default-open') === 'true'
+      let isOpen = defaultOpen
+
+      const trigger = root.querySelector<HTMLElement>('[data-rfr-mobile-nav-trigger]')
+      const content = root.querySelector<HTMLElement>('[data-rfr-mobile-nav-content]')
+
+      function setState(open: boolean) {
+        isOpen = open
+        const state = open ? 'open' : 'closed'
+        root.setAttribute('data-state', state)
+        trigger?.setAttribute('aria-expanded', String(open))
+        content?.setAttribute('data-state', state)
+
+        // Update trigger icon
+        const openIcon = trigger?.querySelector('[data-rfr-mobile-nav-icon-open]')
+        const closedIcon = trigger?.querySelector('[data-rfr-mobile-nav-icon-closed]')
+        if (openIcon && closedIcon) {
+          if (open) {
+            openIcon.removeAttribute('hidden')
+            closedIcon.setAttribute('hidden', '')
+          } else {
+            openIcon.setAttribute('hidden', '')
+            closedIcon.removeAttribute('hidden')
+          }
+        }
+
+        root.dispatchEvent(new CustomEvent('rfr-mobile-nav-change', { detail: { open }, bubbles: true }))
+      }
+
+      // Trigger click
+      trigger?.addEventListener('click', () => setState(!isOpen))
+
+      // Escape key
+      root.addEventListener('keydown', (e) => {
+        if (!isOpen) return
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          setState(false)
+          trigger?.focus()
+        }
+      })
+
+      // Set initial state for icon visibility
+      if (!defaultOpen) {
+        const openIcon = trigger?.querySelector('[data-rfr-mobile-nav-icon-open]')
+        openIcon?.setAttribute('hidden', '')
+      } else {
+        const closedIcon = trigger?.querySelector('[data-rfr-mobile-nav-icon-closed]')
+        closedIcon?.setAttribute('hidden', '')
+      }
+    })
+  }
+
+  initMobileNavs()
+  document.addEventListener('astro:after-swap', initMobileNavs)
+</script>

--- a/packages/astro-mobile-nav/src/MobileNavContent.astro
+++ b/packages/astro-mobile-nav/src/MobileNavContent.astro
@@ -1,0 +1,29 @@
+---
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<div
+  data-rfr-mobile-nav-content
+  data-state="closed"
+  role="menu"
+  class={cn('w-full overflow-hidden border-b bg-background transition-all duration-200', className)}
+  {...props}
+>
+  <slot />
+</div>
+
+<style>
+  [data-rfr-mobile-nav-content][data-state="open"] {
+    max-height: 100vh;
+    opacity: 1;
+  }
+  [data-rfr-mobile-nav-content][data-state="closed"] {
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+</style>

--- a/packages/astro-mobile-nav/src/MobileNavLink.astro
+++ b/packages/astro-mobile-nav/src/MobileNavLink.astro
@@ -1,0 +1,16 @@
+---
+import { mobileNavLinkVariants } from '@refraction-ui/mobile-nav'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.AnchorHTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+---
+
+<a
+  role="menuitem"
+  class={cn(mobileNavLinkVariants(), className)}
+  {...props}
+>
+  <slot />
+</a>

--- a/packages/astro-mobile-nav/src/MobileNavTrigger.astro
+++ b/packages/astro-mobile-nav/src/MobileNavTrigger.astro
@@ -1,0 +1,57 @@
+---
+import { mobileNavTriggerVariants } from '@refraction-ui/mobile-nav'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const hasChildren = Astro.slots.has('default')
+---
+
+<button
+  type="button"
+  data-rfr-mobile-nav-trigger
+  aria-expanded="false"
+  aria-label="Toggle menu"
+  class={cn(mobileNavTriggerVariants(), className)}
+  {...props}
+>
+  {hasChildren ? (
+    <slot />
+  ) : (
+    <Fragment>
+      <svg
+        data-rfr-mobile-nav-icon-closed
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="4" y1="6" x2="20" y2="6" />
+        <line x1="4" y1="12" x2="20" y2="12" />
+        <line x1="4" y1="18" x2="20" y2="18" />
+      </svg>
+      <svg
+        data-rfr-mobile-nav-icon-open
+        hidden
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </Fragment>
+  )}
+</button>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-mobile-nav`
- Uses headless `@refraction-ui/mobile-nav` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)