### PR TITLE
fix: isolate React meta optional peers and declarations

### DIFF
--- a/.changeset/react-meta-packaging.md
+++ b/.changeset/react-meta-packaging.md
@@ -1,0 +1,5 @@
+---
+"@refraction-ui/react": minor
+---
+
+Keep React Hook Form-backed exports behind the `@refraction-ui/react/form` subpath, remove stale Monaco peer metadata, and embed internal declaration files in the consolidated React package so consumers do not need private workspace packages installed for TypeScript.

--- a/packages/react-meta/README.md
+++ b/packages/react-meta/README.md
@@ -7,7 +7,15 @@ npm install @refraction-ui/react
 ```
 
 ```tsx
-import { Button, Card, Dialog, ThemeProvider } from '@refraction-ui/react'
+import { Button, Card, Dialog } from '@refraction-ui/react'
+import { ThemeProvider } from '@refraction-ui/react/theme'
+```
+
+React Hook Form-backed primitives are opt-in so the root package does not force
+every consumer to install `react-hook-form`:
+
+```tsx
+import { Form, FormField, useForm } from '@refraction-ui/react/form'
 ```
 
 ## Default theme stylesheet

--- a/packages/react-meta/__tests__/meta.test.ts
+++ b/packages/react-meta/__tests__/meta.test.ts
@@ -1,6 +1,31 @@
 import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import * as MetaExports from '../src/index.js'
+import * as FormExports from '../src/form.js'
 import * as ThemeExports from '../src/theme.js'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+function listDeclarationFiles(dir: string): string[] {
+  const files: string[] = []
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...listDeclarationFiles(path))
+      continue
+    }
+
+    if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.d.cts')) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
 
 describe('@refraction-ui/react (meta package)', () => {
   it('exports Button from react-button', () => {
@@ -37,6 +62,17 @@ describe('@refraction-ui/react (meta package)', () => {
 
   it('does NOT export ThemeProvider from main entry (opt-in only)', () => {
     expect((MetaExports as Record<string, unknown>).ThemeProvider).toBeUndefined()
+  })
+
+  it('does NOT export RHF-backed Form from main entry (opt-in only)', () => {
+    expect((MetaExports as Record<string, unknown>).Form).toBeUndefined()
+    expect((MetaExports as Record<string, unknown>).useForm).toBeUndefined()
+  })
+
+  it('exposes RHF-backed Form via @refraction-ui/react/form subpath', () => {
+    expect(FormExports.Form).toBeDefined()
+    expect(FormExports.FormField).toBeDefined()
+    expect(FormExports.useForm).toBeDefined()
   })
 
   it('exports Sheet compound components from react-sheet', () => {
@@ -91,5 +127,41 @@ describe('@refraction-ui/react (meta package)', () => {
     const exportedKeys = Object.keys(MetaExports)
     // With 39 active packages, we should have many exports
     expect(exportedKeys.length).toBeGreaterThan(30)
+  })
+
+  it('does not leak react-hook-form or private re-export specifiers from the built root entry', () => {
+    const distDir = join(testDir, '..', 'dist')
+    const rootJs = readFileSync(join(distDir, 'index.js'), 'utf8')
+    const rootTypes = readFileSync(join(distDir, 'index.d.ts'), 'utf8')
+
+    expect(rootJs).not.toContain('react-hook-form')
+    expect(rootJs).not.toContain('@monaco-editor/react')
+    expect(rootTypes).not.toContain('react-hook-form')
+    expect(rootTypes).not.toMatch(/from ['"]@refraction-ui\//)
+  })
+
+  it('keeps react-hook-form isolated to the built form subpath', () => {
+    const distDir = join(testDir, '..', 'dist')
+    const formJs = readFileSync(join(distDir, 'form.js'), 'utf8')
+    const formTypes = readFileSync(join(distDir, 'form.d.ts'), 'utf8')
+    const internalFormTypes = readFileSync(
+      join(distDir, 'internal', 'react-form', 'index.d.ts'),
+      'utf8'
+    )
+
+    expect(formJs).toContain('react-hook-form')
+    expect(formTypes).not.toContain('react-hook-form')
+    expect(internalFormTypes).toContain('react-hook-form')
+    expect(formTypes).not.toMatch(/from ['"]@refraction-ui\//)
+  })
+
+  it('ships embedded declarations instead of public references to private packages', () => {
+    const distDir = join(testDir, '..', 'dist')
+    const declarationText = listDeclarationFiles(distDir)
+      .map((file) => readFileSync(file, 'utf8'))
+      .join('\n')
+
+    expect(declarationText).not.toMatch(/from ['"]@refraction-ui\//)
+    expect(declarationText).not.toMatch(/import\(['"]@refraction-ui\//)
   })
 })

--- a/packages/react-meta/package.json
+++ b/packages/react-meta/package.json
@@ -17,13 +17,18 @@
       "import": "./dist/theme.js",
       "require": "./dist/theme.cjs"
     },
+    "./form": {
+      "types": "./dist/form.d.ts",
+      "import": "./dist/form.js",
+      "require": "./dist/form.cjs"
+    },
     "./styles.css": "./dist/styles.css"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && cp src/styles.css dist/styles.css && node ./scripts/embed-internal-types.mjs",
     "dev": "tsup --watch",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
@@ -33,15 +38,11 @@
     "clean": "rm -rf dist"
   },
   "peerDependencies": {
-    "@monaco-editor/react": ">=4",
     "react": ">=18",
     "react-dom": ">=18",
     "react-hook-form": ">=7.43.0"
   },
   "peerDependenciesMeta": {
-    "@monaco-editor/react": {
-      "optional": true
-    },
     "react-hook-form": {
       "optional": true
     }

--- a/packages/react-meta/scripts/embed-internal-types.mjs
+++ b/packages/react-meta/scripts/embed-internal-types.mjs
@@ -1,0 +1,136 @@
+import { cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = resolve(packageDir, '..', '..')
+const distDir = resolve(packageDir, 'dist')
+const internalDir = resolve(distDir, 'internal')
+const selfPackageName = '@refraction-ui/react'
+const packageSpecifierPattern = /(['"])@refraction-ui\/([a-z0-9-]+)\1/g
+const entryDeclarationProxies = [
+  ['form.d.ts', '@refraction-ui/react-form'],
+  ['form.d.cts', '@refraction-ui/react-form'],
+  ['theme.d.ts', '@refraction-ui/react-theme'],
+  ['theme.d.cts', '@refraction-ui/react-theme'],
+]
+
+const copied = new Set()
+const queued = []
+
+async function pathExists(path) {
+  try {
+    await readdir(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function listDeclarationFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const path = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listDeclarationFiles(path)))
+      continue
+    }
+
+    if (entry.name.endsWith('.d.ts') || entry.name.endsWith('.d.cts')) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function toSpecifier(fromFile, packageName) {
+  const extension = fromFile.endsWith('.d.cts') ? '.cjs' : '.js'
+  const target = resolve(internalDir, packageName, `index${extension}`)
+  let specifier = relative(dirname(fromFile), target).replaceAll('\\', '/')
+
+  if (!specifier.startsWith('.')) {
+    specifier = `./${specifier}`
+  }
+
+  return specifier
+}
+
+function queuePackage(packageName) {
+  if (packageName === selfPackageName || copied.has(packageName)) {
+    return
+  }
+
+  if (!queued.includes(packageName)) {
+    queued.push(packageName)
+  }
+}
+
+async function rewriteDeclarationFile(path) {
+  const original = await readFile(path, 'utf8')
+  const rewritten = original.replace(
+    packageSpecifierPattern,
+    (match, quote, localName) => {
+      const packageName = `@refraction-ui/${localName}`
+      queuePackage(packageName)
+      return `${quote}${toSpecifier(path, localName)}${quote}`
+    }
+  )
+
+  if (rewritten !== original) {
+    await writeFile(path, rewritten)
+  }
+}
+
+async function writeEntryDeclarationProxy(fileName, packageName) {
+  const file = resolve(distDir, fileName)
+  const localName = packageName.replace('@refraction-ui/', '')
+
+  queuePackage(packageName)
+  await writeFile(file, `export * from '${toSpecifier(file, localName)}';\n`)
+}
+
+async function copyPackageDeclarations(packageName) {
+  const localName = packageName.replace('@refraction-ui/', '')
+  const sourceDir = resolve(repoRoot, 'packages', localName, 'dist')
+  const targetDir = resolve(internalDir, localName)
+
+  if (!(await pathExists(sourceDir))) {
+    throw new Error(`Missing declaration source for ${packageName}: ${sourceDir}`)
+  }
+
+  await mkdir(targetDir, { recursive: true })
+
+  for (const file of await listDeclarationFiles(sourceDir)) {
+    const target = resolve(targetDir, relative(sourceDir, file))
+    await mkdir(dirname(target), { recursive: true })
+    await cp(file, target)
+  }
+
+  copied.add(packageName)
+
+  for (const file of await listDeclarationFiles(targetDir)) {
+    await rewriteDeclarationFile(file)
+  }
+}
+
+for (const [fileName, packageName] of entryDeclarationProxies) {
+  await writeEntryDeclarationProxy(fileName, packageName)
+}
+
+for (const file of await listDeclarationFiles(distDir)) {
+  if (!file.includes(`${internalDir}/`)) {
+    await rewriteDeclarationFile(file)
+  }
+}
+
+while (queued.length > 0) {
+  const packageName = queued.shift()
+  if (copied.has(packageName)) {
+    continue
+  }
+
+  await copyPackageDeclarations(packageName)
+}

--- a/packages/react-meta/src/form.ts
+++ b/packages/react-meta/src/form.ts
@@ -1,0 +1,11 @@
+/**
+ * @refraction-ui/react/form
+ *
+ * Opt-in subpath for React Hook Form-backed primitives. Keeping these exports
+ * out of the root entry prevents ordinary component consumers from having to
+ * install or resolve react-hook-form.
+ *
+ *   import { Form, FormField, useForm } from '@refraction-ui/react/form'
+ */
+
+export * from '@refraction-ui/react-form'

--- a/packages/react-meta/src/index.ts
+++ b/packages/react-meta/src/index.ts
@@ -4,7 +4,7 @@
  * Meta package that re-exports all @refraction-ui/react-* component packages.
  * Allows consumers to install everything from a single package:
  *
- *   import { Button, Dialog, ThemeProvider } from '@refraction-ui/react'
+ *   import { Button, Dialog } from '@refraction-ui/react'
  *
  * Or install individual packages for smaller bundles:
  *
@@ -15,6 +15,10 @@
 // NOTE: Theme exports moved to opt-in subpath '@refraction-ui/react/theme'
 // to avoid name clashes with consumers' existing theme systems (e.g. next-themes).
 // Import via: `import { ThemeProvider } from '@refraction-ui/react/theme'`
+//
+// RHF-backed Form exports also live behind an opt-in subpath so the root
+// package does not force every consumer to resolve react-hook-form.
+// Import via: `import { Form, useForm } from '@refraction-ui/react/form'`
 
 // Components (alphabetical)
 export * from '@refraction-ui/react-accordion'
@@ -38,7 +42,6 @@ export * from '@refraction-ui/react-dialog'
 export * from '@refraction-ui/react-dropdown-menu'
 export * from '@refraction-ui/react-feedback-dialog'
 export * from '@refraction-ui/react-footer'
-export * from '@refraction-ui/react-form'
 export * from '@refraction-ui/react-inline-editor'
 export * from '@refraction-ui/react-input'
 export * from '@refraction-ui/react-input-group'
@@ -163,4 +166,3 @@ export * from '@refraction-ui/react-card-grid'
 
 
 export * from '@refraction-ui/react-payment'
-

--- a/packages/react-meta/tsup.config.ts
+++ b/packages/react-meta/tsup.config.ts
@@ -1,18 +1,14 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/theme.ts'],
+  entry: ['src/index.ts', 'src/theme.ts', 'src/form.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,
   clean: true,
   treeshake: true,
   // Bundle all @refraction-ui/* workspace packages into the output.
-  // Only external deps (react, monaco) remain as peer deps.
+  // Only external deps (React and RHF for the form subpath) remain as peer deps.
   noExternal: [/@refraction-ui\//],
-  external: ['react', 'react-dom', '@monaco-editor/react', 'react-hook-form'],
-  // tsup does not bundle CSS, so copy the default theme stylesheet to
-  // dist/styles.css after the JS build completes. Consumers import it via
-  // `import '@refraction-ui/react/styles.css'` (see package.json exports).
-  onSuccess: 'cp src/styles.css dist/styles.css',
+  external: ['react', 'react-dom', 'react-hook-form'],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3275,9 +3275,6 @@ importers:
 
   packages/react-meta:
     dependencies:
-      '@monaco-editor/react':
-        specifier: '>=4'
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-hook-form:
         specifier: '>=7.43.0'
         version: 7.54.2(react@19.0.0)

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
       "outputs": ["coverage/**"]
     },
     "test:coverage": {
-      "dependsOn": ["^test:coverage"],
+      "dependsOn": ["build", "^test:coverage"],
       "outputs": ["coverage/**"]
     },
     "storybook:test": {


### PR DESCRIPTION
## Summary

- move RHF-backed form exports out of the root React entry and expose them via `@refraction-ui/react/form`
- embed internal declaration files into the consolidated `@refraction-ui/react` package so root types no longer point at private workspace package names
- remove stale `@monaco-editor/react` peer metadata from the React meta package
- add artifact tests and README guidance for the new form subpath

Closes #198.
Closes #199.

## Verification

- `pnpm --filter @refraction-ui/react build`
- `pnpm --filter @refraction-ui/react test`
- `pnpm --filter @refraction-ui/react typecheck`
- `pnpm --filter @refraction-ui/react lint`
- packed `@refraction-ui/react` locally, installed it into a fresh Vite app without `react-hook-form`, verified `tsc --noEmit` and `vite build` using Button/Dialog + `@refraction-ui/react/theme`
- installed `react-hook-form` in the repro app and verified `@refraction-ui/react/form` type-checks