### PR TITLE
feat(astro): add reaction-bar component

### DIFF
--- a/packages/astro-reaction-bar/src/ReactionBar.astro
+++ b/packages/astro-reaction-bar/src/ReactionBar.astro
@@ -1,0 +1,117 @@
+---
+import {
+  createReactionBar,
+  reactionBarStyles,
+  reactionPillVariants,
+  reactionAddButtonStyles,
+  reactionEmojiStyles,
+  reactionCountStyles,
+  type Reaction,
+} from '@refraction-ui/reaction-bar'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Array of reactions to display */
+  reactions: Reaction[]
+  /** Whether to show the add reaction button. Default: true */
+  showAddButton?: boolean
+}
+
+const {
+  reactions,
+  showAddButton = true,
+  class: className,
+  ...props
+} = Astro.props
+
+const api = createReactionBar({ reactions })
+---
+
+<div
+  data-rfr-reaction-bar
+  data-rfr-rb-reactions={JSON.stringify(reactions)}
+  class={cn(reactionBarStyles, className)}
+  role="group"
+  aria-label="Reactions"
+  {...props}
+>
+  {api.reactions.map((reaction) => (
+    <button
+      type="button"
+      data-rfr-rb-emoji={reaction.emoji}
+      class={reactionPillVariants({ state: reaction.userReacted ? 'active' : 'inactive' })}
+      role="button"
+      aria-pressed={reaction.userReacted ? 'true' : 'false'}
+      aria-label={`${reaction.emoji} ${reaction.count} reaction${reaction.count === 1 ? '' : 's'}${reaction.userReacted ? ', you reacted' : ''}`}
+    >
+      <span class={reactionEmojiStyles}>{reaction.emoji}</span>
+      <span class={reactionCountStyles} data-rfr-rb-count>{reaction.count}</span>
+    </button>
+  ))}
+  {showAddButton && (
+    <button
+      type="button"
+      data-rfr-rb-add
+      class={reactionAddButtonStyles}
+      role="button"
+      aria-label="Add reaction"
+    >
+      +
+    </button>
+  )}
+</div>
+
+<script>
+  function initReactionBars() {
+    document.querySelectorAll<HTMLElement>('[data-rfr-reaction-bar]').forEach((el) => {
+      if (el.hasAttribute('data-rfr-rb-init')) return
+      el.setAttribute('data-rfr-rb-init', '')
+
+      // Handle emoji button clicks (toggle reaction)
+      el.querySelectorAll<HTMLElement>('[data-rfr-rb-emoji]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const emoji = btn.getAttribute('data-rfr-rb-emoji')
+          if (!emoji) return
+
+          const isPressed = btn.getAttribute('aria-pressed') === 'true'
+          const countEl = btn.querySelector<HTMLElement>('[data-rfr-rb-count]')
+          const currentCount = countEl ? Number(countEl.textContent || 0) : 0
+
+          // Toggle state
+          const newPressed = !isPressed
+          const newCount = newPressed ? currentCount + 1 : Math.max(0, currentCount - 1)
+
+          btn.setAttribute('aria-pressed', String(newPressed))
+          if (countEl) countEl.textContent = String(newCount)
+
+          // Update styling
+          const activeClass = 'border-primary bg-primary/10 text-primary'
+          const inactiveClass = 'border-border bg-background text-foreground'
+          const baseClass = 'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs cursor-pointer transition-colors hover:bg-accent'
+
+          btn.className = `${baseClass} ${newPressed ? activeClass : inactiveClass}`
+
+          // Update aria-label
+          btn.setAttribute('aria-label', `${emoji} ${newCount} reaction${newCount === 1 ? '' : 's'}${newPressed ? ', you reacted' : ''}`)
+
+          el.dispatchEvent(new CustomEvent('rfr-reaction-toggle', {
+            detail: { emoji, userReacted: newPressed, count: newCount },
+            bubbles: true,
+          }))
+        })
+      })
+
+      // Handle add button click
+      const addBtn = el.querySelector<HTMLElement>('[data-rfr-rb-add]')
+      addBtn?.addEventListener('click', () => {
+        el.dispatchEvent(new CustomEvent('rfr-reaction-add', {
+          detail: { emoji: '\u{1F44D}' },
+          bubbles: true,
+        }))
+      })
+    })
+  }
+
+  initReactionBars()
+  document.addEventListener('astro:after-swap', initReactionBars)
+</script>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-reaction-bar`
- Uses headless `@refraction-ui/reaction-bar` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)