### PR TITLE
feat(astro): add navbar component

### DIFF
--- a/packages/astro-navbar/src/Navbar.astro
+++ b/packages/astro-navbar/src/Navbar.astro
@@ -1,0 +1,49 @@
+---
+import {
+  createNavbar,
+  navbarVariants,
+  navLinkVariants,
+  type NavLink,
+  type NavbarVariant,
+} from '@refraction-ui/navbar'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  links?: NavLink[]
+  currentPath?: string
+  variant?: NavbarVariant
+}
+
+const { links = [], currentPath, variant, class: className, ...props } = Astro.props
+const api = createNavbar({ links, currentPath, variant })
+const classes = cn(navbarVariants({ variant }), className)
+---
+
+<header class={classes} {...props}>
+  <nav
+    class="mx-auto flex h-14 max-w-7xl items-center justify-between px-4"
+    {...api.ariaProps}
+  >
+    <div class="flex-shrink-0">
+      <slot name="logo" />
+    </div>
+    <ul class="hidden items-center gap-6 md:flex">
+      {links.map((link) => (
+        <li>
+          <a
+            href={link.href}
+            class={navLinkVariants({
+              active: api.isActive(link.href) ? 'true' : 'false',
+            })}
+            {...api.linkAriaProps(link.href)}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+    <div class="flex items-center gap-2">
+      <slot name="actions" />
+    </div>
+  </nav>
+</header>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-navbar`
- Uses headless `@refraction-ui/navbar` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)