### PR TITLE
chore(flutter): clear all dart analyze warnings

### DIFF
--- a/packages/flutter/example/lib/dev_tools/device_frame.dart
+++ b/packages/flutter/example/lib/dev_tools/device_frame.dart
@@ -8,10 +8,10 @@ class RefractionDeviceFrame extends StatefulWidget {
   final DeviceType deviceType;
 
   const RefractionDeviceFrame({
-    Key? key,
+    super.key,
     required this.child,
     this.deviceType = DeviceType.iphone,
-  }) : super(key: key);
+  });
 
   @override
   _RefractionDeviceFrameState createState() => _RefractionDeviceFrameState();
@@ -32,7 +32,7 @@ class _RefractionDeviceFrameState extends State<RefractionDeviceFrame> {
     super.dispose();
   }
 
-  String _debugFocus = "INIT";
+  final String _debugFocus = "INIT";
 
   void _handleFocusChange() {
     final focus = FocusManager.instance.primaryFocus;

--- a/packages/flutter/lib/refraction_ui.dart
+++ b/packages/flutter/lib/refraction_ui.dart
@@ -1,4 +1,4 @@
-library refraction_ui;
+library;
 
 export 'src/theme/refraction_colors.dart';
 export 'src/theme/refraction_theme.dart';

--- a/packages/flutter/lib/src/components/badge.dart
+++ b/packages/flutter/lib/src/components/badge.dart
@@ -8,10 +8,10 @@ class RefractionBadge extends StatelessWidget {
   final RefractionBadgeVariant variant;
 
   const RefractionBadge({
-    Key? key,
+    super.key,
     required this.child,
     this.variant = RefractionBadgeVariant.primary,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +37,6 @@ class RefractionBadge extends StatelessWidget {
         borderColor = colors.border;
         break;
       case RefractionBadgeVariant.primary:
-      default:
         backgroundColor = colors.primary;
         foregroundColor = colors.primaryForeground;
         break;

--- a/packages/flutter/lib/src/components/bottom_nav.dart
+++ b/packages/flutter/lib/src/components/bottom_nav.dart
@@ -33,7 +33,7 @@ class RefractionBottomNav extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: colors.background.withOpacity(0.95),
+        color: colors.background.withValues(alpha: 0.95),
         border: Border(top: BorderSide(color: colors.border)),
       ),
       child: SafeArea(

--- a/packages/flutter/lib/src/components/breadcrumbs.dart
+++ b/packages/flutter/lib/src/components/breadcrumbs.dart
@@ -75,7 +75,7 @@ class RefractionBreadcrumbs extends StatelessWidget {
               separator,
               style: TextStyle(
                 fontSize: 14,
-                color: colors.mutedForeground.withOpacity(0.5),
+                color: colors.mutedForeground.withValues(alpha: 0.5),
               ),
             ),
           ),

--- a/packages/flutter/lib/src/components/button.dart
+++ b/packages/flutter/lib/src/components/button.dart
@@ -20,16 +20,16 @@ class RefractionButton extends StatefulWidget {
   final bool isLoading;
 
   const RefractionButton({
-    Key? key,
+    super.key,
     required this.onPressed,
     required this.child,
     this.variant = RefractionButtonVariant.primary,
     this.size = RefractionButtonSize.defaultSize,
     this.isLoading = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionButtonState createState() => _RefractionButtonState();
+  State<RefractionButton> createState() => _RefractionButtonState();
 }
 
 class _RefractionButtonState extends State<RefractionButton> {
@@ -47,7 +47,7 @@ class _RefractionButtonState extends State<RefractionButton> {
     switch (widget.variant) {
       case RefractionButtonVariant.destructive:
         backgroundColor = _isHovered
-            ? colors.destructive.withOpacity(0.9)
+            ? colors.destructive.withValues(alpha: 0.9)
             : colors.destructive;
         foregroundColor = colors.destructiveForeground;
         break;
@@ -60,7 +60,7 @@ class _RefractionButtonState extends State<RefractionButton> {
         break;
       case RefractionButtonVariant.secondary:
         backgroundColor = _isHovered
-            ? colors.secondary.withOpacity(0.8)
+            ? colors.secondary.withValues(alpha: 0.8)
             : colors.secondary;
         foregroundColor = colors.secondaryForeground;
         break;
@@ -75,18 +75,17 @@ class _RefractionButtonState extends State<RefractionButton> {
         foregroundColor = colors.primary;
         break;
       case RefractionButtonVariant.primary:
-      default:
         backgroundColor = _isHovered
-            ? colors.primary.withOpacity(0.9)
+            ? colors.primary.withValues(alpha: 0.9)
             : colors.primary;
         foregroundColor = colors.primaryForeground;
         break;
     }
 
     if (widget.onPressed == null) {
-      backgroundColor = backgroundColor.withOpacity(0.5);
-      foregroundColor = foregroundColor.withOpacity(0.5);
-      if (borderColor != null) borderColor = borderColor.withOpacity(0.5);
+      backgroundColor = backgroundColor.withValues(alpha: 0.5);
+      foregroundColor = foregroundColor.withValues(alpha: 0.5);
+      if (borderColor != null) borderColor = borderColor.withValues(alpha: 0.5);
     }
 
     EdgeInsetsGeometry padding;
@@ -112,7 +111,6 @@ class _RefractionButtonState extends State<RefractionButton> {
         minHeight = 36.0;
         break;
       case RefractionButtonSize.defaultSize:
-      default:
         padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 10);
         fontSize = 14.0;
         minHeight = 36.0;

--- a/packages/flutter/lib/src/components/chat_input.dart
+++ b/packages/flutter/lib/src/components/chat_input.dart
@@ -14,7 +14,7 @@ class RefractionRichChatInput extends StatefulWidget {
   final bool disabled;
 
   const RefractionRichChatInput({
-    Key? key,
+    super.key,
     this.controller,
     this.placeholder = "Message...",
     this.prefixIcon,
@@ -24,10 +24,10 @@ class RefractionRichChatInput extends StatefulWidget {
     this.minLines = 1,
     this.maxLines = 5,
     this.disabled = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionRichChatInputState createState() => _RefractionRichChatInputState();
+  State<RefractionRichChatInput> createState() => _RefractionRichChatInputState();
 }
 
 class _RefractionRichChatInputState extends State<RefractionRichChatInput> {

--- a/packages/flutter/lib/src/components/checkbox.dart
+++ b/packages/flutter/lib/src/components/checkbox.dart
@@ -7,14 +7,14 @@ class RefractionCheckbox extends StatefulWidget {
   final bool disabled;
 
   const RefractionCheckbox({
-    Key? key,
+    super.key,
     required this.value,
     this.onChanged,
     this.disabled = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionCheckboxState createState() => _RefractionCheckboxState();
+  State<RefractionCheckbox> createState() => _RefractionCheckboxState();
 }
 
 class _RefractionCheckboxState extends State<RefractionCheckbox> {

--- a/packages/flutter/lib/src/components/input.dart
+++ b/packages/flutter/lib/src/components/input.dart
@@ -12,7 +12,7 @@ class RefractionInput extends StatefulWidget {
   final int maxLines;
 
   const RefractionInput({
-    Key? key,
+    super.key,
     this.controller,
     this.placeholder,
     this.obscureText = false,
@@ -21,10 +21,10 @@ class RefractionInput extends StatefulWidget {
     this.suffix,
     this.onChanged,
     this.maxLines = 1,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionInputState createState() => _RefractionInputState();
+  State<RefractionInput> createState() => _RefractionInputState();
 }
 
 class _RefractionInputState extends State<RefractionInput> {
@@ -105,12 +105,12 @@ class RefractionTextarea extends StatelessWidget {
   final ValueChanged<String>? onChanged;
 
   const RefractionTextarea({
-    Key? key,
+    super.key,
     this.controller,
     this.placeholder,
     this.disabled = false,
     this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter/lib/src/components/navbar.dart
+++ b/packages/flutter/lib/src/components/navbar.dart
@@ -42,7 +42,7 @@ class RefractionNavbar extends StatelessWidget implements PreferredSizeWidget {
     return Container(
       height: preferredSize.height,
       decoration: BoxDecoration(
-        color: colors.background.withOpacity(0.95), // Slight glass feel
+        color: colors.background.withValues(alpha: 0.95), // Slight glass feel
         border: Border(bottom: BorderSide(color: colors.border)),
       ),
       child: SafeArea(
@@ -94,7 +94,7 @@ class RefractionNavbar extends StatelessWidget implements PreferredSizeWidget {
                 const Spacer(),
 
               // Trailing Actions Slot
-              if (actions != null) actions!,
+              ?actions,
             ],
           ),
         ),

--- a/packages/flutter/lib/src/components/otp_input.dart
+++ b/packages/flutter/lib/src/components/otp_input.dart
@@ -9,15 +9,15 @@ class RefractionOtpInput extends StatefulWidget {
   final bool autofocus;
 
   const RefractionOtpInput({
-    Key? key,
+    super.key,
     this.length = 6,
     this.onCompleted,
     this.onChanged,
     this.autofocus = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionOtpInputState createState() => _RefractionOtpInputState();
+  State<RefractionOtpInput> createState() => _RefractionOtpInputState();
 }
 
 class _RefractionOtpInputState extends State<RefractionOtpInput> {

--- a/packages/flutter/lib/src/components/popover.dart
+++ b/packages/flutter/lib/src/components/popover.dart
@@ -7,14 +7,14 @@ class RefractionPopover extends StatefulWidget {
   final Offset offset;
 
   const RefractionPopover({
-    Key? key,
+    super.key,
     required this.trigger,
     required this.content,
     this.offset = const Offset(0, 8),
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionPopoverState createState() => _RefractionPopoverState();
+  State<RefractionPopover> createState() => _RefractionPopoverState();
 }
 
 class _RefractionPopoverState extends State<RefractionPopover> {

--- a/packages/flutter/lib/src/components/select.dart
+++ b/packages/flutter/lib/src/components/select.dart
@@ -9,16 +9,16 @@ class RefractionSelect<T> extends StatefulWidget {
   final bool disabled;
 
   const RefractionSelect({
-    Key? key,
+    super.key,
     required this.items,
     this.value,
     this.onChanged,
     this.placeholder,
     this.disabled = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionSelectState createState() => _RefractionSelectState();
+  State<RefractionSelect> createState() => _RefractionSelectState();
 }
 
 class _RefractionSelectState<T> extends State<RefractionSelect<T>> {

--- a/packages/flutter/lib/src/components/switch.dart
+++ b/packages/flutter/lib/src/components/switch.dart
@@ -7,14 +7,14 @@ class RefractionSwitch extends StatefulWidget {
   final bool disabled;
 
   const RefractionSwitch({
-    Key? key,
+    super.key,
     required this.value,
     this.onChanged,
     this.disabled = false,
-  }) : super(key: key);
+  });
 
   @override
-  _RefractionSwitchState createState() => _RefractionSwitchState();
+  State<RefractionSwitch> createState() => _RefractionSwitchState();
 }
 
 class _RefractionSwitchState extends State<RefractionSwitch> {
@@ -79,7 +79,7 @@ class _RefractionSwitchState extends State<RefractionSwitch> {
                         shape: BoxShape.circle,
                         boxShadow: [
                           BoxShadow(
-                            color: Colors.black.withOpacity(0.1),
+                            color: Colors.black.withValues(alpha: 0.1),
                             blurRadius: 2,
                             offset: const Offset(0, 1),
                           ),

--- a/packages/flutter/lib/src/components/tabs.dart
+++ b/packages/flutter/lib/src/components/tabs.dart
@@ -7,15 +7,14 @@ class RefractionTabs extends StatefulWidget {
   final int initialIndex;
 
   const RefractionTabs({
-    Key? key,
+    super.key,
     required this.tabs,
     required this.children,
     this.initialIndex = 0,
-  }) : assert(tabs.length == children.length),
-       super(key: key);
+  }) : assert(tabs.length == children.length);
 
   @override
-  _RefractionTabsState createState() => _RefractionTabsState();
+  State<RefractionTabs> createState() => _RefractionTabsState();
 }
 
 class _RefractionTabsState extends State<RefractionTabs> {
@@ -67,7 +66,7 @@ class _RefractionTabsState extends State<RefractionTabs> {
                       boxShadow: isSelected
                           ? [
                               BoxShadow(
-                                color: Colors.black.withOpacity(0.05),
+                                color: Colors.black.withValues(alpha: 0.05),
                                 blurRadius: 2,
                                 offset: const Offset(0, 1),
                               ),

--- a/packages/flutter/lib/src/components/toast.dart
+++ b/packages/flutter/lib/src/components/toast.dart
@@ -38,7 +38,7 @@ class RefractionToast {
                       border: Border.all(color: colors.border),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withOpacity(0.1),
+                          color: Colors.black.withValues(alpha: 0.1),
                           blurRadius: 12,
                           offset: const Offset(0, 4),
                         ),

--- a/packages/flutter/lib/src/components/tooltip.dart
+++ b/packages/flutter/lib/src/components/tooltip.dart
@@ -7,11 +7,11 @@ class RefractionTooltip extends StatelessWidget {
   final Duration waitDuration;
 
   const RefractionTooltip({
-    Key? key,
+    super.key,
     required this.message,
     required this.child,
     this.waitDuration = const Duration(milliseconds: 300),
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +36,7 @@ class RefractionTooltip extends StatelessWidget {
         border: Border.all(color: colors.border),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 8,
             offset: const Offset(0, 4),
           ),


### PR DESCRIPTION
## Summary

Brings `packages/flutter` from 39 lib-level analyzer issues to zero. Final blocker before `dart pub publish` produces a clean dry-run.

### Fix categories (mechanical, no API change)
- **Deprecated `withOpacity` (13 sites)**: replaced with `withValues(alpha: x)` per Flutter 3.27 deprecation.
- **`super.key` (10 sites)**: applied via `dart fix --apply`.
- **`unreachable_switch_default` (3 sites)**: removed `default:` clauses following exhaustive `case` on enums in `badge.dart` and `button.dart`.
- **`library_private_types_in_public_api` (9 sites)**: changed `createState()` return type from `_FooState` to `State<Foo>`. State class stays private; analyzer satisfied.
- **`unnecessary_library_name`**: removed redundant `library refraction_ui;` directive.

## Verification
- `dart analyze lib` — `No issues found!` ✅
- `flutter test` — 26/26 ✅
- `dart pub publish --dry-run` — only remaining warning is "modified files in git" (resolved by this commit)

## Out of scope
`example/lib/dev_tools/device_frame.dart` was also touched by `dart fix --apply` for example-app-only warnings; those don't affect publish.