### PR TITLE
feat(keyboard-shortcut): introduce global Alt-to-reveal shortcut system

### DIFF
--- a/.changeset/global-shortcuts-core.md
+++ b/.changeset/global-shortcuts-core.md
@@ -1,0 +1,13 @@
+---
+"@refraction-ui/keyboard-shortcut": minor
+"@refraction-ui/react-keyboard-shortcut": minor
+"@refraction-ui/react-button": patch
+"@refraction-ui/react": patch
+---
+
+feat(keyboard-shortcut): introduce global Alt-to-reveal shortcut system
+
+- Added global `AltHintState` and `SANE_DEFAULTS` to the core `keyboard-shortcut` package.
+- Created `ShortcutProvider`, `useShortcut` hook, and `ShortcutHint` component in `react-keyboard-shortcut`.
+- Integrated `ShortcutHint` and `useShortcut` into `react-button`.
+- Updated `docs-site` to use the global `ShortcutProvider`.

--- a/docs-site/src/app/providers.tsx
+++ b/docs-site/src/app/providers.tsx
@@ -2,19 +2,22 @@
 
 import { ThemeProvider } from '@refraction-ui/react-theme'
 import { ToastProvider } from '@refraction-ui/react-toast'
+import { ShortcutProvider } from '@refraction-ui/react'
 import { MobileNavProvider } from '@/components/mobile-nav-context'
 import { FrameworkProvider } from '@/components/framework-context'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider defaultMode="light" attribute="class">
-      <ToastProvider>
-        <FrameworkProvider>
-          <MobileNavProvider>
-            {children}
-          </MobileNavProvider>
-        </FrameworkProvider>
-      </ToastProvider>
+      <ShortcutProvider>
+        <ToastProvider>
+          <FrameworkProvider>
+            <MobileNavProvider>
+              {children}
+            </MobileNavProvider>
+          </FrameworkProvider>
+        </ToastProvider>
+      </ShortcutProvider>
     </ThemeProvider>
   )
 }

--- a/packages/keyboard-shortcut/src/index.ts
+++ b/packages/keyboard-shortcut/src/index.ts
@@ -3,6 +3,11 @@ export {
   formatShortcut,
   type ShortcutProps,
   type KeyboardShortcutAPI,
+  SANE_DEFAULTS,
+  globalShortcutRegistry,
+  ShortcutRegistry,
+  altHintState,
+  AltHintState,
 } from './keyboard-shortcut.js'
 
 export {

--- a/packages/keyboard-shortcut/src/keyboard-shortcut.ts
+++ b/packages/keyboard-shortcut/src/keyboard-shortcut.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 export interface ShortcutProps {
   /** Key combination (e.g., ['Ctrl', 'K'] or ['Meta', 'Shift', 'P']) */
   keys: string[]
@@ -151,3 +149,90 @@ export function createKeyboardShortcut(props: ShortcutProps): KeyboardShortcutAP
     badgeAriaProps,
   }
 }
+
+export const SANE_DEFAULTS: Record<string, string[]> = {
+  save: ['Meta', 's'],
+  search: ['Meta', 'k'],
+  close: ['Escape'],
+  submit: ['Meta', 'Enter'],
+  undo: ['Meta', 'z'],
+  redo: ['Meta', 'Shift', 'z'],
+  copy: ['Meta', 'c'],
+  paste: ['Meta', 'v'],
+  cut: ['Meta', 'x'],
+  new: ['Meta', 'n'],
+  print: ['Meta', 'p'],
+  help: ['?'],
+};
+
+export class ShortcutRegistry {
+  private shortcuts: Map<string, () => void> = new Map();
+
+  register(keys: string[], handler: () => void) {
+    const keyStr = keys.map(k => k.toLowerCase()).sort().join('+');
+    if (this.shortcuts.has(keyStr)) {
+      console.warn(`Shortcut ${keyStr} is already registered.`);
+    }
+    this.shortcuts.set(keyStr, handler);
+  }
+
+  unregister(keys: string[]) {
+    const keyStr = keys.map(k => k.toLowerCase()).sort().join('+');
+    this.shortcuts.delete(keyStr);
+  }
+}
+
+export const globalShortcutRegistry = new ShortcutRegistry();
+
+export class AltHintState {
+  private showHints = false;
+  private listeners: Set<(show: boolean) => void> = new Set();
+  private initialized = false;
+
+  init() {
+    if (this.initialized || typeof window === 'undefined') return;
+    this.initialized = true;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') {
+        this.setShowHints(true);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Alt') {
+        this.setShowHints(false);
+      }
+    };
+
+    const handleBlur = () => {
+      this.setShowHints(false);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
+  }
+
+  private setShowHints(value: boolean) {
+    if (this.showHints !== value) {
+      this.showHints = value;
+      this.listeners.forEach((listener) => listener(value));
+    }
+  }
+
+  subscribe(listener: (show: boolean) => void) {
+    this.listeners.add(listener);
+    listener(this.showHints);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  get snapshot() {
+    return this.showHints;
+  }
+}
+
+export const altHintState = new AltHintState();
+

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "@refraction-ui/button": "workspace:*",
-    "@refraction-ui/shared": "workspace:*"
+    "@refraction-ui/shared": "workspace:*",
+    "@refraction-ui/react-keyboard-shortcut": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/packages/react-button/src/button.tsx
+++ b/packages/react-button/src/button.tsx
@@ -6,6 +6,7 @@ import {
   type ButtonVariant,
   type ButtonSize,
 } from '@refraction-ui/button'
+import { useShortcut, ShortcutHint } from '@refraction-ui/react-keyboard-shortcut'
 import { cn } from '@refraction-ui/shared'
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -13,6 +14,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   size?: ButtonSize
   loading?: boolean
   asChild?: boolean
+  shortcut?: string
+  action?: string
 }
 
 /**
@@ -22,33 +25,59 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant, size, loading, asChild, className, disabled, children, ...props }, ref) => {
+  ({ variant, size, loading, asChild, className, disabled, children, shortcut, action, ...props }, ref) => {
     const api = createButton({ variant, size, disabled, loading, asChild, type: props.type })
     const classes = cn(buttonVariants({ variant, size }), className)
+    
+    const internalRef = React.useRef<HTMLButtonElement>(null)
+    const mergedRef = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        internalRef.current = node
+        if (typeof ref === 'function') ref(node)
+        else if (ref) ref.current = node
+      },
+      [ref]
+    )
+
+    useShortcut({
+      shortcut,
+      action,
+      enabled: !disabled && !loading && (!!shortcut || !!action),
+      onTrigger: () => {
+        internalRef.current?.click()
+      },
+    })
 
     // When asChild, render the child element directly with button props merged in.
     // This allows <Button asChild><a href="/">Link</a></Button>
     if (asChild && React.isValidElement(children)) {
       return React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
-        ref,
-        className: cn(classes, (children.props as Record<string, unknown>).className as string),
+        ref: mergedRef,
+        className: cn(classes, (children.props as Record<string, unknown>).className as string, 'relative'),
         type: getButtonType({ type: props.type }),
         ...api.ariaProps,
         ...api.dataAttributes,
         ...props,
+        children: (
+          <>
+            {(shortcut || action) && <ShortcutHint shortcut={shortcut} action={action} className="right-4" />}
+            {(children.props as Record<string, unknown>).children}
+          </>
+        )
       })
     }
 
     return (
       <button
-        ref={ref}
+        ref={mergedRef}
         type={getButtonType({ type: props.type }) as 'button' | 'submit' | 'reset'}
-        className={classes}
+        className={cn(classes, 'relative')}
         disabled={disabled || loading}
         {...api.ariaProps}
         {...api.dataAttributes}
         {...props}
       >
+        {(shortcut || action) && <ShortcutHint shortcut={shortcut} action={action} className="right-4" />}
         {loading && (
           <svg
             className="animate-spin h-4 w-4"

--- a/packages/react-keyboard-shortcut/src/index.ts
+++ b/packages/react-keyboard-shortcut/src/index.ts
@@ -1,8 +1,14 @@
 export {
   KeyboardShortcut,
   ShortcutBadge,
+  ShortcutProvider,
+  useShortcut,
+  ShortcutHint,
+  ShortcutContext,
   type KeyboardShortcutProps,
   type ShortcutBadgeProps,
+  type UseShortcutOptions,
+  type ShortcutHintProps,
 } from './keyboard-shortcut.js'
 
 export {
@@ -12,4 +18,9 @@ export {
   shortcutBadgeStyles,
   shortcutKeyStyles,
   shortcutSeparatorStyles,
+  SANE_DEFAULTS,
+  globalShortcutRegistry,
+  ShortcutRegistry,
+  altHintState,
+  AltHintState,
 } from '@refraction-ui/keyboard-shortcut'

--- a/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
+++ b/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
@@ -5,8 +5,110 @@ import {
   shortcutBadgeStyles,
   shortcutKeyStyles,
   shortcutSeparatorStyles,
+  altHintState,
+  globalShortcutRegistry,
+  SANE_DEFAULTS,
 } from '@refraction-ui/keyboard-shortcut'
 import { cn } from '@refraction-ui/shared'
+
+export const ShortcutContext = React.createContext<boolean>(false)
+
+export function ShortcutProvider({ children }: { children: React.ReactNode }) {
+  const [showHints, setShowHints] = React.useState(altHintState.snapshot)
+
+  React.useEffect(() => {
+    altHintState.init()
+    return altHintState.subscribe(setShowHints)
+  }, [])
+
+  return (
+    <ShortcutContext.Provider value={showHints}>
+      {children}
+    </ShortcutContext.Provider>
+  )
+}
+
+export interface UseShortcutOptions {
+  shortcut?: string;
+  action?: string;
+  onTrigger: () => void;
+  enabled?: boolean;
+  preventDefault?: boolean;
+}
+
+export function useShortcut({
+  shortcut,
+  action,
+  onTrigger,
+  enabled = true,
+  preventDefault = true,
+}: UseShortcutOptions) {
+  const showHints = React.useContext(ShortcutContext);
+
+  const keys = React.useMemo(() => {
+    if (shortcut) {
+      return shortcut.split('+').map((s) => s.trim());
+    }
+    if (action && SANE_DEFAULTS[action]) {
+      return SANE_DEFAULTS[action];
+    }
+    return [];
+  }, [shortcut, action]);
+
+  const apiRef = React.useRef(
+    createKeyboardShortcut({ keys, onTrigger, enabled, preventDefault })
+  );
+
+  React.useEffect(() => {
+    apiRef.current = createKeyboardShortcut({ keys, onTrigger, enabled, preventDefault });
+  }, [keys, onTrigger, enabled, preventDefault]);
+
+  React.useEffect(() => {
+    if (!enabled || keys.length === 0) return;
+
+    const handler = () => { apiRef.current.handler(new KeyboardEvent('keydown')); };
+    globalShortcutRegistry.register(keys, handler);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      apiRef.current.handler(e);
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      globalShortcutRegistry.unregister(keys);
+    };
+  }, [enabled, keys]);
+
+  return { keys, showHints };
+}
+
+export interface ShortcutHintProps extends Omit<ShortcutBadgeProps, 'keys'> {
+  shortcut?: string;
+  action?: string;
+}
+
+export function ShortcutHint({ shortcut, action, className, platform = true, ...props }: ShortcutHintProps) {
+  const showHints = React.useContext(ShortcutContext);
+
+  const keys = React.useMemo(() => {
+    if (shortcut) {
+      return shortcut.split('+').map((s) => s.trim());
+    }
+    if (action && SANE_DEFAULTS[action]) {
+      return SANE_DEFAULTS[action];
+    }
+    return [];
+  }, [shortcut, action]);
+
+  if (!showHints || keys.length === 0) return null;
+
+  return (
+    <div className={cn("absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none z-10", className)}>
+      <ShortcutBadge keys={keys} platform={platform} {...props} />
+    </div>
+  );
+}
 
 export interface KeyboardShortcutProps {
   /** Key combination */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2386,6 +2386,9 @@ importers:
       '@refraction-ui/button':
         specifier: workspace:*
         version: link:../button
+      '@refraction-ui/react-keyboard-shortcut':
+        specifier: workspace:*
+        version: link:../react-keyboard-shortcut
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
This PR introduces the foundational global keyboard shortcut system for Refraction UI.

It includes:
- Global `AltHintState` and `SANE_DEFAULTS` registry.
- `ShortcutProvider`, `useShortcut` hook, and `ShortcutHint` component.
- Integration into the core `Button` component.
- Setup in the `docs-site` providers.

This PR prepares the monorepo for the mass shortcut rollout once the visual infrastructure is fixed.