### PR TITLE
fix: resolve app-shell variables, typography, and syntax highlighting bugs

### DIFF
--- a/.changeset/fix-bugs-appshell-typography-codeblocks.md
+++ b/.changeset/fix-bugs-appshell-typography-codeblocks.md
@@ -1,0 +1,10 @@
+---
+"@refraction-ui/app-shell": patch
+"@refraction-ui/tailwind-config": patch
+---
+
+fix: resolve core styling, layout, and typography bugs
+
+- Fixed `app-shell`, `auth-shell`, and `page-shell` factories where `undefined` config values incorrectly overwrote default settings.
+- Added `@tailwindcss/typography` plugin to the `refractionPreset` to ensure proper markdown styling.
+- Upgraded the documentation site's code blocks to use `shiki` for proper syntax highlighting.

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -6,12 +6,9 @@
     "build": "NODE_OPTIONS='--max-old-space-size=4096' next build"
   },
   "dependencies": {
-    "next": "^15.5.15",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@refraction-ui/react-app-shell": "workspace:*",
     "@refraction-ui/app-shell": "workspace:*",
     "@refraction-ui/react-animated-text": "workspace:*",
+    "@refraction-ui/react-app-shell": "workspace:*",
     "@refraction-ui/react-avatar": "workspace:*",
     "@refraction-ui/react-avatar-group": "workspace:*",
     "@refraction-ui/react-badge": "workspace:*",
@@ -60,16 +57,20 @@
     "@refraction-ui/react-tooltip": "workspace:*",
     "@refraction-ui/react-version-selector": "workspace:*",
     "@refraction-ui/react-video-player": "workspace:*",
-    "@refraction-ui/tailwind-config": "workspace:*"
+    "@refraction-ui/tailwind-config": "workspace:*",
+    "next": "^15.5.15",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "shiki": "4.0.2"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4.0",
     "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0",
-    "typescript": "^5.8.0",
+    "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/node": "^22.0.0"
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.8.0"
   }
 }

--- a/docs-site/src/components/code-block.tsx
+++ b/docs-site/src/components/code-block.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useFramework, Framework } from './framework-context'
+import { codeToHtml } from 'shiki'
 
 interface CodeBlockProps {
   code?: string
@@ -12,9 +13,37 @@ interface CodeBlockProps {
 
 export function CodeBlock({ code, frameworks, language = 'tsx', showLineNumbers = false }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
+  const [html, setHtml] = useState<string>('')
   const { framework } = useFramework()
 
   const displayCode = frameworks?.[framework] || code || ''
+
+  useEffect(() => {
+    let isMounted = true
+    async function highlight() {
+      if (!displayCode) {
+        if (isMounted) setHtml('')
+        return
+      }
+      try {
+        const highlighted = await codeToHtml(displayCode, {
+          lang: language,
+          theme: 'github-dark',
+        })
+        if (isMounted) {
+          // Remove the outer <pre> and <code> wrappers shiki adds, 
+          // because we provide our own custom wrapper structure below.
+          // Or we can just render Shiki's output directly inside our container.
+          // Shiki outputs <pre class="shiki github-dark" ...><code>...</code></pre>
+          setHtml(highlighted)
+        }
+      } catch (e) {
+        if (isMounted) setHtml(`<pre><code class="block px-5 font-mono text-zinc-200 whitespace-pre">${displayCode}</code></pre>`)
+      }
+    }
+    highlight()
+    return () => { isMounted = false }
+  }, [displayCode, language])
 
   const handleCopy = async () => {
     if (!displayCode) return
@@ -34,8 +63,6 @@ export function CodeBlock({ code, frameworks, language = 'tsx', showLineNumbers 
     }
   }
 
-  const lines = displayCode.split('\n')
-
   if (!displayCode) {
     return (
       <div className="rounded-xl bg-zinc-950 p-6 text-sm text-zinc-500 italic text-center dark:bg-zinc-900 ring-1 ring-white/10">
@@ -45,7 +72,7 @@ export function CodeBlock({ code, frameworks, language = 'tsx', showLineNumbers 
   }
 
   return (
-    <div className="group relative rounded-xl bg-zinc-950 overflow-hidden ring-1 ring-white/10 dark:bg-zinc-900">
+    <div className="group relative rounded-xl bg-[#24292e] overflow-hidden ring-1 ring-white/10">
       {/* Header bar */}
       <div className="flex items-center justify-between border-b border-white/5 px-4 py-2.5">
         <div className="flex items-center gap-2">
@@ -80,29 +107,14 @@ export function CodeBlock({ code, frameworks, language = 'tsx', showLineNumbers 
         </div>
       </div>
       {/* Code content */}
-      <div className="overflow-x-auto">
-        <pre className="py-4 text-[13px] leading-relaxed">
-          {showLineNumbers ? (
-            <table className="w-full border-collapse">
-              <tbody>
-                {lines.map((line, i) => (
-                  <tr key={i} className="hover:bg-white/[0.02]">
-                    <td className="w-12 select-none border-r border-white/5 pr-4 text-right font-mono text-xs text-zinc-600">
-                      {i + 1}
-                    </td>
-                    <td className="pl-4 pr-6">
-                      <code className="font-mono text-zinc-200 whitespace-pre">{line}</code>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : (
-            <code className="block px-5 font-mono text-zinc-200 whitespace-pre">
-              {displayCode}
-            </code>
-          )}
-        </pre>
+      <div className="overflow-x-auto text-[13px] leading-relaxed [&>pre]:!bg-transparent [&>pre]:!p-4 [&_code]:!font-mono [&_code]:!text-[13px]">
+        {html ? (
+          <div dangerouslySetInnerHTML={{ __html: html }} />
+        ) : (
+          <pre className="py-4">
+            <code className="block px-5 font-mono text-zinc-200 whitespace-pre">{displayCode}</code>
+          </pre>
+        )}
       </div>
     </div>
   )

--- a/packages/app-shell/src/app-shell.ts
+++ b/packages/app-shell/src/app-shell.ts
@@ -131,7 +131,10 @@ function makeState(
 // ---------------------------------------------------------------------------
 
 export function createAppShell(config?: AppShellConfig): AppShellAPI {
-  const resolved: Required<AppShellConfig> = { ...DEFAULTS, ...config }
+  const resolved: Required<AppShellConfig> = {
+    ...DEFAULTS,
+    ...(config ? Object.fromEntries(Object.entries(config).filter(([_, v]) => v !== undefined)) : {})
+  } as Required<AppShellConfig>
 
   // Internal mutable state
   let sidebarOpen = false

--- a/packages/app-shell/src/auth-shell.ts
+++ b/packages/app-shell/src/auth-shell.ts
@@ -47,7 +47,10 @@ const MAX_WIDTH_CLASSES: Record<AuthShellConfig['maxWidth'] & string, string> = 
 // ---------------------------------------------------------------------------
 
 export function createAuthShell(config?: AuthShellConfig): AuthShellAPI {
-  const resolved: Required<AuthShellConfig> = { ...DEFAULTS, ...config }
+  const resolved: Required<AuthShellConfig> = {
+    ...DEFAULTS,
+    ...(config ? Object.fromEntries(Object.entries(config).filter(([_, v]) => v !== undefined)) : {})
+  } as Required<AuthShellConfig>
 
   const containerParts: string[] = ['min-h-screen', 'flex', 'w-full']
 

--- a/packages/app-shell/src/page-shell.ts
+++ b/packages/app-shell/src/page-shell.ts
@@ -67,7 +67,10 @@ const BACKGROUND_CLASSES: Record<NonNullable<SectionConfig['background']>, strin
 // ---------------------------------------------------------------------------
 
 export function createPageShell(config?: PageShellConfig): PageShellAPI {
-  const resolved: Required<PageShellConfig> = { ...DEFAULTS, ...config }
+  const resolved: Required<PageShellConfig> = {
+    ...DEFAULTS,
+    ...(config ? Object.fromEntries(Object.entries(config).filter(([_, v]) => v !== undefined)) : {})
+  } as Required<PageShellConfig>
 
   function getSectionClasses(sectionConfig?: SectionConfig): string {
     const {

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -26,8 +26,9 @@
     "lint": "eslint src --ext .ts",
     "clean": "rm -rf dist"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "@tailwindcss/typography": "0.5.19"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tailwind-config/src/preset.ts
+++ b/packages/tailwind-config/src/preset.ts
@@ -12,9 +12,11 @@
 
 import { colors } from './colors.js'
 import { keyframes, animation } from './animations.js'
+import typography from '@tailwindcss/typography'
 
 export const refractionPreset = {
   darkMode: 'class' as const,
+  plugins: [typography],
   theme: {
     container: {
       center: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      shiki:
+        specifier: 4.0.2
+        version: 4.0.2
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
@@ -4176,7 +4179,11 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
-  packages/tailwind-config: {}
+  packages/tailwind-config:
+    dependencies:
+      '@tailwindcss/typography':
+        specifier: 0.5.19
+        version: 0.5.19
 
   packages/textarea:
     dependencies:
@@ -5454,6 +5461,11 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -7280,6 +7292,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -9214,6 +9230,10 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.6
       tailwindcss: 4.2.2
+
+  '@tailwindcss/typography@0.5.19':
+    dependencies:
+      postcss-selector-parser: 6.0.10
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -11396,6 +11416,11 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:


### PR DESCRIPTION
This PR fixes three critical issues:
1. **AppShell Variables**: Fixed a bug where `undefined` config values incorrectly overwrote default settings in `app-shell`, `auth-shell`, and `page-shell`.
2. **Typography**: Added `@tailwindcss/typography` plugin to the `refractionPreset` so prose elements, blockquotes, tables, etc., have proper styling.
3. **Syntax Highlighting**: Upgraded the documentation site's code blocks to use `shiki` instead of rendering undifferentiated monospace text.

Tests have been run locally using `make ci`.