### PR TITLE
fix(flutter): replace placeholder LICENSE and add 0.1.0 CHANGELOG

### DIFF
--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,3 +1,14 @@
-## 0.0.1
+## 0.1.0
 
-* TODO: Describe initial release.
+Initial release of `refraction_ui` for Flutter — a headless, highly customizable, fully accessible UI library mirroring the Refraction UI design system.
+
+Components included:
+
+- **Layout & navigation**: Sidebar, Tabs, Accordion
+- **Inputs & forms**: Input, Select, Checkbox, Radio, RadioGroup, Switch, OTP Input
+- **Buttons & menus**: Button, Command Menu, Dropdown
+- **Feedback**: Alert, Toast, Tooltip, Skeleton, Progress, Slider
+- **Identity & status**: Avatar, Badge
+- **Theming**: `RefractionTheme`, `RefractionThemeData`, `RefractionColors`
+
+All components consume `RefractionThemeData` for theme tokens, matching the headless-and-token-driven approach of the React/Angular/Astro packages.

--- a/packages/flutter/LICENSE
+++ b/packages/flutter/LICENSE
@@ -1,1 +1,21 @@
-TODO: Add your license here.
+MIT License
+
+Copyright (c) 2025 elloloop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Unblocks `dart pub publish` for `packages/flutter/`.

- `packages/flutter/LICENSE` — was the `flutter create` placeholder (`TODO: Add your license here.`), which pub.dev rejects with `LICENSE file contains generic TODO`. Replaced with the repo's MIT LICENSE.
- `packages/flutter/CHANGELOG.md` — was the placeholder `## 0.0.1 — TODO: Describe initial release`. Replaced with a real `## 0.1.0` entry listing the components shipped (matches `pubspec.yaml: version: 0.1.0`).

## Out of scope

`dart analyze` reports 39 issues (mostly `unreachable_switch_default`, deprecated `withOpacity`, `use_super_parameters`). These affect pub.dev package score but don't block publication — separate follow-up.

## Test plan

- [x] `dart pub publish --dry-run` no longer fails on LICENSE or CHANGELOG
- [ ] Actual publish succeeds once pub.dev automated-publishing config is set up