### PR TITLE
fix: publish React latest release

### DIFF
--- a/packages/react-meta/CHANGELOG.md
+++ b/packages/react-meta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @refraction-ui/react
 
+## 0.4.1
+
+### Patch Changes
+
+- Publish the React framework package to npm `latest` after `0.4.0` was already present under the `canary` dist-tag.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/react-meta/package.json
+++ b/packages/react-meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refraction-ui/react",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "All Refraction UI React components in one package — headless, accessible, zero-dependency",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump `@refraction-ui/react` to `0.4.1` so the framework package can publish to npm `latest`
- add a changelog note explaining the dist-tag recovery after `0.4.0` was already published under `canary`

## Verification
- `pnpm --filter @refraction-ui/react build`

This is needed because npm OIDC publish tokens can publish a new version, but the package-scoped token rejected moving the existing `0.4.0` dist-tag from `canary` to `latest`.