### PR TITLE
fix(flutter): pubspec metadata + discoverability fields

### DIFF
--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -2,7 +2,16 @@ name: refraction_ui
 description: "A headless, highly customizable, and fully accessible Flutter UI library matching Refraction UI."
 version: 0.1.0
 homepage: https://elloloop.github.io/refraction-ui
-repository: https://github.com/elloloop/refraction-ui-flutter
+repository: https://github.com/elloloop/refraction-ui
+issue_tracker: https://github.com/elloloop/refraction-ui/issues
+documentation: https://elloloop.github.io/refraction-ui/flutter/
+
+topics:
+  - ui
+  - widgets
+  - design-system
+  - components
+  - theme
 
 environment:
   sdk: ^3.10.1


### PR DESCRIPTION
Pure metadata fix to the Flutter package's pubspec.yaml.

- Corrects `repository:` from `elloloop/refraction-ui-flutter` (which doesn't exist) to `elloloop/refraction-ui` (this monorepo).
- Adds `issue_tracker:` and `documentation:` so pub.dev surfaces both in the sidebar.
- Adds 5 `topics:` (`ui`, `widgets`, `design-system`, `components`, `theme`) for discoverability — also a scored category in pub.dev's package report.

No source or behavior changes.