### PR TITLE
chore: repair package generator + ignore local-only files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,8 @@ playwright-report/
 # Lost Pixel (current and diff — baselines are committed)
 .lostpixel/current/
 .lostpixel/difference/
+
+# Local-only / editor / tooling artifacts
+.DS_Store
+.claude/
+job_log_vrt.txt

--- a/scripts/generate-package.mjs
+++ b/scripts/generate-package.mjs
@@ -208,4 +208,3 @@ switch (type) {
 }
 
 console.log(`✓ Created packages/${name} (${type})`)
-e})`)


### PR DESCRIPTION
Fixes a corrupt trailing line in `scripts/generate-package.mjs` (`e})\`)` at line 211) that caused a `SyntaxError` and **blocked all package scaffolding** — prerequisite for the telemetry/analytics epics (#206, #213). Also gitignores `.claude/`, `.DS_Store`, `job_log_vrt.txt` so local-only artifacts stop polluting diffs.

Verified: `node --check` passes; generator scaffolds a core package successfully.