### PR TITLE
fix(flutter): replace flutter create README with real package page

### DIFF
--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -1,39 +1,100 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# refraction_ui
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+A headless, highly customizable, and fully accessible Flutter UI library — the Flutter port of [Refraction UI](https://github.com/elloloop/refraction-ui).
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+`refraction_ui` brings the same headless-and-token-driven approach used by Refraction UI's React, Angular, and Astro packages to Flutter. Components consume a single `RefractionThemeData` for tokens (colors, radii, typography), so you can match an existing brand or design system by configuring tokens in one place rather than re-styling each widget.
 
 ## Features
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+A complete primitives set, all driven by `RefractionThemeData`:
+
+- **Layout & navigation** — `RefractionSidebar`, `RefractionTabs`, `RefractionAccordion`, `RefractionBreadcrumbs`, `RefractionBottomNav`, `RefractionNavbar`
+- **Inputs & forms** — `RefractionInput`, `RefractionSelect`, `RefractionCheckbox`, `RefractionRadioGroup`, `RefractionSwitch`, `RefractionOtpInput`, `RefractionRichChatInput`
+- **Buttons & menus** — `RefractionButton`, `RefractionCommandMenu`, `RefractionDropdown`
+- **Feedback** — `RefractionAlert`, `RefractionToast`, `RefractionTooltip`, `RefractionSkeleton`, `RefractionProgress`, `RefractionSlider`
+- **Identity** — `RefractionAvatar`, `RefractionBadge`
+- **Theming** — `RefractionTheme`, `RefractionThemeData`, `RefractionColors`
+
+All widgets are pure Flutter — no platform channels, no native code. Behavior, accessibility (`Semantics`), and keyboard handling match the platform conventions you'd expect.
 
 ## Getting started
 
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+Add to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  refraction_ui: ^0.1.0
+```
+
+Then wrap your app in `RefractionTheme` near the root, supplying a `RefractionThemeData`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  runApp(
+    RefractionTheme(
+      data: RefractionThemeData.light(),  // or .dark()
+      child: const MyApp(),
+    ),
+  );
+}
+```
+
+Every component below this point reads its tokens from `RefractionTheme.of(context)`.
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
+Buttons:
 
 ```dart
-const like = 'sample';
+RefractionButton(
+  variant: RefractionButtonVariant.primary,
+  onPressed: () => debugPrint('tapped'),
+  child: const Text('Submit'),
+)
 ```
+
+Inputs:
+
+```dart
+RefractionInput(
+  controller: _controller,
+  placeholder: 'name@example.com',
+  onChanged: (value) => setState(() => _email = value),
+)
+```
+
+Tabs:
+
+```dart
+RefractionTabs(
+  tabs: const ['Overview', 'Activity', 'Settings'],
+  contents: [OverviewPage(), ActivityPage(), SettingsPage()],
+)
+```
+
+Custom theme tokens:
+
+```dart
+RefractionTheme(
+  data: RefractionThemeData.light().copyWith(
+    colors: const RefractionColors.light().copyWith(
+      primary: Color(0xFF6366F1),
+      primaryForeground: Colors.white,
+    ),
+    borderRadius: 12.0,
+  ),
+  child: const MyApp(),
+)
+```
+
+Longer end-to-end examples (a complete demo app showing every component, plus role-specific dashboards and a developer tools harness) live under [`example/`](https://github.com/elloloop/refraction-ui/tree/main/packages/flutter/example).
 
 ## Additional information
 
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+- **Source & issues**: [github.com/elloloop/refraction-ui](https://github.com/elloloop/refraction-ui) (this Flutter package lives under `packages/flutter/`)
+- **Sister packages**: React (`@refraction-ui/react`), Angular (`@refraction-ui/angular-*`), Astro (`@refraction-ui/astro-*`) — same design tokens, framework-idiomatic APIs.
+- **Design tokens**: shared across all framework packages, so an app mixing Flutter (mobile) and React (web) can keep visual parity by exporting the same `RefractionColors` values to both.
+- **License**: MIT.


### PR DESCRIPTION
## Summary

`dart pub publish` rejected the package with:
> Message from server: \`README.md\` contains a generic text fragment coming from package templates (\`TODO: Put a short description of the package here\`).

The file was the `flutter create` placeholder full of TODOs. Replaced with a real package page following the [dart.dev package-pages guide](https://dart.dev/guides/libraries/writing-package-pages):

- Short pitch tying the package back to Refraction UI's headless/token-driven approach
- **Features** list grouped by domain (layout, inputs, buttons, feedback, identity, theming) — names every shipped widget so it's discoverable on pub.dev
- **Getting started** showing `RefractionTheme` + `RefractionThemeData` wiring at the app root
- **Usage** with concrete code samples for button, input, tabs, and custom tokens
- **Additional information** linking to the monorepo, listing the sister framework packages, and naming the license

## Test plan

- [x] `dart pub publish --dry-run` no longer surfaces the README placeholder warning
- [x] Markdown renders cleanly (no broken fences, anchors, etc.)
- [ ] pub.dev's actual server-side check accepts the new content