### PR TITLE
feat(astro): add progress-display component

### DIFF
--- a/packages/astro-progress-display/src/BadgeDisplay.astro
+++ b/packages/astro-progress-display/src/BadgeDisplay.astro
@@ -1,0 +1,33 @@
+---
+import {
+  createProgressDisplay,
+  badgeGridVariants,
+  badgeItemVariants,
+  type BadgeData,
+} from '@refraction-ui/progress-display'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  badges: BadgeData[]
+}
+
+const { badges, class: className, ...props } = Astro.props
+const api = createProgressDisplay({ stats: [], badges })
+---
+
+<div class={cn(badgeGridVariants(), className)} {...props}>
+  {api.badges.map((badge) => (
+    <div
+      class={badgeItemVariants({
+        state: badge.isUnlocked ? 'unlocked' : 'locked',
+      })}
+      {...api.getBadgeAriaProps(badge)}
+    >
+      <span class="text-3xl">{badge.icon}</span>
+      <span class="font-medium">{badge.name}</span>
+      {!badge.isUnlocked && (
+        <span class="text-xs text-muted-foreground">Locked</span>
+      )}
+    </div>
+  ))}
+</div>

--- a/packages/astro-progress-display/src/ProgressBar.astro
+++ b/packages/astro-progress-display/src/ProgressBar.astro
@@ -1,0 +1,27 @@
+---
+import { progressBarVariants } from '@refraction-ui/progress-display'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  value: number
+  max?: number
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const { value, max = 100, size, class: className, ...props } = Astro.props
+const percent = Math.min(100, Math.max(0, (value / max) * 100))
+---
+
+<div
+  class={cn(progressBarVariants({ size }), className)}
+  role="progressbar"
+  aria-valuenow={value}
+  aria-valuemin={0}
+  aria-valuemax={max}
+  {...props}
+>
+  <div
+    class="h-full rounded-full bg-primary transition-all"
+    style={`width: ${percent}%`}
+  />
+</div>

--- a/packages/astro-progress-display/src/StatsGrid.astro
+++ b/packages/astro-progress-display/src/StatsGrid.astro
@@ -1,0 +1,32 @@
+---
+import {
+  createProgressDisplay,
+  statsGridVariants,
+  statCardVariants,
+  type StatCardData,
+  type BadgeData,
+} from '@refraction-ui/progress-display'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  stats: StatCardData[]
+  badges?: BadgeData[]
+}
+
+const { stats, badges = [], class: className, ...props } = Astro.props
+const api = createProgressDisplay({ stats, badges })
+---
+
+<div class={cn(statsGridVariants(), className)} {...api.ariaProps} {...props}>
+  {api.stats.map((stat) => (
+    <div
+      class={statCardVariants({
+        color: (stat.color as 'default' | 'primary' | 'success' | 'warning' | 'destructive') ?? 'default',
+      })}
+    >
+      {stat.icon && <span class="text-2xl">{stat.icon}</span>}
+      <div class="text-2xl font-bold">{stat.value}</div>
+      <div class="text-sm text-muted-foreground">{stat.label}</div>
+    </div>
+  ))}
+</div>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-progress-display`
- Uses headless `@refraction-ui/progress-display` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)