### PR TITLE
feat(astro): add status-indicator component

### DIFF
--- a/packages/astro-status-indicator/src/StatusIndicator.astro
+++ b/packages/astro-status-indicator/src/StatusIndicator.astro
@@ -1,0 +1,31 @@
+---
+import {
+  createStatusIndicator,
+  statusContainerStyles,
+  statusDotVariants,
+  statusPulseVariants,
+  statusLabelStyles,
+  type StatusType,
+} from '@refraction-ui/status-indicator'
+import { cn } from '@refraction-ui/shared'
+
+interface Props {
+  type: StatusType
+  label?: string
+  pulse?: boolean
+  showLabel?: boolean
+  class?: string
+}
+
+const { type, label, pulse, showLabel = true, class: className } = Astro.props
+const api = createStatusIndicator({ type, label, pulse })
+
+const dotClassName = api.pulse
+  ? statusPulseVariants({ type })
+  : statusDotVariants({ type })
+---
+
+<span {...api.ariaProps} class={cn(statusContainerStyles, className)}>
+  <span class={dotClassName} />
+  {showLabel && <span class={statusLabelStyles}>{api.label}</span>}
+</span>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-status-indicator`
- Uses headless `@refraction-ui/status-indicator` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)