### PR TITLE
feat(astro): add textarea component

### DIFF
--- a/packages/astro-textarea/src/Textarea.astro
+++ b/packages/astro-textarea/src/Textarea.astro
@@ -1,0 +1,51 @@
+---
+import {
+  createTextarea,
+  textareaVariants,
+} from '@refraction-ui/textarea'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  size?: 'sm' | 'default' | 'lg'
+  disabled?: boolean
+  readonly?: boolean
+  required?: boolean
+  rows?: number
+  maxRows?: number
+  'aria-invalid'?: boolean
+}
+
+const {
+  size,
+  class: className,
+  disabled,
+  readonly,
+  required,
+  rows,
+  maxRows,
+  'aria-invalid': ariaInvalid,
+  ...props
+} = Astro.props
+
+const api = createTextarea({
+  disabled,
+  readOnly: readonly,
+  required,
+  rows,
+  maxRows,
+  'aria-invalid': ariaInvalid === true ? true : undefined,
+})
+
+const classes = cn(textareaVariants({ size }), className)
+---
+
+<textarea
+  class={classes}
+  disabled={disabled}
+  readonly={readonly}
+  required={required}
+  rows={rows}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+><slot /></textarea>


### PR DESCRIPTION
## Summary
- Implement Astro component for `@refraction-ui/astro-textarea`
- Uses headless `@refraction-ui/textarea` core for logic and a11y
- Ships as source `.astro` files

## Test plan
- [ ] Component renders in Astro project
- [ ] A11y attributes match React version

Generated with [Claude Code](https://claude.com/claude-code)