### PR TITLE
chore: unify CI runner with local make ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,8 @@ jobs:
           cache: pnpm
       - name: Install deps
         run: pnpm install --frozen-lockfile
-      - name: Lint
-        run: pnpm turbo lint --continue
-      - name: Typecheck
-        run: pnpm turbo typecheck --continue
-      - name: Unit tests
-        run: pnpm turbo test --continue -- --coverage
-      - name: Build packages
-        run: pnpm turbo build --continue
+      - name: Run CI
+        run: make ci
       - name: Storybook tests (axe + interactions)
         run: pnpm turbo storybook:test --continue
       - name: Bundle size check

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -30,12 +30,8 @@ jobs:
         uses: dtinth/setup-github-actions-caching-for-turbo@v1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run tests
-        run: pnpm turbo test --continue
-      - name: Run typecheck
-        run: pnpm turbo typecheck --continue
-      - name: Build packages
-        run: pnpm turbo build --continue
+      - name: Run CI
+        run: make ci
 
   browser-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Consolidates Github Action workflow sequential turbo boundaries behind the identical strict make ci target used for local development.