### PR TITLE
feat(logger): @refraction-ui/logger headless core (#207)

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,143 @@
+# @refraction-ui/logger
+
+Headless, vendor-neutral telemetry/logging core. Manager + provider (sink)
+pattern, mirroring [`@refraction-ui/ai`](../ai). No framework, no UI, no
+required network dependency.
+
+- **Vendor-neutral** — engines implement a `TelemetrySink` interface. The
+  default engine is Grafana Faro, attached via **optional peerDependencies**.
+  No Faro/Grafana type ever appears in the public API.
+- **Console by default** — with no `endpoint`, telemetry is console-only.
+- **Kill switch** — `enabled: false` returns a tree-shakeable noop logger
+  that produces zero emissions and never imports an engine.
+- **Env presets** — `development` (sync, pretty, `debug`, no batching) vs
+  `production` (batched, sampled, `>= warn`, beacon flush on page exit).
+- **Child loggers** with bound context, async **spans**, **redaction**.
+
+## Install
+
+```sh
+pnpm add @refraction-ui/logger
+```
+
+To use the Faro engine (optional — only when you set an `endpoint`):
+
+```sh
+pnpm add @grafana/faro-web-sdk @grafana/faro-web-tracing
+```
+
+If these peers are not installed, the logger silently stays console-only.
+
+## Quick start
+
+```ts
+import { createTelemetry } from '@refraction-ui/logger'
+
+const telemetry = createTelemetry({
+  app: 'interview-service',
+  env: 'production',
+  endpoint: 'https://collector.example/ingest', // optional
+  sampleRate: 0.25,                              // optional
+  redactKeys: ['password', 'token'],             // optional
+  enabled: true,                                 // optional (default true)
+})
+
+telemetry.warn('rate limited', { route: '/v1/answer' })
+
+const session = telemetry.child({ sessionId: 's-123' })
+const turn = session.child({ turnId: 't-7' })
+
+const span = turn.startSpan('llm-call', { model: 'gpt' })
+try {
+  // ... async work ...
+  span.end()
+} catch (err) {
+  span.end({ error: err })
+}
+
+await telemetry.flush()
+```
+
+## API
+
+### `createTelemetry(config): Telemetry`
+
+| Config field | Type | Notes |
+| --- | --- | --- |
+| `app` | `string` | Logical app/service name on every record. **Required.** |
+| `env` | `'development' \| 'production'` | Selects a behavior preset. **Required.** |
+| `endpoint` | `string?` | Remote collector URL. Omit → console only (no engine constructed). |
+| `enabled` | `boolean?` | `false` → tree-shakeable noop, zero emissions. Default `true`. |
+| `sampleRate` | `number?` | `0..1` kept fraction. Defaults to the preset (`1` dev / `0.25` prod). |
+| `redactKeys` | `string[]?` | Context keys (deep, case-insensitive) replaced with `[REDACTED]`. |
+
+Returns a `Telemetry` — which **is** a `Logger` bound to an empty root
+context, plus sink management.
+
+### `Logger`
+
+| Member | Description |
+| --- | --- |
+| `debug/info/warn/error/fatal(message, context?)` | Emit a record at that level. |
+| `child(context)` | Derive a logger with merged bound context (e.g. `sessionId`, `interviewId`, `turnId`). Parent is unaffected. |
+| `startSpan(name, attributes?) → Span` | Begin a timed span. |
+| `flush()` | Deliver buffered records (batched presets) and flush every sink. |
+
+### `Span`
+
+| Member | Description |
+| --- | --- |
+| `end(opts?)` | End and emit a `SpanRecord`. `opts.error` → `status: 'error'`; `opts.attributes` merges in. Idempotent. |
+
+### `Telemetry` (extends `Logger`)
+
+| Member | Description |
+| --- | --- |
+| `sinks` | Registered sink names, insertion order. |
+| `addSink(sink)` | Register an additional `TelemetrySink`. |
+| `removeSink(name)` | Remove a sink by name. |
+
+### Presets
+
+| | development | production |
+| --- | --- | --- |
+| min level | `debug` | `warn` |
+| delivery | sync | batched (size 20) |
+| sample rate | `1` | `0.25` |
+| console output | pretty | structured JSON |
+| beacon flush on `pagehide`/`visibilitychange` | no | yes |
+
+Exposed as `PRESETS` and `resolvePreset(env)`.
+
+### Sinks (transports)
+
+`TelemetrySink` is the vendor-neutral engine contract:
+
+```ts
+interface TelemetrySink {
+  name: string
+  log(record: LogRecord): void
+  span(record: SpanRecord): void
+  flush(): Promise<void>
+}
+```
+
+Built-ins:
+
+- `createConsoleSink(options?)` — default zero-dependency transport.
+- `createFaroSink(options)` — async Grafana Faro engine. Loads the optional
+  peers dynamically; resolves to `null` when they are absent (caller falls
+  back to console). Accepts an injectable `transport` for tests (no network).
+- `createNoopTelemetry()` — the kill-switch logger (used internally when
+  `enabled: false`).
+
+### Utilities
+
+- `redact(context, keys)` — deep, case-insensitive, cycle-safe redaction.
+- `createMockSink(name?)` — recording sink for tests (`logs`, `spans`,
+  `flushCalls`). Mirrors `createMockAIProvider`.
+- `LEVEL_ORDER` — numeric level ordering for threshold comparisons.
+
+## License
+
+MIT

--- a/packages/logger/__tests__/console-sink.test.ts
+++ b/packages/logger/__tests__/console-sink.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createConsoleSink } from '../src/console-sink.js'
+import type { LogRecord, SpanRecord } from '../src/types.js'
+
+function makeLog(overrides: Partial<LogRecord> = {}): LogRecord {
+  return {
+    level: 'info',
+    message: 'hello',
+    timestamp: 1_700_000_000_000,
+    app: 'app',
+    env: 'development',
+    context: { a: 1 },
+    ...overrides,
+  }
+}
+
+function makeSpan(overrides: Partial<SpanRecord> = {}): SpanRecord {
+  return {
+    name: 'work',
+    startTime: 0,
+    endTime: 5,
+    durationMs: 5,
+    app: 'app',
+    env: 'development',
+    context: {},
+    status: 'ok',
+    ...overrides,
+  }
+}
+
+describe('createConsoleSink', () => {
+  it('maps levels to console methods', () => {
+    const fake = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const sink = createConsoleSink({ console: fake })
+    sink.log(makeLog({ level: 'debug' }))
+    sink.log(makeLog({ level: 'info' }))
+    sink.log(makeLog({ level: 'warn' }))
+    sink.log(makeLog({ level: 'error' }))
+    sink.log(makeLog({ level: 'fatal' }))
+    expect(fake.debug).toHaveBeenCalledTimes(1)
+    expect(fake.info).toHaveBeenCalledTimes(1)
+    expect(fake.warn).toHaveBeenCalledTimes(1)
+    // fatal maps to error
+    expect(fake.error).toHaveBeenCalledTimes(2)
+  })
+
+  it('pretty mode writes a single readable line + context payload', () => {
+    const fake = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const sink = createConsoleSink({ pretty: true, console: fake })
+    sink.log(makeLog({ message: 'pretty please' }))
+    const [line, payload] = fake.info.mock.calls[0]
+    expect(String(line)).toContain('INFO')
+    expect(String(line)).toContain('[app]')
+    expect(String(line)).toContain('pretty please')
+    expect(payload).toEqual({ a: 1 })
+  })
+
+  it('structured mode writes JSON', () => {
+    const fake = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const sink = createConsoleSink({ pretty: false, console: fake })
+    sink.log(makeLog())
+    const [line] = fake.info.mock.calls[0]
+    const parsed = JSON.parse(String(line))
+    expect(parsed.type).toBe('log')
+    expect(parsed.message).toBe('hello')
+  })
+
+  it('span ok uses debug, span error uses error', () => {
+    const fake = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const sink = createConsoleSink({ console: fake })
+    sink.span(makeSpan({ status: 'ok' }))
+    sink.span(makeSpan({ status: 'error' }))
+    expect(fake.debug).toHaveBeenCalledTimes(1)
+    expect(fake.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('flush resolves (nothing buffered)', async () => {
+    const sink = createConsoleSink({ console: { debug() {}, info() {}, warn() {}, error() {} } })
+    await expect(sink.flush()).resolves.toBeUndefined()
+  })
+})

--- a/packages/logger/__tests__/faro-engine.test.ts
+++ b/packages/logger/__tests__/faro-engine.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createFaroSink } from '../src/faro-engine.js'
+import type { LogRecord, SpanRecord } from '../src/types.js'
+
+function makeLog(overrides: Partial<LogRecord> = {}): LogRecord {
+  return {
+    level: 'warn',
+    message: 'faro msg',
+    timestamp: 1,
+    app: 'app',
+    env: 'production',
+    context: { sessionId: 's1' },
+    ...overrides,
+  }
+}
+
+function makeSpan(overrides: Partial<SpanRecord> = {}): SpanRecord {
+  return {
+    name: 'turn',
+    startTime: 0,
+    endTime: 10,
+    durationMs: 10,
+    app: 'app',
+    env: 'production',
+    context: { turnId: 't1' },
+    status: 'ok',
+    ...overrides,
+  }
+}
+
+describe('createFaroSink (mock transport, no network)', () => {
+  it('returns a sink that forwards logs to the injected transport', async () => {
+    const push = vi.fn()
+    const sink = await createFaroSink({
+      app: 'app',
+      endpoint: 'https://collector.example/ingest',
+      transport: { push },
+    })
+    expect(sink).not.toBeNull()
+    expect(sink!.name).toBe('faro')
+
+    const record = makeLog()
+    sink!.log(record)
+    expect(push).toHaveBeenCalledWith({ kind: 'log', record })
+  })
+
+  it('forwards spans to the injected transport', async () => {
+    const push = vi.fn()
+    const sink = await createFaroSink({
+      app: 'app',
+      endpoint: 'https://collector.example/ingest',
+      transport: { push },
+    })
+    const record = makeSpan()
+    sink!.span(record)
+    expect(push).toHaveBeenCalledWith({ kind: 'span', record })
+  })
+
+  it('flush resolves without I/O', async () => {
+    const sink = await createFaroSink({
+      app: 'app',
+      endpoint: 'https://x',
+      transport: { push: vi.fn() },
+    })
+    await expect(sink!.flush()).resolves.toBeUndefined()
+  })
+
+  it('returns null when Faro peers are absent and no transport injected', async () => {
+    // The optional @grafana/faro-* peers are NOT installed in this repo, so
+    // the dynamic import inside the engine fails and the factory yields null.
+    const sink = await createFaroSink({
+      app: 'app',
+      endpoint: 'https://collector.example/ingest',
+    })
+    expect(sink).toBeNull()
+  })
+
+  it('never leaks Faro/Grafana names through its public surface', async () => {
+    const sink = await createFaroSink({
+      app: 'app',
+      endpoint: 'https://x',
+      transport: { push: vi.fn() },
+    })
+    // Public sink shape is exactly the vendor-neutral TelemetrySink.
+    expect(Object.keys(sink!).sort()).toEqual(['flush', 'log', 'name', 'span'])
+    expect(sink!.name).toBe('faro')
+  })
+})

--- a/packages/logger/__tests__/noop.test.ts
+++ b/packages/logger/__tests__/noop.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createNoopTelemetry } from '../src/noop.js'
+
+describe('createNoopTelemetry', () => {
+  it('exposes the full Telemetry surface', () => {
+    const t = createNoopTelemetry()
+    expect(typeof t.debug).toBe('function')
+    expect(typeof t.info).toBe('function')
+    expect(typeof t.warn).toBe('function')
+    expect(typeof t.error).toBe('function')
+    expect(typeof t.fatal).toBe('function')
+    expect(typeof t.child).toBe('function')
+    expect(typeof t.startSpan).toBe('function')
+    expect(typeof t.flush).toBe('function')
+    expect(typeof t.addSink).toBe('function')
+    expect(typeof t.removeSink).toBe('function')
+  })
+
+  it('never writes to console', () => {
+    const spies = (['debug', 'info', 'warn', 'error'] as const).map((m) =>
+      vi.spyOn(console, m).mockImplementation(() => {}),
+    )
+    const t = createNoopTelemetry()
+    t.debug('x')
+    t.info('x')
+    t.warn('x')
+    t.error('x')
+    t.fatal('x')
+    for (const s of spies) {
+      expect(s).not.toHaveBeenCalled()
+      s.mockRestore()
+    }
+  })
+
+  it('reports zero sinks and addSink is inert', () => {
+    const t = createNoopTelemetry()
+    expect(t.sinks).toEqual([])
+    t.addSink({ name: 'x', log() {}, span() {}, flush: async () => {} })
+    expect(t.sinks).toEqual([])
+  })
+
+  it('child returns a noop logger', () => {
+    const t = createNoopTelemetry()
+    const child = t.child({ a: 1 })
+    expect(child.sinks).toEqual([])
+    expect(() => child.info('x')).not.toThrow()
+  })
+
+  it('span end and flush resolve without effect', async () => {
+    const t = createNoopTelemetry()
+    expect(() => t.startSpan('x').end()).not.toThrow()
+    await expect(t.flush()).resolves.toBeUndefined()
+  })
+})

--- a/packages/logger/__tests__/presets.test.ts
+++ b/packages/logger/__tests__/presets.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { PRESETS, resolvePreset } from '../src/presets.js'
+
+describe('presets', () => {
+  it('development is sync, pretty, level=debug, no batch, full sample', () => {
+    const p = PRESETS.development
+    expect(p.minLevel).toBe('debug')
+    expect(p.batch).toBe(false)
+    expect(p.pretty).toBe(true)
+    expect(p.sampleRate).toBe(1)
+    expect(p.beaconFlush).toBe(false)
+  })
+
+  it('production is batched, sampled, level>=warn, beacon flush', () => {
+    const p = PRESETS.production
+    expect(p.minLevel).toBe('warn')
+    expect(p.batch).toBe(true)
+    expect(p.batchSize).toBeGreaterThan(1)
+    expect(p.sampleRate).toBeGreaterThan(0)
+    expect(p.sampleRate).toBeLessThan(1)
+    expect(p.beaconFlush).toBe(true)
+    expect(p.pretty).toBe(false)
+  })
+
+  it('resolvePreset returns a defensive copy', () => {
+    const a = resolvePreset('development')
+    const b = resolvePreset('development')
+    expect(a).toEqual(b)
+    expect(a).not.toBe(b)
+    a.minLevel = 'error'
+    expect(PRESETS.development.minLevel).toBe('debug')
+  })
+
+  it('resolvePreset selects the right env', () => {
+    expect(resolvePreset('production').minLevel).toBe('warn')
+    expect(resolvePreset('development').minLevel).toBe('debug')
+  })
+})

--- a/packages/logger/__tests__/redact.test.ts
+++ b/packages/logger/__tests__/redact.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { redact } from '../src/redact.js'
+
+describe('redact', () => {
+  it('returns the same reference when no keys configured', () => {
+    const input = { a: 1 }
+    expect(redact(input, [])).toBe(input)
+  })
+
+  it('replaces matching top-level keys', () => {
+    expect(redact({ user: 'a', password: 'p' }, ['password'])).toEqual({
+      user: 'a',
+      password: '[REDACTED]',
+    })
+  })
+
+  it('is case-insensitive', () => {
+    expect(redact({ Token: 'x' }, ['token'])).toEqual({ Token: '[REDACTED]' })
+  })
+
+  it('redacts nested objects and arrays', () => {
+    const out = redact(
+      { list: [{ secret: 1, ok: 2 }], deep: { inner: { secret: 3 } } },
+      ['secret'],
+    )
+    expect(out).toEqual({
+      list: [{ secret: '[REDACTED]', ok: 2 }],
+      deep: { inner: { secret: '[REDACTED]' } },
+    })
+  })
+
+  it('does not mutate the input', () => {
+    const input = { password: 'p', nested: { token: 't' } }
+    const out = redact(input, ['password', 'token'])
+    expect(input).toEqual({ password: 'p', nested: { token: 't' } })
+    expect(out).not.toBe(input)
+  })
+
+  it('guards against circular references', () => {
+    const input: Record<string, unknown> = { a: 1 }
+    input.self = input
+    const out = redact(input, ['nope']) as Record<string, unknown>
+    expect(out.a).toBe(1)
+    expect(out.self).toBe('[Circular]')
+  })
+
+  it('passes primitives through untouched', () => {
+    expect(redact({ n: 1, s: 'x', b: true, z: null }, ['secret'])).toEqual({
+      n: 1,
+      s: 'x',
+      b: true,
+      z: null,
+    })
+  })
+})

--- a/packages/logger/__tests__/telemetry-manager.test.ts
+++ b/packages/logger/__tests__/telemetry-manager.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createTelemetry } from '../src/telemetry-manager.js'
+import { createMockSink } from '../src/mock-sink.js'
+import type { TelemetryConfig } from '../src/types.js'
+
+const baseDev: TelemetryConfig = { app: 'test-app', env: 'development' }
+const baseProd: TelemetryConfig = { app: 'test-app', env: 'production' }
+
+describe('createTelemetry', () => {
+  // --- Construction / config ---
+  describe('config', () => {
+    it('returns a logger with all level methods', () => {
+      const t = createTelemetry(baseDev)
+      expect(typeof t.debug).toBe('function')
+      expect(typeof t.info).toBe('function')
+      expect(typeof t.warn).toBe('function')
+      expect(typeof t.error).toBe('function')
+      expect(typeof t.fatal).toBe('function')
+      expect(typeof t.child).toBe('function')
+      expect(typeof t.startSpan).toBe('function')
+      expect(typeof t.flush).toBe('function')
+    })
+
+    it('registers a console sink by default (no endpoint)', () => {
+      const t = createTelemetry(baseDev)
+      expect(t.sinks).toEqual(['console'])
+    })
+
+    it('addSink / removeSink manage extra sinks in order', () => {
+      const t = createTelemetry(baseDev)
+      t.addSink(createMockSink('a'))
+      t.addSink(createMockSink('b'))
+      expect(t.sinks).toEqual(['console', 'a', 'b'])
+      t.removeSink('a')
+      expect(t.sinks).toEqual(['console', 'b'])
+    })
+
+    it('removeSink is a no-op for unknown sink', () => {
+      const t = createTelemetry(baseDev)
+      t.removeSink('nope')
+      expect(t.sinks).toEqual(['console'])
+    })
+
+    it('addSink with same name replaces in place', () => {
+      const t = createTelemetry(baseDev)
+      const a1 = createMockSink('x')
+      const a2 = createMockSink('x')
+      t.addSink(a1)
+      t.addSink(a2)
+      expect(t.sinks).toEqual(['console', 'x'])
+    })
+  })
+
+  // --- Preset selection ---
+  describe('preset selection', () => {
+    it('development preset emits debug-level records synchronously', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.debug('hello')
+      expect(sink.logs).toHaveLength(1)
+      expect(sink.logs[0].level).toBe('debug')
+      expect(sink.logs[0].app).toBe('test-app')
+      expect(sink.logs[0].env).toBe('development')
+    })
+
+    it('production preset drops records below warn', async () => {
+      const t = createTelemetry({ ...baseProd, sampleRate: 1 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.debug('drop me')
+      t.info('drop me too')
+      t.warn('keep me')
+      t.error('keep me too')
+      // Production batches — flush to deliver buffered (>= warn) records.
+      await t.flush()
+      expect(sink.logs.map((l) => l.level)).toEqual(['warn', 'error'])
+    })
+
+    it('explicit sampleRate overrides preset default', async () => {
+      const rnd = vi.spyOn(Math, 'random').mockReturnValue(0.9)
+      const t = createTelemetry({ ...baseProd, sampleRate: 0 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.error('sampled out')
+      await t.flush()
+      // sampleRate:0 drops before buffering — flush yields nothing.
+      expect(sink.logs).toHaveLength(0)
+      rnd.mockRestore()
+    })
+
+    it('sampleRate=1 keeps everything', () => {
+      const t = createTelemetry({ ...baseDev, sampleRate: 1 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      for (let i = 0; i < 10; i++) t.info(`m${i}`)
+      expect(sink.logs).toHaveLength(10)
+    })
+  })
+
+  // --- Child-logger context binding ---
+  describe('child context binding', () => {
+    it('child binds context onto every record', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const child = t.child({ sessionId: 's1', interviewId: 'i1' })
+      child.info('joined', { turnId: 't1' })
+      expect(sink.logs[0].context).toEqual({
+        sessionId: 's1',
+        interviewId: 'i1',
+        turnId: 't1',
+      })
+    })
+
+    it('nested children merge and override parent context', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const a = t.child({ sessionId: 's1', role: 'root' })
+      const b = a.child({ interviewId: 'i1', role: 'child' })
+      b.warn('nested')
+      expect(sink.logs[0].context).toEqual({
+        sessionId: 's1',
+        interviewId: 'i1',
+        role: 'child',
+      })
+    })
+
+    it('parent logger is unaffected by child context', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.child({ sessionId: 's1' })
+      t.info('root only')
+      expect(sink.logs[0].context).toEqual({})
+    })
+
+    it('child shares the same sink registry as the parent', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink('shared')
+      t.addSink(sink)
+      const child = t.child({ a: 1 })
+      expect(child.sinks).toEqual(['console', 'shared'])
+    })
+  })
+
+  // --- Span lifecycle ---
+  describe('span lifecycle', () => {
+    it('startSpan/end emits a span record with duration', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const span = t.startSpan('load-model', { model: 'gpt' })
+      span.end()
+      expect(sink.spans).toHaveLength(1)
+      expect(sink.spans[0].name).toBe('load-model')
+      expect(sink.spans[0].status).toBe('ok')
+      expect(sink.spans[0].context).toMatchObject({ model: 'gpt' })
+      expect(sink.spans[0].durationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it('span end is idempotent', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const span = t.startSpan('once')
+      span.end()
+      span.end()
+      expect(sink.spans).toHaveLength(1)
+    })
+
+    it('span end with error sets status=error and captures message', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const span = t.startSpan('risky')
+      span.end({ error: new Error('boom') })
+      expect(sink.spans[0].status).toBe('error')
+      expect(sink.spans[0].error).toEqual({ name: 'Error', message: 'boom' })
+    })
+
+    it('span inherits bound child context', () => {
+      const t = createTelemetry(baseDev)
+      const sink = createMockSink()
+      t.addSink(sink)
+      const child = t.child({ sessionId: 's1' })
+      child.startSpan('work', { step: 1 }).end({ attributes: { step: 2 } })
+      expect(sink.spans[0].context).toEqual({ sessionId: 's1', step: 2 })
+    })
+  })
+
+  // --- Redaction ---
+  describe('redaction', () => {
+    it('strips configured keys from log context', () => {
+      const t = createTelemetry({ ...baseDev, redactKeys: ['password', 'token'] })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.info('login', { user: 'a', password: 'hunter2', token: 'abc' })
+      expect(sink.logs[0].context).toEqual({
+        user: 'a',
+        password: '[REDACTED]',
+        token: '[REDACTED]',
+      })
+    })
+
+    it('redacts deeply and case-insensitively', () => {
+      const t = createTelemetry({ ...baseDev, redactKeys: ['secret'] })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.info('m', { nested: { SECRET: 'x', ok: 1 } })
+      expect(sink.logs[0].context).toEqual({ nested: { SECRET: '[REDACTED]', ok: 1 } })
+    })
+
+    it('redacts span context too', () => {
+      const t = createTelemetry({ ...baseDev, redactKeys: ['apikey'] })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.startSpan('call', { apikey: 'sk-1', endpoint: '/x' }).end()
+      expect(sink.spans[0].context).toEqual({
+        apikey: '[REDACTED]',
+        endpoint: '/x',
+      })
+    })
+  })
+
+  // --- Behavior: disabled => zero emissions ---
+  describe('disabled kill switch', () => {
+    it('enabled:false produces zero emissions and no sinks', () => {
+      const t = createTelemetry({ ...baseDev, enabled: false })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.info('nope')
+      t.error('still nope')
+      t.startSpan('x').end()
+      expect(sink.logs).toHaveLength(0)
+      expect(sink.spans).toHaveLength(0)
+      expect(t.sinks).toEqual([])
+    })
+
+    it('disabled child loggers are also silent', () => {
+      const t = createTelemetry({ ...baseDev, enabled: false })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.child({ a: 1 }).warn('quiet')
+      expect(sink.logs).toHaveLength(0)
+    })
+  })
+
+  // --- Behavior: no endpoint => console only ---
+  describe('no endpoint => console only', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    })
+    afterEach(() => logSpy.mockRestore())
+
+    it('uses only the console sink and writes to console', () => {
+      const t = createTelemetry(baseDev)
+      expect(t.sinks).toEqual(['console'])
+      t.info('to console')
+      expect(logSpy).toHaveBeenCalledTimes(1)
+      expect(String(logSpy.mock.calls[0][0])).toContain('to console')
+    })
+  })
+
+  // --- Behavior: prod preset batches & flushes on pagehide ---
+  describe('prod preset batching + pagehide flush', () => {
+    const listeners = new Map<string, Array<() => void>>()
+    const g = globalThis as unknown as {
+      addEventListener?: unknown
+      document?: unknown
+    }
+    let hadAdd: boolean
+    let hadDoc: boolean
+
+    beforeEach(() => {
+      listeners.clear()
+      // Node env has no DOM — stub the page lifecycle surface the manager
+      // probes (window.addEventListener + document.visibilityState).
+      hadAdd = 'addEventListener' in g
+      hadDoc = 'document' in g
+      g.addEventListener = (type: string, fn: () => void) => {
+        const arr = listeners.get(type) ?? []
+        arr.push(fn)
+        listeners.set(type, arr)
+      }
+      g.document = { visibilityState: 'hidden' }
+    })
+    afterEach(() => {
+      if (!hadAdd) delete g.addEventListener
+      if (!hadDoc) delete g.document
+    })
+
+    it('buffers records until batchSize, then flushes', async () => {
+      const t = createTelemetry({ ...baseProd, sampleRate: 1 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      // batchSize is 20; emit 19 warns -> still buffered
+      for (let i = 0; i < 19; i++) t.warn(`w${i}`)
+      expect(sink.logs).toHaveLength(0)
+      // 20th triggers an automatic flush
+      t.warn('w19')
+      await Promise.resolve()
+      expect(sink.logs).toHaveLength(20)
+    })
+
+    it('explicit flush() delivers buffered records and calls sink.flush', async () => {
+      const t = createTelemetry({ ...baseProd, sampleRate: 1 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.error('buffered')
+      expect(sink.logs).toHaveLength(0)
+      await t.flush()
+      expect(sink.logs).toHaveLength(1)
+      expect(sink.flushCalls).toBeGreaterThanOrEqual(1)
+    })
+
+    it('registers pagehide + visibilitychange listeners and flushes on pagehide', async () => {
+      const t = createTelemetry({ ...baseProd, sampleRate: 1 })
+      const sink = createMockSink()
+      t.addSink(sink)
+      t.warn('pending')
+      expect(listeners.has('pagehide')).toBe(true)
+      expect(listeners.has('visibilitychange')).toBe(true)
+      // Fire pagehide -> buffered record should be delivered.
+      for (const fn of listeners.get('pagehide')!) fn()
+      await Promise.resolve()
+      expect(sink.logs).toHaveLength(1)
+      expect(sink.logs[0].message).toBe('pending')
+    })
+  })
+})

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@refraction-ui/logger",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@grafana/faro-web-sdk": ">=1",
+    "@grafana/faro-web-tracing": ">=1"
+  },
+  "peerDependenciesMeta": {
+    "@grafana/faro-web-sdk": {
+      "optional": true
+    },
+    "@grafana/faro-web-tracing": {
+      "optional": true
+    }
+  },
+  "devDependencies": {},
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/logger"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/logger/src/console-sink.ts
+++ b/packages/logger/src/console-sink.ts
@@ -1,0 +1,64 @@
+import type { LogLevel, LogRecord, SpanRecord, TelemetrySink } from './types.js'
+
+/** Console method used for each level. */
+const METHOD: Record<LogLevel, 'debug' | 'info' | 'warn' | 'error'> = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+  fatal: 'error',
+}
+
+export interface ConsoleSinkOptions {
+  /** Single-line pretty output (vs. structured JSON). */
+  pretty?: boolean
+  /** Console to write to (injectable for tests). Defaults to global console. */
+  console?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>
+}
+
+/**
+ * Default zero-dependency transport. Used whenever no `endpoint` is set.
+ * Synchronous; `flush()` is a resolved no-op (nothing is buffered).
+ */
+export function createConsoleSink(opts?: ConsoleSinkOptions): TelemetrySink {
+  const pretty = opts?.pretty ?? true
+  const out = opts?.console ?? console
+
+  function emit(level: LogLevel, line: string, payload: unknown): void {
+    out[METHOD[level]](line, payload)
+  }
+
+  return {
+    name: 'console',
+
+    log(record: LogRecord): void {
+      if (pretty) {
+        const ts = new Date(record.timestamp).toISOString()
+        emit(
+          record.level,
+          `${ts} ${record.level.toUpperCase()} [${record.app}] ${record.message}`,
+          record.context,
+        )
+      } else {
+        emit(record.level, JSON.stringify({ type: 'log', ...record }), record.context)
+      }
+    },
+
+    span(record: SpanRecord): void {
+      const level: LogLevel = record.status === 'error' ? 'error' : 'debug'
+      if (pretty) {
+        emit(
+          level,
+          `[span] ${record.name} ${record.durationMs.toFixed(2)}ms (${record.status})`,
+          record.context,
+        )
+      } else {
+        emit(level, JSON.stringify({ type: 'span', ...record }), record.context)
+      }
+    },
+
+    async flush(): Promise<void> {
+      // Console is synchronous — nothing buffered.
+    },
+  }
+}

--- a/packages/logger/src/faro-engine.ts
+++ b/packages/logger/src/faro-engine.ts
@@ -1,0 +1,130 @@
+import type { LogLevel, LogRecord, SpanRecord, TelemetrySink } from './types.js'
+
+/**
+ * Faro-backed engine. `@grafana/faro-web-sdk` + `@grafana/faro-web-tracing`
+ * are **optional peerDependencies** — they are loaded dynamically and never
+ * referenced in this module's public types. If the peers are absent the
+ * factory resolves to `null` so the caller can fall back to console.
+ *
+ * For tests, a `transport` may be injected: an object with a `push(payload)`
+ * method. This bypasses Faro entirely (no network, no peer required).
+ */
+
+/** Minimal structural shape of a Faro-ish transport. Not exported. */
+interface FaroTransport {
+  push(payload: { kind: 'log' | 'span'; record: LogRecord | SpanRecord }): void
+}
+
+export interface FaroEngineOptions {
+  app: string
+  endpoint: string
+  /**
+   * Test/override transport. When provided, the Faro peers are NOT loaded
+   * and records are forwarded straight to `transport.push`.
+   */
+  transport?: FaroTransport
+}
+
+/** Map our levels onto Faro's log-level strings. */
+const FARO_LEVEL: Record<LogLevel, string> = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+  fatal: 'error',
+}
+
+/**
+ * Construct the Faro engine. Returns `null` when the optional peers are not
+ * installed and no override transport was supplied — callers treat `null` as
+ * "fall back to console".
+ */
+export async function createFaroSink(
+  opts: FaroEngineOptions,
+): Promise<TelemetrySink | null> {
+  const transport = opts.transport ?? (await loadFaroTransport(opts))
+  if (!transport) return null
+
+  return {
+    name: 'faro',
+
+    log(record: LogRecord): void {
+      transport.push({ kind: 'log', record })
+    },
+
+    span(record: SpanRecord): void {
+      transport.push({ kind: 'span', record })
+    },
+
+    async flush(): Promise<void> {
+      // Faro's own transports flush on their schedule / on beacon; the
+      // manager drives page-exit beacon flushing. Nothing buffered here.
+    },
+  }
+}
+
+/**
+ * Dynamically import the Faro peers and adapt them to {@link FaroTransport}.
+ * Returns `null` if either peer is missing (optional peerDependency absent).
+ */
+async function loadFaroTransport(
+  opts: FaroEngineOptions,
+): Promise<FaroTransport | null> {
+  try {
+    // Indirected so bundlers keep these as runtime-optional dynamic imports.
+    const sdkName = '@grafana/faro-web-sdk'
+    const tracingName = '@grafana/faro-web-tracing'
+    const sdk = (await import(/* @vite-ignore */ sdkName)) as {
+      initializeFaro: (cfg: unknown) => unknown
+      getWebInstrumentations: () => unknown[]
+    }
+    const tracing = (await import(/* @vite-ignore */ tracingName)) as {
+      TracingInstrumentation: new () => unknown
+    }
+
+    const faro = sdk.initializeFaro({
+      url: opts.endpoint,
+      app: { name: opts.app },
+      instrumentations: [
+        ...sdk.getWebInstrumentations(),
+        new tracing.TracingInstrumentation(),
+      ],
+    }) as {
+      api: {
+        pushLog: (msgs: unknown[], opts?: unknown) => void
+        pushEvent: (name: string, attrs?: Record<string, unknown>) => void
+      }
+    }
+
+    return {
+      push({ kind, record }): void {
+        if (kind === 'log') {
+          const r = record as LogRecord
+          faro.api.pushLog([r.message], {
+            level: FARO_LEVEL[r.level],
+            context: flatten(r.context),
+          })
+        } else {
+          const r = record as SpanRecord
+          faro.api.pushEvent(`span:${r.name}`, {
+            durationMs: String(r.durationMs),
+            status: r.status,
+            ...flatten(r.context),
+          })
+        }
+      },
+    }
+  } catch {
+    // Peer not installed (optional) or init failed — caller falls back.
+    return null
+  }
+}
+
+/** Faro context attributes are flat string maps; coerce ours to match. */
+function flatten(ctx: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(ctx)) {
+    out[k] = typeof v === 'string' ? v : JSON.stringify(v)
+  }
+  return out
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,39 @@
+// Types (vendor-neutral — no Faro/Grafana types are exported)
+export type {
+  LogLevel,
+  LogContext,
+  LogRecord,
+  SpanRecord,
+  TelemetrySink,
+  TelemetryEnv,
+  TelemetryConfig,
+  Logger,
+  Span,
+  Telemetry,
+} from './types.js'
+export { LEVEL_ORDER } from './types.js'
+
+// Manager
+export { createTelemetry } from './telemetry-manager.js'
+export type { TelemetryPreset } from './telemetry-manager.js'
+
+// Presets
+export { PRESETS, resolvePreset } from './presets.js'
+
+// Built-in transports
+export { createConsoleSink } from './console-sink.js'
+export type { ConsoleSinkOptions } from './console-sink.js'
+
+// Faro engine (optional peers loaded dynamically; types stay vendor-neutral)
+export { createFaroSink } from './faro-engine.js'
+export type { FaroEngineOptions } from './faro-engine.js'
+
+// Kill switch
+export { createNoopTelemetry } from './noop.js'
+
+// Utilities
+export { redact } from './redact.js'
+
+// Mock sink (for testing)
+export { createMockSink } from './mock-sink.js'
+export type { MockSinkExtended } from './mock-sink.js'

--- a/packages/logger/src/mock-sink.ts
+++ b/packages/logger/src/mock-sink.ts
@@ -1,0 +1,38 @@
+import type { LogRecord, SpanRecord, TelemetrySink } from './types.js'
+
+export interface MockSinkExtended extends TelemetrySink {
+  /** Every log record received, in order. */
+  logs: LogRecord[]
+  /** Every span record received, in order. */
+  spans: SpanRecord[]
+  /** Number of times {@link TelemetrySink.flush} was called. */
+  flushCalls: number
+}
+
+/**
+ * createMockSink — a {@link TelemetrySink} that records everything for
+ * assertions instead of doing I/O. Used to test the manager and the Faro
+ * engine without any network. Mirrors `createMockAIProvider` in `packages/ai`.
+ */
+export function createMockSink(name: string = 'mock'): MockSinkExtended {
+  const sink: MockSinkExtended = {
+    name,
+    logs: [],
+    spans: [],
+    flushCalls: 0,
+
+    log(record: LogRecord): void {
+      sink.logs.push(record)
+    },
+
+    span(record: SpanRecord): void {
+      sink.spans.push(record)
+    },
+
+    async flush(): Promise<void> {
+      sink.flushCalls++
+    },
+  }
+
+  return sink
+}

--- a/packages/logger/src/noop.ts
+++ b/packages/logger/src/noop.ts
@@ -1,0 +1,52 @@
+import type { Span, Telemetry } from './types.js'
+
+/** Shared no-op span — emits nothing, allocates nothing per call. */
+const NOOP_SPAN: Span = {
+  end(): void {
+    /* no-op */
+  },
+}
+
+/**
+ * Returned by {@link createTelemetry} when `enabled: false`. Every method is
+ * an empty stub, so a bundler can dead-code-eliminate call sites and the
+ * engines (console/Faro) are never imported at runtime. Zero emissions.
+ */
+export function createNoopTelemetry(): Telemetry {
+  const noop: Telemetry = {
+    debug(): void {
+      /* no-op */
+    },
+    info(): void {
+      /* no-op */
+    },
+    warn(): void {
+      /* no-op */
+    },
+    error(): void {
+      /* no-op */
+    },
+    fatal(): void {
+      /* no-op */
+    },
+    child(): Telemetry {
+      return noop
+    },
+    startSpan(): Span {
+      return NOOP_SPAN
+    },
+    async flush(): Promise<void> {
+      /* no-op */
+    },
+    get sinks(): string[] {
+      return []
+    },
+    addSink(): void {
+      /* no-op */
+    },
+    removeSink(): void {
+      /* no-op */
+    },
+  }
+  return noop
+}

--- a/packages/logger/src/presets.ts
+++ b/packages/logger/src/presets.ts
@@ -1,0 +1,51 @@
+import type { LogLevel, TelemetryEnv } from './types.js'
+
+/**
+ * Behavior derived from {@link TelemetryConfig.env}. The manager reads these
+ * fields to decide level filtering, batching, sampling, and flush triggers.
+ */
+export interface TelemetryPreset {
+  /** Records strictly below this level are dropped. */
+  minLevel: LogLevel
+  /** Buffer records and deliver in batches instead of synchronously. */
+  batch: boolean
+  /** Batch size before an automatic flush (only when `batch`). */
+  batchSize: number
+  /** Default sample rate when config omits `sampleRate`. */
+  sampleRate: number
+  /** Pretty, single-line console output (vs. structured JSON). */
+  pretty: boolean
+  /**
+   * Flush buffered records on `pagehide` + `visibilitychange` (hidden),
+   * using `navigator.sendBeacon` when available.
+   */
+  beaconFlush: boolean
+}
+
+/**
+ * - development: sync, pretty, level=debug, no batching, sample everything.
+ * - production: batched + sampled, level>=warn, beacon flush on page exit.
+ */
+export const PRESETS: Record<TelemetryEnv, TelemetryPreset> = {
+  development: {
+    minLevel: 'debug',
+    batch: false,
+    batchSize: 1,
+    sampleRate: 1,
+    pretty: true,
+    beaconFlush: false,
+  },
+  production: {
+    minLevel: 'warn',
+    batch: true,
+    batchSize: 20,
+    sampleRate: 0.25,
+    pretty: false,
+    beaconFlush: true,
+  },
+}
+
+/** Resolve the preset for an env (defensive copy so callers can't mutate it). */
+export function resolvePreset(env: TelemetryEnv): TelemetryPreset {
+  return { ...PRESETS[env] }
+}

--- a/packages/logger/src/redact.ts
+++ b/packages/logger/src/redact.ts
@@ -1,0 +1,33 @@
+import type { LogContext } from './types.js'
+
+/**
+ * Deep-strip any object key whose name (case-insensitive) is in `keys`.
+ * Arrays are walked; cycles are guarded; non-matching values pass through
+ * unchanged. Returns a new structure — the input is never mutated.
+ */
+export function redact(value: LogContext, keys: string[]): LogContext {
+  if (keys.length === 0) return value
+  const lookup = new Set(keys.map((k) => k.toLowerCase()))
+  return walk(value, lookup, new WeakSet()) as LogContext
+}
+
+function walk(value: unknown, keys: Set<string>, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') return value
+
+  if (seen.has(value as object)) return '[Circular]'
+  seen.add(value as object)
+
+  if (Array.isArray(value)) {
+    return value.map((item) => walk(item, keys, seen))
+  }
+
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (keys.has(k.toLowerCase())) {
+      out[k] = '[REDACTED]'
+      continue
+    }
+    out[k] = walk(v, keys, seen)
+  }
+  return out
+}

--- a/packages/logger/src/telemetry-manager.ts
+++ b/packages/logger/src/telemetry-manager.ts
@@ -1,0 +1,229 @@
+import { createConsoleSink } from './console-sink.js'
+import { createNoopTelemetry } from './noop.js'
+import { resolvePreset, type TelemetryPreset } from './presets.js'
+import { redact } from './redact.js'
+import {
+  LEVEL_ORDER,
+  type LogContext,
+  type LogLevel,
+  type LogRecord,
+  type Span,
+  type SpanRecord,
+  type Telemetry,
+  type TelemetryConfig,
+  type TelemetrySink,
+} from './types.js'
+
+/**
+ * createTelemetry — creates a telemetry manager that fans records out to
+ * registered sinks. Manager/provider pattern, mirroring `createAI`.
+ *
+ * - `enabled: false` -> tree-shakeable noop (zero emissions, no engines).
+ * - no `endpoint` -> console-only transport.
+ * - `endpoint` set -> async Faro engine is registered when the optional
+ *   peers exist; console stays as a safe fallback until then.
+ *
+ * The returned object IS a logger (root context = `{}`); `child()` derives
+ * loggers with bound context (sessionId / interviewId / turnId / ...).
+ */
+export function createTelemetry(config: TelemetryConfig): Telemetry {
+  if (config.enabled === false) {
+    return createNoopTelemetry()
+  }
+
+  const preset = resolvePreset(config.env)
+  const sampleRate = config.sampleRate ?? preset.sampleRate
+  const redactKeys = config.redactKeys ?? []
+
+  const sinks = new Map<string, TelemetrySink>()
+  /** Insertion-ordered sink names. */
+  const sinkOrder: string[] = []
+  /** Batch buffer (production preset only). */
+  const buffer: Array<{ kind: 'log'; record: LogRecord } | { kind: 'span'; record: SpanRecord }> = []
+
+  function addSinkInternal(sink: TelemetrySink): void {
+    if (sinks.has(sink.name)) {
+      sinks.set(sink.name, sink)
+    } else {
+      sinks.set(sink.name, sink)
+      sinkOrder.push(sink.name)
+    }
+  }
+
+  // Console transport is always present as the zero-dependency baseline.
+  addSinkInternal(createConsoleSink({ pretty: preset.pretty }))
+
+  // When an endpoint is configured, attempt to attach the Faro engine. The
+  // import is lazy + dynamic so the optional peers never become required and
+  // Faro names stay out of the public API.
+  if (config.endpoint) {
+    const endpoint = config.endpoint
+    void import('./faro-engine.js')
+      .then(({ createFaroSink }) => createFaroSink({ app: config.app, endpoint }))
+      .then((faro) => {
+        if (faro) addSinkInternal(faro)
+      })
+      .catch(() => {
+        /* peers absent or init failed — console remains */
+      })
+  }
+
+  function shouldSample(): boolean {
+    if (sampleRate >= 1) return true
+    if (sampleRate <= 0) return false
+    return Math.random() < sampleRate
+  }
+
+  function dispatch(
+    entry: { kind: 'log'; record: LogRecord } | { kind: 'span'; record: SpanRecord },
+  ): void {
+    if (preset.batch) {
+      buffer.push(entry)
+      if (buffer.length >= preset.batchSize) {
+        void flushBuffer()
+      }
+      return
+    }
+    deliver(entry)
+  }
+
+  function deliver(
+    entry: { kind: 'log'; record: LogRecord } | { kind: 'span'; record: SpanRecord },
+  ): void {
+    for (const name of sinkOrder) {
+      const sink = sinks.get(name)
+      if (!sink) continue
+      if (entry.kind === 'log') sink.log(entry.record)
+      else sink.span(entry.record)
+    }
+  }
+
+  async function flushBuffer(): Promise<void> {
+    if (buffer.length > 0) {
+      const pending = buffer.splice(0, buffer.length)
+      for (const entry of pending) deliver(entry)
+    }
+    await Promise.all(
+      sinkOrder.map((name) => sinks.get(name)?.flush() ?? Promise.resolve()),
+    )
+  }
+
+  // ---- page-exit beacon flush (production preset) -------------------------
+  // Browser only — `navigator.sendBeacon` is used by the underlying engine
+  // transport; here we just trigger a flush on the page-exit signals.
+  const root = globalThis as {
+    addEventListener?: (type: string, listener: () => void) => void
+    document?: { visibilityState?: string }
+    navigator?: { sendBeacon?: unknown }
+  }
+  if (preset.beaconFlush && typeof root.addEventListener === 'function') {
+    const onExit = (): void => {
+      void flushBuffer()
+    }
+    root.addEventListener('pagehide', onExit)
+    root.addEventListener('visibilitychange', () => {
+      if (root.document?.visibilityState === 'hidden') onExit()
+    })
+  }
+
+  function makeLogger(boundContext: LogContext): Telemetry {
+    function emit(level: LogLevel, message: string, context?: LogContext): void {
+      if (LEVEL_ORDER[level] < LEVEL_ORDER[preset.minLevel]) return
+      if (!shouldSample()) return
+      const merged = redact({ ...boundContext, ...context }, redactKeys)
+      const record: LogRecord = {
+        level,
+        message,
+        timestamp: Date.now(),
+        app: config.app,
+        env: config.env,
+        context: merged,
+      }
+      dispatch({ kind: 'log', record })
+    }
+
+    const logger: Telemetry = {
+      debug(message, context?) {
+        emit('debug', message, context)
+      },
+      info(message, context?) {
+        emit('info', message, context)
+      },
+      warn(message, context?) {
+        emit('warn', message, context)
+      },
+      error(message, context?) {
+        emit('error', message, context)
+      },
+      fatal(message, context?) {
+        emit('fatal', message, context)
+      },
+
+      child(context: LogContext): Telemetry {
+        return makeLogger({ ...boundContext, ...context })
+      },
+
+      startSpan(name: string, attributes?: LogContext): Span {
+        const startTime = Date.now()
+        let ended = false
+        return {
+          end(opts?: { error?: unknown; attributes?: LogContext }): void {
+            if (ended) return
+            ended = true
+            const endTime = Date.now()
+            const merged = redact(
+              { ...boundContext, ...attributes, ...opts?.attributes },
+              redactKeys,
+            )
+            const err = opts?.error
+            const record: SpanRecord = {
+              name,
+              startTime,
+              endTime,
+              durationMs: endTime - startTime,
+              app: config.app,
+              env: config.env,
+              context: merged,
+              status: err ? 'error' : 'ok',
+              ...(err
+                ? {
+                    error: {
+                      name: err instanceof Error ? err.name : 'Error',
+                      message: err instanceof Error ? err.message : String(err),
+                    },
+                  }
+                : {}),
+            }
+            dispatch({ kind: 'span', record })
+          },
+        }
+      },
+
+      flush(): Promise<void> {
+        return flushBuffer()
+      },
+
+      get sinks(): string[] {
+        return [...sinkOrder]
+      },
+
+      addSink(sink: TelemetrySink): void {
+        addSinkInternal(sink)
+      },
+
+      removeSink(name: string): void {
+        if (sinks.has(name)) {
+          sinks.delete(name)
+          const idx = sinkOrder.indexOf(name)
+          if (idx !== -1) sinkOrder.splice(idx, 1)
+        }
+      },
+    }
+
+    return logger
+  }
+
+  return makeLogger({})
+}
+
+export type { TelemetryPreset }

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -1,0 +1,121 @@
+/** Severity levels, ordered low -> high. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+
+/** Numeric ordering used for level threshold comparisons. */
+export const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  fatal: 50,
+}
+
+/** Bound key/value pairs attached to every record emitted by a logger. */
+export type LogContext = Record<string, unknown>
+
+/** A single structured log record handed to a sink. */
+export interface LogRecord {
+  level: LogLevel
+  message: string
+  timestamp: number
+  app: string
+  env: TelemetryEnv
+  /** Merged bound context (child loggers) + per-call context, post-redaction. */
+  context: LogContext
+}
+
+/** A span record handed to a sink when a span ends. */
+export interface SpanRecord {
+  name: string
+  startTime: number
+  endTime: number
+  durationMs: number
+  app: string
+  env: TelemetryEnv
+  /** Merged bound context + span attributes, post-redaction. */
+  context: LogContext
+  /** 'ok' unless ended with an error. */
+  status: 'ok' | 'error'
+  error?: { name: string; message: string }
+}
+
+/**
+ * Vendor-neutral telemetry sink. Engines (console, Faro, custom) implement
+ * this — no vendor type ever leaks across this boundary.
+ */
+export interface TelemetrySink {
+  /** Engine name, for diagnostics. */
+  name: string
+  /** Receive a log record. May buffer; honor flush(). */
+  log(record: LogRecord): void
+  /** Receive a finished span. May buffer; honor flush(). */
+  span(record: SpanRecord): void
+  /** Force-deliver any buffered records. Resolves once delivery is attempted. */
+  flush(): Promise<void>
+}
+
+/** Telemetry environment — selects a behavior preset. */
+export type TelemetryEnv = 'development' | 'production'
+
+/** Config for {@link createTelemetry} — mirrors `createAI`'s config shape. */
+export interface TelemetryConfig {
+  /** Logical app/service name attached to every record. */
+  app: string
+  /** Environment preset selector. */
+  env: TelemetryEnv
+  /**
+   * Remote collector endpoint. When omitted, telemetry stays console-only
+   * (no network engine is constructed).
+   */
+  endpoint?: string
+  /**
+   * Master kill switch. When `false`, a tree-shakeable noop logger is
+   * returned and zero records are ever produced. Defaults to `true`.
+   */
+  enabled?: boolean
+  /**
+   * Fraction of records kept, 0..1. Defaults to the preset value
+   * (1 in development, 0.25 in production). Records below the sample
+   * are dropped before reaching any sink.
+   */
+  sampleRate?: number
+  /**
+   * Context keys to strip (deep) before a record is emitted. Use for
+   * PII / secrets, e.g. `['password', 'token', 'authorization']`.
+   */
+  redactKeys?: string[]
+}
+
+/** A logger bound to a context. Child loggers inherit + extend that context. */
+export interface Logger {
+  debug(message: string, context?: LogContext): void
+  info(message: string, context?: LogContext): void
+  warn(message: string, context?: LogContext): void
+  error(message: string, context?: LogContext): void
+  fatal(message: string, context?: LogContext): void
+  /**
+   * Derive a logger with additional bound context (e.g.
+   * `{ sessionId, interviewId, turnId }`). Merges over the parent's context.
+   */
+  child(context: LogContext): Logger
+  /** Begin a span. Call {@link Span.end} to record its duration. */
+  startSpan(name: string, attributes?: LogContext): Span
+  /** Force-deliver buffered records on every sink. */
+  flush(): Promise<void>
+}
+
+/** An in-flight span returned by {@link Logger.startSpan}. */
+export interface Span {
+  /** End the span and emit a {@link SpanRecord}. Optionally attach error/attrs. */
+  end(opts?: { error?: unknown; attributes?: LogContext }): void
+}
+
+/** Return type of {@link createTelemetry}. */
+export interface Telemetry extends Logger {
+  /** Registered sink names, in insertion order. */
+  readonly sinks: string[]
+  /** Register an additional sink (e.g. a custom collector). */
+  addSink(sink: TelemetrySink): void
+  /** Remove a sink by name. */
+  removeSink(name: string): void
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/logger/tsup.config.ts
+++ b/packages/logger/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+})

--- a/packages/logger/vitest.config.ts
+++ b/packages/logger/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
         version: link:../packages/tailwind-config
       next:
         specifier: 15.5.18
-        version: 15.5.18(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -2171,6 +2171,18 @@ importers:
       '@refraction-ui/i18n':
         specifier: workspace:*
         version: link:../i18n
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+
+  packages/logger:
+    dependencies:
+      '@grafana/faro-web-sdk':
+        specifier: '>=1'
+        version: 2.6.3
+      '@grafana/faro-web-tracing':
+        specifier: '>=1'
+        version: 2.6.3
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared
@@ -4846,6 +4858,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@grafana/faro-core@2.6.3':
+    resolution: {integrity: sha512-PBzH0cYtHgZOeDMCKddIFTL+u9KcT4zCZq2Lc4XnlE0iixDh61etfExror3TbPHeRyTt/aDwB0loneA1S/q1Cg==}
+
+  '@grafana/faro-web-sdk@2.6.3':
+    resolution: {integrity: sha512-cMEjcFOMT2incLamq2q0jgMXivSWp1mQknT24JYbL1eGnugIudNHYa35waFuW8+B+DJfWx9Hsv1N0o9gsO9QmA==}
+
+  '@grafana/faro-web-tracing@2.6.3':
+    resolution: {integrity: sha512-v/hI2ZVi3wegDuWWu589wuEX2MnXgQILTSO1rprvSp+aZyTrz4jwIjuEbxJCJq8s3bvpFGloJ5jBgjy7yPFAMg==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -5111,6 +5132,90 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.217.0':
+    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0':
+    resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fetch@0.217.0':
+    resolution: {integrity: sha512-VTRPrIP4+h2Chfvz2fdJDL9KfoQRBMN83dAZ++v4VCe4Q3fumO5xjbtZFwNZiRFEjsCyX9V3Rjv6uXTY39CqNA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-xml-http-request@0.217.0':
+    resolution: {integrity: sha512-TzG9oyY004VhkDKQ6FltdXS3QpPGD/8C65JrHAdKoIBcWDfSYK79oPH7quU+yIwoDnCF3+Zh5UQTYf9kcun0IA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.217.0':
+    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.217.0':
+    resolution: {integrity: sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.217.0':
+    resolution: {integrity: sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.217.0':
+    resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-web@2.7.1':
+    resolution: {integrity: sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -5122,6 +5227,36 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -5563,6 +5698,11 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -5784,6 +5924,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -6398,6 +6541,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -6669,6 +6816,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -6894,6 +7044,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
@@ -7247,6 +7400,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -7359,6 +7516,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7762,6 +7923,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
+    hasBin: true
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -7995,6 +8160,9 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8535,6 +8703,33 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@grafana/faro-core@2.6.3':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@grafana/faro-web-sdk@2.6.3':
+    dependencies:
+      '@grafana/faro-core': 2.6.3
+      ua-parser-js: 1.0.41
+      web-vitals: 5.2.0
+
+  '@grafana/faro-web-tracing@2.6.3':
+    dependencies:
+      '@grafana/faro-web-sdk': 2.6.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fetch': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-xml-http-request': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -8751,6 +8946,107 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/instrumentation-fetch@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-xml-http-request@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-web@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -8759,6 +9055,29 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -9197,6 +9516,10 @@ snapshots:
       loupe: 3.2.0
       tinyrainbow: 2.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -9486,6 +9809,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   client-only@0.0.1: {}
 
@@ -10170,6 +10495,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   interpret@1.4.0: {}
@@ -10397,6 +10729,8 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -10824,6 +11158,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  module-details-from-path@1.0.4: {}
+
   monaco-editor@0.55.1:
     dependencies:
       dompurify: 3.4.2
@@ -10847,7 +11183,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@15.5.18(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -10865,6 +11201,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.18
       '@next/swc-win32-arm64-msvc': 15.5.18
       '@next/swc-win32-x64-msvc': 15.5.18
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -11136,6 +11473,21 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.0.0
+      long: 5.3.2
+
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
@@ -11271,6 +11623,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -11769,6 +12128,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  ua-parser-js@1.0.41: {}
+
   ufo@1.6.3: {}
 
   ultrahtml@1.6.0: {}
@@ -11971,6 +12332,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
Wave 0 of epic #206. Faro-backed telemetry core, Faro fully hidden behind `createTelemetry({ endpoint })`; vendor-neutral `TelemetrySink`, dev/prod presets, tree-shakeable noop kill switch, redaction, child loggers + spans. Faro = optional peer dep (no Grafana types in public `.d.ts`).

✅ build / typecheck / lint exit 0 · **52/52 tests passing** on latest `main`.

Closes #207.