### PR TITLE
feat(astro): add skeleton component

### DIFF
--- a/packages/astro-skeleton/src/Skeleton.astro
+++ b/packages/astro-skeleton/src/Skeleton.astro
@@ -1,0 +1,39 @@
+---
+import {
+  createSkeleton,
+  skeletonVariants,
+  type SkeletonShape,
+} from '@refraction-ui/skeleton'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  shape?: SkeletonShape
+  width?: string | number
+  height?: string | number
+  /** Whether to animate the skeleton pulse. Defaults to true */
+  animate?: boolean
+}
+
+const { shape, width, height, animate, class: className, style, ...props } = Astro.props
+const api = createSkeleton({ shape, animate })
+const classes = cn(skeletonVariants({ shape }), className)
+
+const styleObj: Record<string, string | number> = {}
+if (width !== undefined) styleObj.width = width
+if (height !== undefined) styleObj.height = height
+
+// Merge any existing inline styles
+const existingStyle = typeof style === 'string' ? style : ''
+const extraStyle = Object.entries(styleObj)
+  .map(([k, v]) => `${k}: ${typeof v === 'number' ? `${v}px` : v}`)
+  .join('; ')
+const mergedStyle = [existingStyle, extraStyle].filter(Boolean).join('; ') || undefined
+---
+
+<div
+  class={classes}
+  style={mergedStyle}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+/>

--- a/packages/astro-skeleton/src/SkeletonText.astro
+++ b/packages/astro-skeleton/src/SkeletonText.astro
@@ -1,0 +1,22 @@
+---
+import Skeleton from './Skeleton.astro'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Number of text lines to render. Defaults to 3 */
+  lines?: number
+  /** Whether to animate the skeleton pulse. Defaults to true */
+  animate?: boolean
+}
+
+const { lines = 3, animate, class: className, ...props } = Astro.props
+
+/** Width percentages for each line to create a natural-looking text block */
+const lineWidths = ['100%', '92%', '85%', '96%', '78%', '88%', '94%', '82%']
+---
+
+<div class={cn('space-y-2', className)} {...props}>
+  {Array.from({ length: lines }, (_, i) => (
+    <Skeleton shape="text" width={lineWidths[i % lineWidths.length]} animate={animate} />
+  ))}
+</div>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-skeleton`
- Uses headless `@refraction-ui/skeleton` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)