### PR TITLE
feat(analytics): @refraction-ui/analytics headless core (#214)

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,211 @@
+# @refraction-ui/analytics
+
+A headless, neutral **Segment-spec collector/router** for product analytics.
+The app instruments **once** — it never names a vendor. The library collects
+the canonical event envelope and **fans it out** to N pluggable sinks
+(GA4, Azure App Insights, PostHog, your own backend, …). **There is no
+privileged engine** — every vendor is just a sink.
+
+Sibling of `@refraction-ui/ai`: same factory/manager pattern (`createAnalytics`
+mirrors `createAI`). No runtime dependencies beyond `@refraction-ui/shared`.
+
+---
+
+## Consumer API
+
+```ts
+import { createAnalytics } from '@refraction-ui/analytics'
+
+const analytics = createAnalytics({
+  app: 'my-app',
+  env: process.env.NODE_ENV,          // drives dev/prod presets
+  endpoint: 'https://collect.example.com', // optional: auto-adds the http sink
+  writeKey: 'WRITE_KEY',
+  enabled: true,                      // false → tree-shakeable noop
+  sampleRate: 1,                      // 0..1, applied per call
+  redactKeys: ['internalScore'],      // extra PII keys to strip
+  consent: { granted: ['analytics'] },
+})
+
+// Segment Spec — the entire instrumentation surface
+analytics.track('Signup Clicked', { plan: 'pro' })
+analytics.identify('user_42', { plan: 'pro' })   // userId is opaque to the lib
+analytics.page('Pricing', { path: '/pricing' })
+analytics.screen('Dashboard')
+analytics.group('org_7', { name: 'Acme' })
+analytics.alias('user_42', 'anon-or-prev-id')
+
+// Sessions (analytics session — NOT replay)
+analytics.session.id()        // current UUIDv4 session id
+analytics.session.start()     // force a new session
+analytics.session.end()
+analytics.session.set({ plan: 'pro' })
+
+// Consent gate (per-sink categories)
+analytics.consent.grant('marketing')
+analytics.consent.revoke('marketing')
+analytics.consent.isGranted('analytics')
+
+// Child context — merged into every event, parent untouched
+const checkout = analytics.with({ feature: 'checkout' })
+checkout.track('Card Added')
+
+// Lifecycle
+await analytics.flush()       // drain the batch + flush all sinks
+analytics.reset()             // privacy-safe logout: new anonymousId + end session
+```
+
+### Config
+
+| Key               | Default                         | Purpose |
+|-------------------|---------------------------------|---------|
+| `app`             | —                               | Stamped into `context.app` |
+| `env`             | —                               | `production` → prod preset, else dev |
+| `endpoint`        | —                               | When set, auto-registers the built-in `http` sink |
+| `writeKey`        | `''`                            | Auth for the auto `http` sink |
+| `enabled`         | `true`                          | `false` → tree-shakeable noop |
+| `sampleRate`      | `1`                             | Per-call sampling (0..1) |
+| `redactKeys`      | `[]`                            | Extra keys to redact (on top of the PII deny-list) |
+| `sinks`           | `[]`                            | Explicit sinks (override same-named built-ins) |
+| `session`         | 30-min timeout, localStorage    | `{ timeoutMs, resetOnCampaign, storage, storageKey }` |
+| `identity`        | localStorage                    | `{ storage, storageKey }` |
+| `consent`         | nothing granted                 | `{ granted, strict }` |
+| `preset`          | from `env`                      | `'dev'` \| `'prod'` |
+| `batchSize`       | `20`                            | Auto-flush threshold (prod) |
+| `flushIntervalMs` | `10000`                         | Auto-flush interval (prod) |
+
+### Presets
+
+- **dev** (`env !== 'production'`): synchronous, unbatched delivery + a
+  built-in `console` sink so engineers see exactly what would ship.
+- **prod**: batching + sampling, plus a `sendBeacon` flush bound to
+  `pagehide` / `visibilitychange` so in-flight events are not lost on unload.
+- **`enabled: false`**: returns a noop whose every method is empty — the live
+  collector and all sink code tree-shake out of the bundle.
+
+### Sessions / Identity / Consent
+
+- **`sessionId`** — client UUIDv4, minted at session start. A session ends
+  after **30 min of inactivity** (GA4 parity, configurable) **or** when a new
+  campaign (UTM / `gclid` / `fbclid` / `msclkid`) is detected. Persisted
+  cross-tab via localStorage → cookie → memory.
+- **`anonymousId`** — persistent, non-PII, **resettable** UUIDv4. `reset()`
+  mints a fresh one so a new visitor is never stitched to the old one.
+- **`userId`** — opaque, app-supplied; never persisted by the library (the app
+  owns the user record).
+- **`alias`** — emits a `previousId → userId` stitch event.
+- **PII** — a built-in deny-list (email / phone / name / password / card / …)
+  plus `redactKeys`. Matching is case- and separator-insensitive and recurses
+  into nested objects/arrays. Values become `"[REDACTED]"`.
+- **Consent** — each sink declares the categories it requires; the router will
+  not deliver to a sink unless **all** its categories are granted.
+
+---
+
+## Backend wire contract (the `http` sink)
+
+The built-in `http` sink implements the **Segment HTTP Tracking API** batch
+format — *adopt, do not invent* — so **RudderStack / Jitsu / Segment** are
+drop-in conforming backends, and any custom backend can be built to conform.
+
+### Request
+
+```
+POST {endpoint}/v{schemaVersion}/batch          (schemaVersion = 1 → /v1/batch)
+Content-Type: application/json                   (gzip optional)
+Authorization: Basic base64("{writeKey}:")       ← note the trailing colon
+```
+
+```jsonc
+{
+  "batch": [ /* AnalyticsEvent[] — canonical envelope (below) */ ],
+  "sentAt": "2026-05-16T12:00:00.000Z",          // honest client send time
+  "batchId": "<uuid v4>"
+}
+```
+
+### Canonical event envelope (`AnalyticsEvent`)
+
+```jsonc
+{
+  "type": "track",                  // track|identify|page|screen|group|alias
+  "event": "Signup Clicked",        // track/page/screen name (optional)
+  "messageId": "<uuid v4>",         // idempotency key — backends MUST dedupe
+  "anonymousId": "<uuid v4>",       // persistent, non-PII
+  "userId": "user_42",              // opaque, optional
+  "groupId": "org_7",               // group calls
+  "previousId": "anon-id",          // alias calls
+  "sessionId": "<uuid v4>",         // analytics session
+  "properties": { },                // track/page/screen/group payload
+  "traits": { },                    // identify/group traits
+  "context": {
+    "app": "my-app",
+    "env": "production",
+    "page": { "path": "/", "url": "...", "referrer": "...", "title": "..." },
+    "library": { "name": "@refraction-ui/analytics", "version": "0.1.0" }
+  },
+  "timestamp": "2026-05-16T12:00:00.000Z",  // ISO-8601 client time
+  "schemaVersion": 1
+}
+```
+
+### Response semantics (accept-and-queue)
+
+| Status      | Meaning              | Client behaviour |
+|-------------|----------------------|------------------|
+| `2xx`       | Accepted **and queued** (not yet processed) | done |
+| `400`       | Malformed            | **drop, never retry** |
+| `401`       | Bad write key        | **drop, never retry** |
+| `413`       | Payload too large    | **drop** (client also pre-splits) |
+| `429`/`5xx` | Transient / overload | **exponential backoff retry** |
+| network err | —                    | treated as transient → retry |
+
+- **Idempotency** — backends **MUST** dedupe on `messageId`.
+- **Clock skew** — the backend corrects time as
+  `corrected = timestamp + (receivedAt − sentAt)`; the client always stamps an
+  honest `sentAt`.
+- **Size limits** — soft caps of **≈ 500 KB / batch** and **≈ 32 KB / event**
+  (Segment parity). The client pre-splits oversized batches and drops events
+  that exceed the per-event cap (they can never be delivered).
+- **Versioning** — the path carries `/v{schemaVersion}/`; every event also
+  carries `schemaVersion`.
+
+### sendBeacon caveat (unload path)
+
+On `pagehide` / `visibilitychange` the client uses `navigator.sendBeacon`,
+which **cannot set an `Authorization` header**. On that path the sink falls
+back to:
+
+```
+POST {endpoint}/v1/batch?writeKey={writeKey}
+Content-Type: text/plain
+```
+
+A conforming backend **MUST** also accept the write key via the `writeKey`
+query parameter with a `text/plain` body.
+
+---
+
+## Sinks
+
+A sink implements the `AnalyticsSink` SPI:
+
+```ts
+interface AnalyticsSink {
+  name: string
+  consentCategories?: string[]                 // required categories
+  init?(ctx): void | Promise<void>
+  deliver(batch, ctx): void | Promise<void>    // canonical envelopes
+  flush?(): void | Promise<void>
+  shutdown?(): void | Promise<void>
+}
+```
+
+Built-ins: `createHttpSink` (wire contract above), `createConsoleSink` (dev),
+`createMockSink` (testing). Vendor adapters (GA4, Azure, PostHog) ship as
+separate packages and are *just sinks* — register them via `config.sinks` or
+`analytics.addSink(...)`.
+
+## License
+
+MIT

--- a/packages/analytics/__tests__/analytics-manager.test.ts
+++ b/packages/analytics/__tests__/analytics-manager.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createAnalytics } from '../src/analytics-manager.js'
+import { createMockSink } from '../src/mock-sink.js'
+import { createMemoryStorage } from '../src/storage.js'
+import { SCHEMA_VERSION } from '../src/types.js'
+import { isUuidV4 } from '../src/uuid.js'
+import type { AnalyticsConfig } from '../src/types.js'
+
+function devConfig(
+  sink = createMockSink(),
+  extra: Partial<AnalyticsConfig> = {},
+): { a: ReturnType<typeof createAnalytics>; sink: typeof sink } {
+  const a = createAnalytics({
+    app: 'test-app',
+    env: 'development',
+    sinks: [sink],
+    session: { storage: createMemoryStorage() },
+    identity: { storage: createMemoryStorage() },
+    consent: { granted: ['analytics'] },
+    ...extra,
+  })
+  return { a, sink }
+}
+
+describe('createAnalytics — envelope shape', () => {
+  it('emits a canonical Segment track envelope', () => {
+    const { a, sink } = devConfig()
+    a.track('Signup Clicked', { plan: 'pro' })
+    expect(sink.events).toHaveLength(1)
+    const ev = sink.events[0]
+    expect(ev.type).toBe('track')
+    expect(ev.event).toBe('Signup Clicked')
+    expect(ev.properties).toMatchObject({ plan: 'pro' })
+    expect(isUuidV4(ev.messageId)).toBe(true)
+    expect(isUuidV4(ev.anonymousId)).toBe(true)
+    expect(isUuidV4(ev.sessionId)).toBe(true)
+    expect(ev.schemaVersion).toBe(SCHEMA_VERSION)
+    expect(typeof ev.timestamp).toBe('string')
+    expect(new Date(ev.timestamp).toString()).not.toBe('Invalid Date')
+    expect(ev.context.app).toBe('test-app')
+    expect(ev.context.env).toBe('development')
+    expect(ev.context.library.name).toBe('@refraction-ui/analytics')
+  })
+
+  it('every call type produces the right envelope', () => {
+    const { a, sink } = devConfig()
+    a.identify('user_1', { plan: 'pro', email: 'a@b.com' })
+    a.page('Home', { path: '/' })
+    a.screen('Dashboard')
+    a.group('org_1', { name: 'Acme' })
+    a.alias('user_2', 'user_1')
+
+    const byType = Object.fromEntries(sink.events.map((e) => [e.type, e]))
+    expect(byType.identify.traits).toMatchObject({ plan: 'pro' })
+    // PII redaction applied to identify traits
+    expect(byType.identify.traits!.email).toBe('[REDACTED]')
+    expect(byType.identify.userId).toBe('user_1')
+    expect(byType.page.event).toBe('Home')
+    expect(byType.screen.event).toBe('Dashboard')
+    expect(byType.group.groupId).toBe('org_1')
+    expect(byType.alias.previousId).toBe('user_1')
+    expect(byType.alias.userId).toBe('user_2')
+  })
+
+  it('redacts PII in track properties via the deny-list', () => {
+    const { a, sink } = devConfig()
+    a.track('Form Submitted', { email: 'a@b.com', value: 42 })
+    expect(sink.events[0].properties).toEqual({
+      email: '[REDACTED]',
+      value: 42,
+    })
+  })
+
+  it('redacts caller-supplied redactKeys', () => {
+    const { a, sink } = devConfig(createMockSink(), {
+      redactKeys: ['internalScore'],
+    })
+    a.track('X', { internalScore: 99, ok: 1 })
+    expect(sink.events[0].properties).toEqual({
+      internalScore: '[REDACTED]',
+      ok: 1,
+    })
+  })
+})
+
+describe('createAnalytics — identity & session', () => {
+  it('binds userId after identify and clears it on reset', () => {
+    const { a } = devConfig()
+    expect(a.userId()).toBeUndefined()
+    a.identify('user_9')
+    expect(a.userId()).toBe('user_9')
+    const anonBefore = a.anonymousId()
+    a.reset()
+    expect(a.userId()).toBeUndefined()
+    expect(a.anonymousId()).not.toBe(anonBefore)
+  })
+
+  it('exposes a working session API', () => {
+    const { a } = devConfig()
+    const id1 = a.session.id()
+    expect(isUuidV4(id1)).toBe(true)
+    const id2 = a.session.start()
+    expect(id2).not.toBe(id1)
+    a.session.end()
+  })
+
+  it('shares one sessionId across events in a session', () => {
+    const { a, sink } = devConfig()
+    a.track('A')
+    a.track('B')
+    expect(sink.events[0].sessionId).toBe(sink.events[1].sessionId)
+  })
+})
+
+describe('createAnalytics — with(context) child', () => {
+  it('merges child context into every event without affecting the parent', () => {
+    const { a, sink } = devConfig()
+    const child = a.with({ feature: 'checkout' } as never)
+    child.track('Child Event')
+    a.track('Parent Event')
+    const childEv = sink.events.find((e) => e.event === 'Child Event')!
+    const parentEv = sink.events.find((e) => e.event === 'Parent Event')!
+    expect((childEv.context as Record<string, unknown>).feature).toBe(
+      'checkout',
+    )
+    expect((parentEv.context as Record<string, unknown>).feature).toBeUndefined()
+  })
+
+  it('child shares identity/session/sinks with the parent', () => {
+    const { a, sink } = devConfig()
+    const child = a.with({})
+    expect(child.anonymousId()).toBe(a.anonymousId())
+    child.addSink(createMockSink({ name: 'extra' }))
+    expect(a.sinks).toContain('extra')
+    expect(sink).toBeDefined()
+  })
+})
+
+describe('createAnalytics — sink registry', () => {
+  it('lists, adds, and removes sinks', () => {
+    const { a } = devConfig()
+    expect(a.sinks).toContain('mock')
+    const extra = createMockSink({ name: 'extra' })
+    a.addSink(extra)
+    expect(a.sinks).toContain('extra')
+    a.removeSink('extra')
+    expect(a.sinks).not.toContain('extra')
+  })
+
+  it('calls sink.init exactly once before the first deliver', () => {
+    const { a, sink } = devConfig()
+    a.track('A')
+    a.track('B')
+    expect(sink.initCalls).toHaveLength(1)
+    expect(sink.initCalls[0]).toMatchObject({
+      app: 'test-app',
+      env: 'development',
+    })
+  })
+
+  it('auto-registers a built-in http sink when endpoint is set', () => {
+    const a = createAnalytics({
+      app: 'x',
+      env: 'development',
+      endpoint: 'https://t.example.com',
+      writeKey: 'wk',
+      session: { storage: createMemoryStorage() },
+      identity: { storage: createMemoryStorage() },
+    })
+    expect(a.sinks).toContain('http')
+  })
+
+  it('dev preset auto-adds a console sink', () => {
+    const a = createAnalytics({
+      app: 'x',
+      env: 'development',
+      session: { storage: createMemoryStorage() },
+      identity: { storage: createMemoryStorage() },
+    })
+    expect(a.sinks).toContain('console')
+  })
+})
+
+describe('createAnalytics — consent gating', () => {
+  it('does not deliver to a sink whose categories are not granted', () => {
+    const open = createMockSink({ name: 'open' }) // no categories
+    const gated = createMockSink({
+      name: 'gated',
+      consentCategories: ['marketing'],
+    })
+    const a = createAnalytics({
+      app: 'x',
+      env: 'development',
+      sinks: [open, gated],
+      session: { storage: createMemoryStorage() },
+      identity: { storage: createMemoryStorage() },
+      consent: { granted: [] },
+    })
+    a.track('A')
+    expect(open.events).toHaveLength(1) // no categories → allowed
+    expect(gated.events).toHaveLength(0) // marketing not granted → blocked
+
+    a.consent.grant('marketing')
+    a.track('B')
+    expect(gated.events).toHaveLength(1) // now flowing
+  })
+
+  it('per-sink categories are independent', () => {
+    const analyticsSink = createMockSink({
+      name: 's-analytics',
+      consentCategories: ['analytics'],
+    })
+    const marketingSink = createMockSink({
+      name: 's-marketing',
+      consentCategories: ['marketing'],
+    })
+    const a = createAnalytics({
+      app: 'x',
+      env: 'development',
+      sinks: [analyticsSink, marketingSink],
+      session: { storage: createMemoryStorage() },
+      identity: { storage: createMemoryStorage() },
+      consent: { granted: ['analytics'] },
+    })
+    a.track('A')
+    expect(analyticsSink.events).toHaveLength(1)
+    expect(marketingSink.events).toHaveLength(0)
+  })
+})
+
+describe('createAnalytics — batching (prod preset)', () => {
+  function prodAnalytics(sink = createMockSink(), batchSize = 3) {
+    const a = createAnalytics({
+      app: 'x',
+      env: 'production',
+      preset: 'prod',
+      batchSize,
+      sinks: [sink],
+      session: { storage: createMemoryStorage() },
+      identity: { storage: createMemoryStorage() },
+      consent: { granted: ['analytics'] },
+    })
+    return { a, sink }
+  }
+
+  it('buffers events and flushes when batchSize is reached', async () => {
+    const { a, sink } = prodAnalytics(createMockSink(), 3)
+    a.track('1')
+    a.track('2')
+    expect(sink.events).toHaveLength(0) // still buffered
+    a.track('3') // hits batchSize → auto-flush
+    await Promise.resolve()
+    expect(sink.events).toHaveLength(3)
+    expect(sink.deliveries[0].batch).toHaveLength(3)
+  })
+
+  it('flush() drains the buffer on demand', async () => {
+    const { a, sink } = prodAnalytics(createMockSink(), 100)
+    a.track('1')
+    a.track('2')
+    expect(sink.events).toHaveLength(0)
+    await a.flush()
+    expect(sink.events).toHaveLength(2)
+  })
+
+  it('dev preset delivers synchronously (no batching)', () => {
+    const { a, sink } = devConfig()
+    a.track('immediate')
+    expect(sink.events).toHaveLength(1)
+  })
+})
+
+describe('createAnalytics — sampling', () => {
+  it('drops events below the sample rate', () => {
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.9)
+    const { a, sink } = devConfig(createMockSink(), { sampleRate: 0.5 })
+    a.track('dropped')
+    expect(sink.events).toHaveLength(0)
+    spy.mockReturnValue(0.1)
+    a.track('kept')
+    expect(sink.events).toHaveLength(1)
+    spy.mockRestore()
+  })
+
+  it('sampleRate >= 1 keeps everything', () => {
+    const { a, sink } = devConfig(createMockSink(), { sampleRate: 1 })
+    a.track('a')
+    a.track('b')
+    expect(sink.events).toHaveLength(2)
+  })
+})
+
+describe('createAnalytics — noop kill switch', () => {
+  it('returns a tree-shakeable noop when enabled:false', () => {
+    const sink = createMockSink()
+    const a = createAnalytics({
+      app: 'x',
+      env: 'production',
+      enabled: false,
+      sinks: [sink],
+    })
+    expect(a.enabled).toBe(false)
+    a.track('nope')
+    a.identify('user')
+    a.page()
+    expect(sink.events).toHaveLength(0)
+    expect(a.sinks).toEqual([])
+    expect(a.userId()).toBeUndefined()
+    // Noop API is fully callable and never throws.
+    expect(() => {
+      a.session.start()
+      a.consent.grant('analytics')
+      a.with({}).track('still nothing')
+      a.reset()
+    }).not.toThrow()
+  })
+
+  it('a live collector reports enabled:true', () => {
+    const { a } = devConfig()
+    expect(a.enabled).toBe(true)
+  })
+})

--- a/packages/analytics/__tests__/consent.test.ts
+++ b/packages/analytics/__tests__/consent.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { createConsent } from '../src/consent.js'
+
+describe('createConsent', () => {
+  it('starts with nothing granted by default', () => {
+    const c = createConsent()
+    expect(c.granted()).toEqual([])
+    expect(c.isGranted('analytics')).toBe(false)
+  })
+
+  it('seeds granted categories from config', () => {
+    const c = createConsent({ granted: ['analytics', 'marketing'] })
+    expect(c.isGranted('analytics')).toBe(true)
+    expect(c.isGranted('marketing')).toBe(true)
+  })
+
+  it('grant/revoke mutate the granted set', () => {
+    const c = createConsent()
+    c.grant('analytics', 'marketing')
+    expect(c.granted().sort()).toEqual(['analytics', 'marketing'])
+    c.revoke('marketing')
+    expect(c.isGranted('marketing')).toBe(false)
+    expect(c.isGranted('analytics')).toBe(true)
+  })
+
+  it('allows() requires ALL categories of a sink (per-sink gating)', () => {
+    const c = createConsent({ granted: ['analytics'] })
+    // sink with no declared categories → always allowed
+    expect(c.allows(undefined)).toBe(true)
+    expect(c.allows([])).toBe(true)
+    // sink requiring only 'analytics' → allowed
+    expect(c.allows(['analytics'])).toBe(true)
+    // sink also requiring 'marketing' → blocked until granted
+    expect(c.allows(['analytics', 'marketing'])).toBe(false)
+    c.grant('marketing')
+    expect(c.allows(['analytics', 'marketing'])).toBe(true)
+  })
+
+  it('exposes the strict flag from config', () => {
+    expect(createConsent().strict).toBe(false)
+    expect(createConsent({ strict: true }).strict).toBe(true)
+  })
+})

--- a/packages/analytics/__tests__/http-sink.test.ts
+++ b/packages/analytics/__tests__/http-sink.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createHttpSink } from '../src/http-sink.js'
+import { SCHEMA_VERSION } from '../src/types.js'
+import { isUuidV4 } from '../src/uuid.js'
+import type { AnalyticsEvent, SinkDeliverContext } from '../src/types.js'
+
+const CTX_ONLINE: SinkDeliverContext = { unload: false }
+const CTX_UNLOAD: SinkDeliverContext = { unload: true }
+
+function makeEvent(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'Test',
+    messageId: 'mid-' + Math.random().toString(36).slice(2),
+    anonymousId: 'anon-1',
+    sessionId: 'sess-1',
+    properties: { a: 1 },
+    context: {
+      app: 'app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: new Date().toISOString(),
+    schemaVersion: SCHEMA_VERSION,
+    ...overrides,
+  }
+}
+
+/** A mock backend conforming to the Segment HTTP Tracking API wire contract. */
+function mockBackend(
+  responder: (call: number) => { status: number } = () => ({ status: 200 }),
+) {
+  const calls: Array<{
+    url: string
+    method: string
+    headers: Record<string, string>
+    body: unknown
+  }> = []
+  let n = 0
+  const fetchImpl = vi.fn(
+    async (url: string, init?: RequestInit): Promise<Response> => {
+      const headers = (init?.headers ?? {}) as Record<string, string>
+      calls.push({
+        url,
+        method: init?.method ?? 'GET',
+        headers,
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      })
+      const { status } = responder(n++)
+      return { status, ok: status >= 200 && status < 300 } as Response
+    },
+  )
+  return { calls, fetchImpl: fetchImpl as unknown as typeof fetch }
+}
+
+describe('http sink — Segment wire contract: batch format', () => {
+  it('POSTs to {endpoint}/v{schemaVersion}/batch with the batch envelope', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://collector.example.com/',
+      writeKey: 'WK123',
+      fetchImpl: be.fetchImpl,
+    })
+    const events = [makeEvent({ event: 'A' }), makeEvent({ event: 'B' })]
+    await sink.deliver(events, CTX_ONLINE)
+
+    expect(be.calls).toHaveLength(1)
+    const call = be.calls[0]
+    expect(call.method).toBe('POST')
+    expect(call.url).toBe(
+      `https://collector.example.com/v${SCHEMA_VERSION}/batch`,
+    )
+    expect(call.headers['Content-Type']).toBe('application/json')
+
+    const body = call.body as {
+      batch: AnalyticsEvent[]
+      sentAt: string
+      batchId: string
+    }
+    expect(body.batch).toHaveLength(2)
+    expect(body.batch[0].event).toBe('A')
+    expect(typeof body.sentAt).toBe('string')
+    expect(new Date(body.sentAt).toString()).not.toBe('Invalid Date')
+    expect(isUuidV4(body.batchId)).toBe(true)
+  })
+
+  it('sends Authorization: Basic base64(writeKey:) — note trailing colon', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'WK123',
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    const auth = be.calls[0].headers['Authorization']
+    expect(auth).toBe(
+      'Basic ' + Buffer.from('WK123:', 'utf-8').toString('base64'),
+    )
+  })
+
+  it('every event carries a messageId idempotency key', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([makeEvent(), makeEvent()], CTX_ONLINE)
+    const body = be.calls[0].body as { batch: AnalyticsEvent[] }
+    for (const ev of body.batch) {
+      expect(typeof ev.messageId).toBe('string')
+      expect(ev.messageId.length).toBeGreaterThan(0)
+    }
+    // distinct per event
+    expect(body.batch[0].messageId).not.toBe(body.batch[1].messageId)
+  })
+
+  it('does nothing for an empty batch', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([], CTX_ONLINE)
+    expect(be.calls).toHaveLength(0)
+  })
+})
+
+describe('http sink — response codes', () => {
+  it('200 accept-and-queue → no retry', async () => {
+    const be = mockBackend(() => ({ status: 200 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(be.calls).toHaveLength(1)
+  })
+
+  it('400 malformed → DROP, never retry', async () => {
+    const be = mockBackend(() => ({ status: 400 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 5,
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(be.calls).toHaveLength(1) // exactly one attempt
+  })
+
+  it('401 bad key → DROP, never retry', async () => {
+    const be = mockBackend(() => ({ status: 401 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 5,
+      fetchImpl: be.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(be.calls).toHaveLength(1)
+  })
+
+  it('429 → exponential backoff retry then give up after maxRetries', async () => {
+    vi.useFakeTimers()
+    const be = mockBackend(() => ({ status: 429 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 3,
+      backoffBaseMs: 10,
+      fetchImpl: be.fetchImpl,
+    })
+    const p = sink.deliver([makeEvent()], CTX_ONLINE)
+    await vi.runAllTimersAsync()
+    await p
+    // initial + 3 retries = 4 attempts
+    expect(be.calls).toHaveLength(4)
+    vi.useRealTimers()
+  })
+
+  it('5xx → retried, then succeeds when the backend recovers', async () => {
+    vi.useFakeTimers()
+    const be = mockBackend((n) => ({ status: n < 2 ? 503 : 200 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 5,
+      backoffBaseMs: 10,
+      fetchImpl: be.fetchImpl,
+    })
+    const p = sink.deliver([makeEvent()], CTX_ONLINE)
+    await vi.runAllTimersAsync()
+    await p
+    expect(be.calls).toHaveLength(3) // 503, 503, 200
+    vi.useRealTimers()
+  })
+
+  it('uses increasing backoff delays between retries', async () => {
+    vi.useFakeTimers()
+    const be = mockBackend(() => ({ status: 500 }))
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 2,
+      backoffBaseMs: 100,
+      fetchImpl: be.fetchImpl,
+    })
+    const p = sink.deliver([makeEvent()], CTX_ONLINE)
+    // attempt 0 immediately
+    await Promise.resolve()
+    expect(be.calls).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(100) // backoff 100ms → attempt 1
+    expect(be.calls).toHaveLength(2)
+    await vi.advanceTimersByTimeAsync(200) // backoff 200ms → attempt 2
+    expect(be.calls).toHaveLength(3)
+    await p
+    vi.useRealTimers()
+  })
+
+  it('network error is treated as transient and retried', async () => {
+    vi.useFakeTimers()
+    let n = 0
+    const fetchImpl = vi.fn(async () => {
+      if (n++ < 1) throw new Error('network down')
+      return { status: 200, ok: true } as Response
+    }) as unknown as typeof fetch
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      maxRetries: 3,
+      backoffBaseMs: 10,
+      fetchImpl,
+    })
+    const p = sink.deliver([makeEvent()], CTX_ONLINE)
+    await vi.runAllTimersAsync()
+    await p
+    expect((fetchImpl as unknown as { mock: { calls: unknown[] } }).mock.calls)
+      .toHaveLength(2)
+    vi.useRealTimers()
+  })
+})
+
+describe('http sink — sendBeacon fallback (unload path)', () => {
+  it('uses beacon with ?writeKey= query (no Authorization header)', async () => {
+    const beaconCalls: Array<{ url: string; body: string }> = []
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'WK secret/with+special',
+      fetchImpl: be.fetchImpl,
+      beaconImpl: (url, body) => {
+        beaconCalls.push({ url, body })
+        return true
+      },
+    })
+    await sink.deliver([makeEvent()], CTX_UNLOAD)
+
+    expect(beaconCalls).toHaveLength(1)
+    expect(be.calls).toHaveLength(0) // beacon used, not fetch
+    const { url, body } = beaconCalls[0]
+    expect(url).toContain(`/v${SCHEMA_VERSION}/batch`)
+    expect(url).toContain(
+      'writeKey=' + encodeURIComponent('WK secret/with+special'),
+    )
+    const parsed = JSON.parse(body) as { batch: unknown[]; batchId: string }
+    expect(parsed.batch).toHaveLength(1)
+    expect(isUuidV4(parsed.batchId)).toBe(true)
+  })
+
+  it('falls back to keepalive fetch when beacon is unavailable on unload', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+      // no beaconImpl, and no navigator in node → falls back to fetch
+    })
+    await sink.deliver([makeEvent()], CTX_UNLOAD)
+    expect(be.calls).toHaveLength(1)
+  })
+
+  it('online path never uses beacon', async () => {
+    const beaconCalls: string[] = []
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+      beaconImpl: (url) => {
+        beaconCalls.push(url)
+        return true
+      },
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(beaconCalls).toHaveLength(0)
+    expect(be.calls).toHaveLength(1)
+  })
+})
+
+describe('http sink — size limits', () => {
+  it('splits a batch that exceeds the per-batch byte cap', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+      maxBatchBytes: 400, // tiny → forces splitting
+      maxEventBytes: 32_000,
+    })
+    const events = [makeEvent(), makeEvent(), makeEvent(), makeEvent()]
+    await sink.deliver(events, CTX_ONLINE)
+    expect(be.calls.length).toBeGreaterThan(1)
+    const total = be.calls.reduce(
+      (sum, c) => sum + (c.body as { batch: unknown[] }).batch.length,
+      0,
+    )
+    expect(total).toBe(4) // no events lost during splitting
+  })
+
+  it('drops a single event larger than the per-event byte cap', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      fetchImpl: be.fetchImpl,
+      maxEventBytes: 100, // smaller than any real event
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(be.calls).toHaveLength(0) // oversized → unsendable, dropped
+  })
+})
+
+describe('http sink — consent categories', () => {
+  it('defaults to requiring the analytics category', () => {
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+    })
+    expect(sink.consentCategories).toEqual(['analytics'])
+  })
+
+  it('honours a custom consentCategories list', () => {
+    const sink = createHttpSink({
+      endpoint: 'https://c.example.com',
+      writeKey: 'k',
+      consentCategories: ['marketing', 'analytics'],
+    })
+    expect(sink.consentCategories).toEqual(['marketing', 'analytics'])
+  })
+})

--- a/packages/analytics/__tests__/identity.test.ts
+++ b/packages/analytics/__tests__/identity.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { createIdentity } from '../src/identity.js'
+import { createMemoryStorage } from '../src/storage.js'
+import { isUuidV4 } from '../src/uuid.js'
+
+describe('createIdentity — anonymousId', () => {
+  it('mints a UUIDv4 anonymousId on first use', () => {
+    const id = createIdentity({ storage: createMemoryStorage() })
+    expect(isUuidV4(id.anonymousId())).toBe(true)
+  })
+
+  it('persists the anonymousId across instances (cross-tab)', () => {
+    const storage = createMemoryStorage()
+    const a = createIdentity({ storage })
+    const b = createIdentity({ storage })
+    expect(b.anonymousId()).toBe(a.anonymousId())
+  })
+
+  it('ignores a corrupt persisted value and re-mints', () => {
+    const storage = createMemoryStorage()
+    storage.set('rfx:analytics:anon', 'garbage-not-a-uuid')
+    const id = createIdentity({ storage })
+    expect(isUuidV4(id.anonymousId())).toBe(true)
+  })
+})
+
+describe('createIdentity — userId (opaque, app-supplied)', () => {
+  it('is undefined until identify()', () => {
+    const id = createIdentity({ storage: createMemoryStorage() })
+    expect(id.userId()).toBeUndefined()
+  })
+
+  it('stores the opaque user id verbatim and does not persist it', () => {
+    const storage = createMemoryStorage()
+    const id = createIdentity({ storage })
+    id.setUserId('user_42')
+    expect(id.userId()).toBe('user_42')
+    // userId must NOT be written to durable storage (app owns the record).
+    expect(storage.get('rfx:analytics:anon')).not.toContain('user_42')
+  })
+})
+
+describe('createIdentity — alias stitching', () => {
+  it('stitches anonymous → user when no prior user', () => {
+    const id = createIdentity({ storage: createMemoryStorage() })
+    const anon = id.anonymousId()
+    const stitch = id.alias('user_1')
+    expect(stitch.previousId).toBe(anon)
+    expect(stitch.userId).toBe('user_1')
+    expect(id.userId()).toBe('user_1')
+  })
+
+  it('stitches old user → new user', () => {
+    const id = createIdentity({ storage: createMemoryStorage() })
+    id.setUserId('old')
+    const stitch = id.alias('new')
+    expect(stitch.previousId).toBe('old')
+    expect(stitch.userId).toBe('new')
+  })
+
+  it('honours an explicit previousId', () => {
+    const id = createIdentity({ storage: createMemoryStorage() })
+    const stitch = id.alias('new', 'explicit-prev')
+    expect(stitch.previousId).toBe('explicit-prev')
+  })
+})
+
+describe('createIdentity — reset (privacy-safe logout)', () => {
+  it('mints a fresh anonymousId and clears the user binding', () => {
+    const storage = createMemoryStorage()
+    const id = createIdentity({ storage })
+    const before = id.anonymousId()
+    id.setUserId('user_1')
+    const fresh = id.reset()
+    expect(fresh).not.toBe(before)
+    expect(id.anonymousId()).toBe(fresh)
+    expect(id.userId()).toBeUndefined()
+    // The new id is what is now persisted (no stitch to the old visitor).
+    expect(storage.get('rfx:analytics:anon')).toBe(fresh)
+  })
+})

--- a/packages/analytics/__tests__/redaction.test.ts
+++ b/packages/analytics/__tests__/redaction.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { createRedactor, PII_DENY_LIST, REDACTED } from '../src/redaction.js'
+
+describe('createRedactor — built-in PII deny-list', () => {
+  it('redacts email/phone/name and common variants', () => {
+    const r = createRedactor()
+    const out = r.redact({
+      email: 'a@b.com',
+      userEmail: 'c@d.com',
+      email_address: 'e@f.com',
+      phone: '+1555',
+      phoneNumber: '+1556',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      fullName: 'Ada Lovelace',
+      plan: 'pro',
+    })!
+    expect(out.email).toBe(REDACTED)
+    expect(out.userEmail).toBe(REDACTED)
+    expect(out.email_address).toBe(REDACTED)
+    expect(out.phone).toBe(REDACTED)
+    expect(out.phoneNumber).toBe(REDACTED)
+    expect(out.firstName).toBe(REDACTED)
+    expect(out.lastName).toBe(REDACTED)
+    expect(out.fullName).toBe(REDACTED)
+    // Non-PII passes through untouched.
+    expect(out.plan).toBe('pro')
+  })
+
+  it('exposes the deny-list and redaction token', () => {
+    expect(PII_DENY_LIST).toContain('email')
+    expect(PII_DENY_LIST).toContain('phone')
+    expect(REDACTED).toBe('[REDACTED]')
+  })
+
+  it('recurses into nested objects and arrays', () => {
+    const r = createRedactor()
+    const out = r.redact({
+      profile: { email: 'x@y.com', tier: 'gold' },
+      contacts: [{ phone: '111' }, { phone: '222' }],
+    })!
+    const profile = out.profile as Record<string, unknown>
+    expect(profile.email).toBe(REDACTED)
+    expect(profile.tier).toBe('gold')
+    const contacts = out.contacts as Array<Record<string, unknown>>
+    expect(contacts[0].phone).toBe(REDACTED)
+    expect(contacts[1].phone).toBe(REDACTED)
+  })
+
+  it('does not mutate the input object', () => {
+    const r = createRedactor()
+    const input = { email: 'a@b.com' }
+    r.redact(input)
+    expect(input.email).toBe('a@b.com')
+  })
+
+  it('returns undefined for undefined input', () => {
+    const r = createRedactor()
+    expect(r.redact(undefined)).toBeUndefined()
+  })
+})
+
+describe('createRedactor — caller redactKeys', () => {
+  it('redacts extra keys exactly (normalised, case-insensitive)', () => {
+    const r = createRedactor(['internalScore', 'secret_token'])
+    const out = r.redact({
+      internalScore: 99,
+      InternalScore: 98,
+      secretToken: 'abc',
+      keep: 'ok',
+    })!
+    expect(out.internalScore).toBe(REDACTED)
+    expect(out.InternalScore).toBe(REDACTED)
+    expect(out.secretToken).toBe(REDACTED)
+    expect(out.keep).toBe('ok')
+  })
+
+  it('shouldRedact reflects both deny-list and extra keys', () => {
+    const r = createRedactor(['campaignBudget'])
+    expect(r.shouldRedact('email')).toBe(true)
+    expect(r.shouldRedact('campaignBudget')).toBe(true)
+    expect(r.shouldRedact('eventName')).toBe(false)
+  })
+})

--- a/packages/analytics/__tests__/session.test.ts
+++ b/packages/analytics/__tests__/session.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createSession,
+  campaignFingerprint,
+  DEFAULT_SESSION_TIMEOUT_MS,
+} from '../src/session.js'
+import { createMemoryStorage } from '../src/storage.js'
+import { isUuidV4 } from '../src/uuid.js'
+
+describe('campaignFingerprint', () => {
+  it('returns undefined when no campaign params are present', () => {
+    expect(campaignFingerprint(undefined)).toBeUndefined()
+    expect(campaignFingerprint('?foo=bar')).toBeUndefined()
+    expect(campaignFingerprint('')).toBeUndefined()
+  })
+
+  it('builds a stable fingerprint from utm params and click ids', () => {
+    const fp = campaignFingerprint('?utm_source=google&utm_medium=cpc&x=1')
+    expect(fp).toBe('utm_source=google&utm_medium=cpc')
+    expect(campaignFingerprint('?gclid=abc')).toBe('gclid=abc')
+  })
+
+  it('accepts a full query string with leading path', () => {
+    expect(campaignFingerprint('/p?utm_campaign=launch')).toBe(
+      'utm_campaign=launch',
+    )
+  })
+})
+
+describe('createSession — lifecycle', () => {
+  it('mints a UUIDv4 session id at first access', () => {
+    const s = createSession({ storage: createMemoryStorage() })
+    const id = s.id()
+    expect(isUuidV4(id)).toBe(true)
+  })
+
+  it('returns a stable id within an active session', () => {
+    const s = createSession({ storage: createMemoryStorage() })
+    expect(s.id()).toBe(s.id())
+  })
+
+  it('start() forces a brand-new session id', () => {
+    const s = createSession({ storage: createMemoryStorage() })
+    const a = s.id()
+    const b = s.start()
+    expect(b).not.toBe(a)
+    expect(isUuidV4(b)).toBe(true)
+  })
+
+  it('end() drops the session; next id() mints a fresh one', () => {
+    const s = createSession({ storage: createMemoryStorage() })
+    const a = s.id()
+    s.end()
+    const b = s.id()
+    expect(b).not.toBe(a)
+  })
+
+  it('exposes the GA4-parity default timeout (30 minutes)', () => {
+    expect(DEFAULT_SESSION_TIMEOUT_MS).toBe(30 * 60 * 1000)
+  })
+})
+
+describe('createSession — inactivity timeout (GA4 parity)', () => {
+  it('rotates the id after the inactivity window elapses', () => {
+    let now = 1_000_000
+    const s = createSession(
+      { storage: createMemoryStorage(), timeoutMs: 1000 },
+      () => now,
+    )
+    const a = s.touch()
+    now += 500 // within window
+    expect(s.touch()).toBe(a)
+    now += 5000 // beyond window since last activity
+    const b = s.touch()
+    expect(b).not.toBe(a)
+  })
+
+  it('touch() slides the window forward (no premature rotation)', () => {
+    let now = 0
+    const s = createSession(
+      { storage: createMemoryStorage(), timeoutMs: 1000 },
+      () => now,
+    )
+    const a = s.touch()
+    for (let i = 0; i < 10; i++) {
+      now += 900 // always within window of the previous touch
+      expect(s.touch()).toBe(a)
+    }
+  })
+})
+
+describe('createSession — campaign reset', () => {
+  it('rotates the id when a new campaign appears', () => {
+    let now = 0
+    const s = createSession(
+      { storage: createMemoryStorage(), timeoutMs: 60_000 },
+      () => now,
+    )
+    const organic = s.touch(undefined)
+    now += 100
+    const campaignA = s.touch('utm_source=google')
+    expect(campaignA).not.toBe(organic)
+    now += 100
+    const campaignB = s.touch('utm_source=bing')
+    expect(campaignB).not.toBe(campaignA)
+  })
+
+  it('does NOT rotate when the same campaign repeats', () => {
+    let now = 0
+    const s = createSession(
+      { storage: createMemoryStorage(), timeoutMs: 60_000 },
+      () => now,
+    )
+    const a = s.touch('utm_source=google')
+    now += 100
+    expect(s.touch('utm_source=google')).toBe(a)
+  })
+
+  it('honours resetOnCampaign:false', () => {
+    let now = 0
+    const s = createSession(
+      {
+        storage: createMemoryStorage(),
+        timeoutMs: 60_000,
+        resetOnCampaign: false,
+      },
+      () => now,
+    )
+    const a = s.touch('utm_source=google')
+    now += 100
+    expect(s.touch('utm_source=bing')).toBe(a)
+  })
+})
+
+describe('createSession — cross-tab persistence', () => {
+  it('shares one session across instances backed by the same storage', () => {
+    const storage = createMemoryStorage()
+    const tabA = createSession({ storage })
+    const tabB = createSession({ storage })
+    expect(tabB.id()).toBe(tabA.id())
+  })
+})
+
+describe('createSession — session-scoped properties', () => {
+  it('merges and reads session.set props', () => {
+    const s = createSession({ storage: createMemoryStorage() })
+    s.set({ plan: 'pro' })
+    s.set({ region: 'eu' })
+    expect(s.props()).toEqual({ plan: 'pro', region: 'eu' })
+  })
+})

--- a/packages/analytics/__tests__/sinks.test.ts
+++ b/packages/analytics/__tests__/sinks.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createConsoleSink } from '../src/console-sink.js'
+import { createMockSink } from '../src/mock-sink.js'
+import { createNoopAnalytics } from '../src/noop.js'
+import { SCHEMA_VERSION } from '../src/types.js'
+import type { AnalyticsEvent } from '../src/types.js'
+
+function ev(event: string): AnalyticsEvent {
+  return {
+    type: 'track',
+    event,
+    messageId: 'm',
+    anonymousId: 'a',
+    sessionId: 's',
+    properties: {},
+    context: {
+      app: 'app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: new Date().toISOString(),
+    schemaVersion: SCHEMA_VERSION,
+  }
+}
+
+describe('createConsoleSink', () => {
+  it('groups and logs each canonical envelope', () => {
+    const logger = {
+      log: vi.fn(),
+      groupCollapsed: vi.fn(),
+      groupEnd: vi.fn(),
+    }
+    const sink = createConsoleSink({ logger })
+    sink.deliver([ev('A'), ev('B')], { unload: false })
+    expect(logger.groupCollapsed).toHaveBeenCalledTimes(2)
+    expect(logger.log).toHaveBeenCalledTimes(2)
+    expect(logger.groupCollapsed).toHaveBeenCalledWith('[analytics] track A')
+  })
+
+  it('falls back to plain log when grouping is unavailable', () => {
+    const log = vi.fn()
+    const sink = createConsoleSink({
+      logger: { log } as never,
+    })
+    sink.deliver([ev('Solo')], { unload: false })
+    expect(log).toHaveBeenCalledWith(
+      '[analytics] track Solo',
+      expect.objectContaining({ event: 'Solo' }),
+    )
+  })
+
+  it('passes through configured consent categories', () => {
+    const sink = createConsoleSink({ consentCategories: ['debug'] })
+    expect(sink.consentCategories).toEqual(['debug'])
+  })
+})
+
+describe('createMockSink', () => {
+  it('captures init/deliver/flush/shutdown for assertions', async () => {
+    const sink = createMockSink({ name: 's1', consentCategories: ['x'] })
+    expect(sink.name).toBe('s1')
+    expect(sink.consentCategories).toEqual(['x'])
+
+    sink.init?.({ app: 'a', env: 'e' })
+    sink.deliver([ev('A')], { unload: false })
+    sink.deliver([ev('B'), ev('C')], { unload: true })
+    await sink.flush?.()
+    await sink.shutdown?.()
+
+    expect(sink.initCalls).toHaveLength(1)
+    expect(sink.deliveries).toHaveLength(2)
+    expect(sink.deliveries[1].ctx.unload).toBe(true)
+    expect(sink.events.map((e) => e.event)).toEqual(['A', 'B', 'C'])
+    expect(sink.flushCalls).toBe(1)
+    expect(sink.shutdownCalls).toBe(1)
+  })
+})
+
+describe('createNoopAnalytics', () => {
+  it('exposes the full Analytics surface, all inert', () => {
+    const a = createNoopAnalytics()
+    expect(a.enabled).toBe(false)
+    expect(a.sinks).toEqual([])
+    expect(a.userId()).toBeUndefined()
+    expect(a.anonymousId()).toMatch(/^0{8}-0{4}-4/)
+    expect(typeof a.session.id()).toBe('string')
+    expect(a.consent.granted()).toEqual([])
+    expect(a.consent.isGranted('analytics')).toBe(false)
+    expect(a.with({})).toBe(a)
+    expect(() => {
+      a.track('x')
+      a.identify('u')
+      a.page()
+      a.screen()
+      a.group('g')
+      a.alias('u2')
+      a.session.start()
+      a.session.end()
+      a.session.set({})
+      a.consent.grant('a')
+      a.consent.revoke('a')
+      a.addSink(createMockSink())
+      a.removeSink('mock')
+      a.reset()
+    }).not.toThrow()
+  })
+
+  it('flush resolves without doing anything', async () => {
+    const a = createNoopAnalytics()
+    await expect(a.flush()).resolves.toBeUndefined()
+  })
+})

--- a/packages/analytics/__tests__/storage.test.ts
+++ b/packages/analytics/__tests__/storage.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createMemoryStorage,
+  createLocalStorageAdapter,
+  createCookieAdapter,
+  resolveStorage,
+} from '../src/storage.js'
+
+describe('createMemoryStorage', () => {
+  it('round-trips values and reports null for missing keys', () => {
+    const s = createMemoryStorage()
+    expect(s.get('k')).toBeNull()
+    s.set('k', 'v')
+    expect(s.get('k')).toBe('v')
+    s.remove('k')
+    expect(s.get('k')).toBeNull()
+  })
+})
+
+describe('createLocalStorageAdapter', () => {
+  it('delegates to the underlying Storage', () => {
+    const map = new Map<string, string>()
+    const fake = {
+      getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+      setItem: (k: string, v: string) => void map.set(k, v),
+      removeItem: (k: string) => void map.delete(k),
+    } as unknown as Storage
+    const s = createLocalStorageAdapter(fake)
+    s.set('a', '1')
+    expect(s.get('a')).toBe('1')
+    expect(map.get('a')).toBe('1')
+    s.remove('a')
+    expect(s.get('a')).toBeNull()
+  })
+
+  it('degrades silently when the store throws (quota / private mode)', () => {
+    const fake = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('quota')
+      },
+      removeItem: () => {
+        throw new Error('blocked')
+      },
+    } as unknown as Storage
+    const s = createLocalStorageAdapter(fake)
+    expect(() => s.set('a', '1')).not.toThrow()
+    expect(s.get('a')).toBeNull()
+    expect(() => s.remove('a')).not.toThrow()
+  })
+})
+
+describe('createCookieAdapter', () => {
+  it('reads, writes, and removes via document.cookie', () => {
+    const jar: { cookie: string } = { cookie: '' }
+    // Simulate a browser cookie jar: writes append; reads see latest.
+    const writes: string[] = []
+    const doc = {
+      get cookie() {
+        return writes
+          .map((w) => w.split(';')[0])
+          .join('; ')
+      },
+      set cookie(v: string) {
+        writes.push(v)
+      },
+    }
+    const s = createCookieAdapter(doc)
+    s.set('rfx', 'hello world')
+    expect(s.get('rfx')).toBe('hello world')
+    expect(jar).toBeDefined()
+  })
+
+  it('encodes/decodes special characters', () => {
+    const writes: string[] = []
+    const doc = {
+      get cookie() {
+        return writes.map((w) => w.split(';')[0]).join('; ')
+      },
+      set cookie(v: string) {
+        writes.push(v)
+      },
+    }
+    const s = createCookieAdapter(doc)
+    s.set('k', 'a=b; c')
+    expect(s.get('k')).toBe('a=b; c')
+  })
+})
+
+describe('resolveStorage', () => {
+  it('returns the override when supplied', () => {
+    const override = createMemoryStorage()
+    expect(resolveStorage(override)).toBe(override)
+  })
+
+  it('falls back to memory storage in a no-DOM environment', () => {
+    // Node test env: no localStorage/document on globalThis.
+    const s = resolveStorage()
+    s.set('x', 'y')
+    expect(s.get('x')).toBe('y')
+  })
+})

--- a/packages/analytics/__tests__/uuid.test.ts
+++ b/packages/analytics/__tests__/uuid.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { uuidv4, isUuidV4, UUID_V4_RE } from '../src/uuid.js'
+
+describe('uuidv4', () => {
+  it('produces an RFC 4122 v4 shaped string', () => {
+    const id = uuidv4()
+    expect(id).toMatch(UUID_V4_RE)
+  })
+
+  it('sets the version nibble to 4', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(uuidv4()[14]).toBe('4')
+    }
+  })
+
+  it('sets the variant nibble to 8/9/a/b', () => {
+    for (let i = 0; i < 50; i++) {
+      expect('89ab').toContain(uuidv4()[19])
+    }
+  })
+
+  it('is collision-free across many draws', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 5000; i++) seen.add(uuidv4())
+    expect(seen.size).toBe(5000)
+  })
+})
+
+describe('isUuidV4', () => {
+  it('accepts valid v4 uuids', () => {
+    expect(isUuidV4(uuidv4())).toBe(true)
+  })
+
+  it('rejects non-uuid strings and non-strings', () => {
+    expect(isUuidV4('not-a-uuid')).toBe(false)
+    expect(isUuidV4('')).toBe(false)
+    expect(isUuidV4(undefined)).toBe(false)
+    expect(isUuidV4(123)).toBe(false)
+    // v1-style (version nibble 1) must be rejected
+    expect(isUuidV4('00000000-0000-1000-8000-000000000000')).toBe(false)
+  })
+})

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@refraction-ui/analytics",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "devDependencies": {},
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/analytics"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/analytics/src/analytics-manager.ts
+++ b/packages/analytics/src/analytics-manager.ts
@@ -1,0 +1,361 @@
+import type {
+  Analytics,
+  AnalyticsConfig,
+  AnalyticsContext,
+  AnalyticsEvent,
+  AnalyticsEventType,
+  AnalyticsSink,
+  CallOptions,
+  SinkDeliverContext,
+} from './types.js'
+import { SCHEMA_VERSION } from './types.js'
+import { uuidv4 } from './uuid.js'
+import { createSession, campaignFingerprint } from './session.js'
+import { createIdentity } from './identity.js'
+import { createConsent } from './consent.js'
+import { createRedactor } from './redaction.js'
+import { createHttpSink } from './http-sink.js'
+import { createConsoleSink } from './console-sink.js'
+import { createNoopAnalytics } from './noop.js'
+
+const LIBRARY = {
+  name: '@refraction-ui/analytics',
+  version: '0.1.0',
+}
+
+/** Read the current page block from the DOM, if any (browser-only). */
+function readPage(): AnalyticsContext['page'] | undefined {
+  const g = globalThis as unknown as {
+    location?: { pathname?: string; href?: string; search?: string }
+    document?: { title?: string; referrer?: string }
+  }
+  if (!g.location && !g.document) return undefined
+  return {
+    path: g.location?.pathname,
+    url: g.location?.href,
+    search: g.location?.search,
+    title: g.document?.title,
+    referrer: g.document?.referrer,
+  }
+}
+
+/**
+ * createAnalytics — the neutral Segment-spec collector/router.
+ *
+ * Mirrors `createAI`: a single factory returns the entire public surface and
+ * fans the canonical envelope out to registered sinks. There is NO privileged
+ * engine — the built-in HTTP sink and every vendor adapter are equal sinks.
+ *
+ * Presets:
+ *   dev  — synchronous delivery + a console sink (see exactly what ships).
+ *   prod — batching + sampling + beacon flush on pagehide/visibilitychange.
+ *
+ * When `enabled: false`, a tree-shakeable noop is returned and none of the
+ * live collector / sink code is reachable.
+ */
+export function createAnalytics(config: AnalyticsConfig): Analytics {
+  if (config.enabled === false) {
+    return createNoopAnalytics()
+  }
+
+  const { app, env } = config
+  const preset =
+    config.preset ?? (env === 'production' ? 'prod' : 'dev')
+  const sampleRate = config.sampleRate ?? 1
+  const batchSize = config.batchSize ?? 20
+  const flushIntervalMs = config.flushIntervalMs ?? 10_000
+
+  const session = createSession(config.session)
+  const identity = createIdentity(config.identity)
+  const consent = createConsent(config.consent)
+  const redactor = createRedactor(config.redactKeys)
+
+  // --- Sink registry ------------------------------------------------------
+  const sinks = new Map<string, AnalyticsSink>()
+  const sinkOrder: string[] = []
+  const initialized = new Set<string>()
+
+  function registerSink(sink: AnalyticsSink): void {
+    if (!sinks.has(sink.name)) sinkOrder.push(sink.name)
+    sinks.set(sink.name, sink)
+  }
+
+  // Auto HTTP sink when an endpoint is supplied.
+  if (config.endpoint) {
+    registerSink(
+      createHttpSink({
+        endpoint: config.endpoint,
+        writeKey: config.writeKey ?? '',
+      }),
+    )
+  }
+  // dev preset → add a console sink for visibility.
+  if (preset === 'dev') {
+    registerSink(createConsoleSink())
+  }
+  // Explicit sinks (override same-named built-ins).
+  for (const s of config.sinks ?? []) registerSink(s)
+
+  /**
+   * Initialise a sink at most once. Returns a promise only when the sink's
+   * own `init` is async — synchronous sinks stay on the synchronous path so
+   * the dev preset delivers without a microtask hop.
+   */
+  function ensureInit(sink: AnalyticsSink): void | Promise<void> {
+    if (initialized.has(sink.name)) return
+    initialized.add(sink.name)
+    if (sink.init) {
+      return sink.init({ app, env, endpoint: config.endpoint })
+    }
+  }
+
+  // --- Batch buffer -------------------------------------------------------
+  const buffer: AnalyticsEvent[] = []
+  let timer: ReturnType<typeof setInterval> | undefined
+
+  function startTimer(): void {
+    if (preset !== 'prod' || timer) return
+    timer = setInterval(() => {
+      void flush(false)
+    }, flushIntervalMs)
+    // Do not keep a Node process alive purely for the flush timer.
+    ;(timer as unknown as { unref?: () => void }).unref?.()
+  }
+
+  /**
+   * Fan a batch out to every consented sink. Stays fully synchronous when all
+   * sinks are synchronous (dev preset visibility); returns a promise only if a
+   * sink's init/deliver is async.
+   */
+  function deliverToSinks(
+    batch: AnalyticsEvent[],
+    unload: boolean,
+  ): void | Promise<void> {
+    if (batch.length === 0) return
+    const ctx: SinkDeliverContext = { unload }
+    const pending: Array<Promise<unknown>> = []
+    for (const name of sinkOrder) {
+      const sink = sinks.get(name)
+      if (!sink) continue
+      if (!consent.allows(sink.consentCategories)) continue
+      const inited = ensureInit(sink)
+      if (inited && typeof (inited as Promise<void>).then === 'function') {
+        pending.push(
+          (inited as Promise<void>).then(() => sink.deliver(batch, ctx)),
+        )
+      } else {
+        const r = sink.deliver(batch, ctx)
+        if (r && typeof (r as Promise<void>).then === 'function') {
+          pending.push(r as Promise<void>)
+        }
+      }
+    }
+    if (pending.length) return Promise.all(pending).then(() => undefined)
+  }
+
+  async function flush(unload = false): Promise<void> {
+    const batch = buffer.splice(0, buffer.length)
+    await deliverToSinks(batch, unload)
+    for (const name of sinkOrder) {
+      const sink = sinks.get(name)
+      if (sink?.flush && consent.allows(sink.consentCategories)) {
+        await sink.flush()
+      }
+    }
+  }
+
+  // --- Unload flush (prod) ------------------------------------------------
+  function bindUnload(): void {
+    if (preset !== 'prod') return
+    const g = globalThis as unknown as {
+      addEventListener?: (t: string, h: () => void) => void
+      document?: { visibilityState?: string }
+    }
+    if (typeof g.addEventListener !== 'function') return
+    const onUnload = (): void => {
+      void deliverToSinks(buffer.splice(0, buffer.length), true)
+    }
+    g.addEventListener('pagehide', onUnload)
+    g.addEventListener('visibilitychange', () => {
+      if (g.document?.visibilityState === 'hidden') onUnload()
+    })
+  }
+
+  startTimer()
+  bindUnload()
+
+  // --- Envelope construction ---------------------------------------------
+  function buildContext(
+    extra?: Partial<AnalyticsContext>,
+    childCtx?: Partial<AnalyticsContext>,
+  ): AnalyticsContext {
+    const page = readPage()
+    return {
+      app,
+      env,
+      ...(page ? { page } : {}),
+      ...childCtx,
+      ...extra,
+      library: LIBRARY,
+    }
+  }
+
+  function sampled(): boolean {
+    if (sampleRate >= 1) return true
+    if (sampleRate <= 0) return false
+    return Math.random() < sampleRate
+  }
+
+  function enqueue(ev: AnalyticsEvent): void {
+    if (preset === 'dev') {
+      // Synchronous, unbatched — immediate visibility.
+      void deliverToSinks([ev], false)
+      return
+    }
+    buffer.push(ev)
+    if (buffer.length >= batchSize) {
+      void flush(false)
+    }
+  }
+
+  function emit(
+    type: AnalyticsEventType,
+    fields: Partial<AnalyticsEvent>,
+    childCtx: Partial<AnalyticsContext> | undefined,
+    opts?: CallOptions,
+  ): void {
+    if (!sampled()) return
+
+    const page = readPage()
+    const campaign = campaignFingerprint(page?.search)
+    const sessionId = session.touch(campaign)
+    const sessionProps = session.props()
+
+    const ev: AnalyticsEvent = {
+      type,
+      messageId: uuidv4(),
+      anonymousId: identity.anonymousId(),
+      userId: identity.userId(),
+      sessionId,
+      context: buildContext(opts?.context, childCtx),
+      timestamp: opts?.timestamp ?? new Date().toISOString(),
+      schemaVersion: SCHEMA_VERSION,
+      ...fields,
+    }
+
+    // Merge session-scoped props beneath call props.
+    if (sessionProps && (ev.properties || type === 'track' || type === 'page' || type === 'screen')) {
+      ev.properties = { ...sessionProps, ...(ev.properties ?? {}) }
+    }
+
+    enqueue(ev)
+  }
+
+  function makeApi(childCtx?: Partial<AnalyticsContext>): Analytics {
+    const api: Analytics = {
+      track(event, properties, opts) {
+        emit(
+          'track',
+          { event, properties: redactor.redact(properties) },
+          childCtx,
+          opts,
+        )
+      },
+
+      identify(userId, traits, opts) {
+        identity.setUserId(userId)
+        emit('identify', { traits: redactor.redact(traits) }, childCtx, opts)
+      },
+
+      page(name, properties, opts) {
+        emit(
+          'page',
+          { event: name, properties: redactor.redact(properties) },
+          childCtx,
+          opts,
+        )
+      },
+
+      screen(name, properties, opts) {
+        emit(
+          'screen',
+          { event: name, properties: redactor.redact(properties) },
+          childCtx,
+          opts,
+        )
+      },
+
+      group(groupId, traits, opts) {
+        emit(
+          'group',
+          { groupId, traits: redactor.redact(traits) },
+          childCtx,
+          opts,
+        )
+      },
+
+      alias(userId, previousId, opts) {
+        const stitch = identity.alias(userId, previousId)
+        emit(
+          'alias',
+          { userId: stitch.userId, previousId: stitch.previousId },
+          childCtx,
+          opts,
+        )
+      },
+
+      session: {
+        id: () => session.id(),
+        start: () => session.start(),
+        end: () => session.end(),
+        set: (props) => session.set(props),
+      },
+
+      consent: {
+        grant: (...c) => consent.grant(...c),
+        revoke: (...c) => consent.revoke(...c),
+        granted: () => consent.granted(),
+        isGranted: (c) => consent.isGranted(c),
+      },
+
+      anonymousId: () => identity.anonymousId(),
+      userId: () => identity.userId(),
+
+      with(extra: Partial<AnalyticsContext>): Analytics {
+        return makeApi({ ...childCtx, ...extra })
+      },
+
+      addSink(sink: AnalyticsSink): void {
+        registerSink(sink)
+      },
+
+      removeSink(name: string): void {
+        if (sinks.has(name)) {
+          sinks.delete(name)
+          const i = sinkOrder.indexOf(name)
+          if (i !== -1) sinkOrder.splice(i, 1)
+          initialized.delete(name)
+        }
+      },
+
+      get sinks(): string[] {
+        return [...sinkOrder]
+      },
+
+      async flush(): Promise<void> {
+        await flush(false)
+      },
+
+      reset(): void {
+        identity.reset()
+        session.end()
+      },
+
+      enabled: true,
+    }
+
+    return api
+  }
+
+  return makeApi()
+}

--- a/packages/analytics/src/consent.ts
+++ b/packages/analytics/src/consent.ts
@@ -1,0 +1,40 @@
+import type { ConsentAPI, ConsentConfig } from './types.js'
+
+/**
+ * Consent gate.
+ *
+ * Holds the set of granted consent categories. The router asks the gate, per
+ * sink, whether *all* of that sink's required categories are granted before
+ * delivering. A sink with no declared categories is always allowed (it is the
+ * sink author's responsibility to declare what it needs).
+ */
+export function createConsent(config?: ConsentConfig): ConsentAPI & {
+  /** True when every required category is granted (empty list ⇒ allowed). */
+  allows(required?: string[]): boolean
+  /** True when at least one sink could receive (used by strict mode). */
+  strict: boolean
+} {
+  const granted = new Set<string>(config?.granted ?? [])
+
+  return {
+    strict: config?.strict ?? false,
+    grant(...categories: string[]): void {
+      for (const c of categories) granted.add(c)
+    },
+    revoke(...categories: string[]): void {
+      for (const c of categories) granted.delete(c)
+    },
+    granted(): string[] {
+      return [...granted]
+    },
+    isGranted(category: string): boolean {
+      return granted.has(category)
+    },
+    allows(required?: string[]): boolean {
+      if (!required || required.length === 0) return true
+      return required.every((c) => granted.has(c))
+    },
+  }
+}
+
+export type Consent = ReturnType<typeof createConsent>

--- a/packages/analytics/src/console-sink.ts
+++ b/packages/analytics/src/console-sink.ts
@@ -1,0 +1,37 @@
+import type { AnalyticsEvent, AnalyticsSink } from './types.js'
+
+export interface ConsoleSinkOptions {
+  /** Injected logger (defaults to globalThis.console). */
+  logger?: Pick<Console, 'log' | 'groupCollapsed' | 'groupEnd'>
+  /** Consent categories this sink requires. Default: none (always allowed). */
+  consentCategories?: string[]
+}
+
+/**
+ * Built-in `console` sink — the dev preset's default. Prints each canonical
+ * envelope so engineers can see exactly what would ship over the wire.
+ */
+export function createConsoleSink(
+  options: ConsoleSinkOptions = {},
+): AnalyticsSink {
+  const logger =
+    options.logger ??
+    (globalThis as unknown as { console: Console }).console
+
+  return {
+    name: 'console',
+    consentCategories: options.consentCategories,
+    deliver(batch: AnalyticsEvent[]): void {
+      for (const ev of batch) {
+        const label = `[analytics] ${ev.type}${ev.event ? ` ${ev.event}` : ''}`
+        if (typeof logger.groupCollapsed === 'function') {
+          logger.groupCollapsed(label)
+          logger.log(ev)
+          logger.groupEnd?.()
+        } else {
+          logger.log(label, ev)
+        }
+      }
+    },
+  }
+}

--- a/packages/analytics/src/http-sink.ts
+++ b/packages/analytics/src/http-sink.ts
@@ -1,0 +1,213 @@
+import type {
+  AnalyticsEvent,
+  AnalyticsSink,
+  HttpSinkOptions,
+  SinkDeliverContext,
+} from './types.js'
+import { SCHEMA_VERSION } from './types.js'
+import { uuidv4 } from './uuid.js'
+
+/**
+ * Built-in `http` sink — Segment HTTP Tracking API wire contract.
+ *
+ * Wire contract (adopt, do not invent — RudderStack/Jitsu/Segment conform):
+ *
+ *   POST {endpoint}/v{schemaVersion}/batch
+ *   Content-Type: application/json
+ *   Authorization: Basic base64(writeKey:)         (note the trailing colon)
+ *   Body: { batch: AnalyticsEvent[], sentAt, batchId }
+ *
+ * Each event carries `messageId` (idempotency — backends MUST dedupe),
+ * `anonymousId`, `userId?`, `sessionId`, `type`, `event?`,
+ * `properties`/`traits`, `context`, `timestamp`, `schemaVersion`.
+ *
+ * Response handling (accept-and-queue semantics):
+ *   200       accepted (the backend has only queued it, not processed it)
+ *   400       malformed       → DROP, never retry
+ *   401       bad write key   → DROP, never retry
+ *   413       payload too big → DROP (we also pre-split under the size caps)
+ *   429 / 5xx transient       → exponential backoff retry
+ *
+ * Clock skew: the backend corrects with
+ *   corrected = timestamp + (receivedAt − sentAt)
+ * so we always stamp an honest client `sentAt`.
+ *
+ * sendBeacon caveat: the unload path (`pagehide`/`visibilitychange`) uses
+ * `navigator.sendBeacon`, which cannot set an `Authorization` header. On that
+ * path we fall back to `?writeKey=` in the query string with a
+ * `text/plain` body (the wire contract requires the backend to accept this).
+ */
+
+const NO_RETRY = new Set([400, 401, 413])
+
+function base64(input: string): string {
+  const g = globalThis as unknown as {
+    btoa?: (s: string) => string
+    Buffer?: { from(s: string, enc: string): { toString(enc: string): string } }
+  }
+  if (typeof g.btoa === 'function') {
+    return g.btoa(input)
+  }
+  if (g.Buffer) {
+    return g.Buffer.from(input, 'utf-8').toString('base64')
+  }
+  throw new Error('No base64 implementation available (btoa/Buffer)')
+}
+
+function byteLength(s: string): number {
+  const g = globalThis as unknown as {
+    TextEncoder?: new () => { encode(s: string): { length: number } }
+  }
+  if (g.TextEncoder) return new g.TextEncoder().encode(s).length
+  // Conservative fallback (UTF-8 worst case is 4 bytes/char; use 3 as typical).
+  return unescape(encodeURIComponent(s)).length
+}
+
+const sleep = (ms: number) =>
+  new Promise<void>((r) => setTimeout(r, ms))
+
+/**
+ * Split a batch so neither the per-event nor per-batch byte caps are
+ * exceeded. Over-sized single events are dropped (they can never be sent).
+ */
+function splitBatch(
+  batch: AnalyticsEvent[],
+  maxBatchBytes: number,
+  maxEventBytes: number,
+): { batches: AnalyticsEvent[][]; dropped: AnalyticsEvent[] } {
+  const batches: AnalyticsEvent[][] = []
+  const dropped: AnalyticsEvent[] = []
+  let current: AnalyticsEvent[] = []
+  let currentBytes = 2 // "[]"
+
+  for (const ev of batch) {
+    const evBytes = byteLength(JSON.stringify(ev))
+    if (evBytes > maxEventBytes) {
+      dropped.push(ev)
+      continue
+    }
+    if (current.length && currentBytes + evBytes + 1 > maxBatchBytes) {
+      batches.push(current)
+      current = []
+      currentBytes = 2
+    }
+    current.push(ev)
+    currentBytes += evBytes + 1
+  }
+  if (current.length) batches.push(current)
+  return { batches, dropped }
+}
+
+/** Create the built-in Segment-spec HTTP sink. */
+export function createHttpSink(options: HttpSinkOptions): AnalyticsSink {
+  const {
+    endpoint,
+    writeKey,
+    maxRetries = 3,
+    backoffBaseMs = 500,
+    consentCategories = ['analytics'],
+    maxBatchBytes = 500_000,
+    maxEventBytes = 32_000,
+  } = options
+
+  const base = endpoint.replace(/\/+$/, '')
+  const url = `${base}/v${SCHEMA_VERSION}/batch`
+  const authHeader = `Basic ${base64(`${writeKey}:`)}`
+
+  const resolveFetch = (): typeof fetch => {
+    if (options.fetchImpl) return options.fetchImpl
+    const f = (globalThis as unknown as { fetch?: typeof fetch }).fetch
+    if (!f) throw new Error('No fetch implementation available')
+    return f
+  }
+
+  const resolveBeacon = ():
+    | ((u: string, body: string) => boolean)
+    | undefined => {
+    if (options.beaconImpl) return options.beaconImpl
+    const nav = (globalThis as unknown as {
+      navigator?: { sendBeacon?: (u: string, data: BodyInit) => boolean }
+    }).navigator
+    if (nav && typeof nav.sendBeacon === 'function') {
+      return (u, body) => nav.sendBeacon!(u, body)
+    }
+    return undefined
+  }
+
+  function envelope(batch: AnalyticsEvent[]) {
+    return {
+      batch,
+      sentAt: new Date().toISOString(),
+      batchId: uuidv4(),
+    }
+  }
+
+  /** Beacon path: writeKey via query string, text/plain body. */
+  function sendViaBeacon(batch: AnalyticsEvent[]): boolean {
+    const beacon = resolveBeacon()
+    if (!beacon) return false
+    const beaconUrl = `${url}?writeKey=${encodeURIComponent(writeKey)}`
+    return beacon(beaconUrl, JSON.stringify(envelope(batch)))
+  }
+
+  /** Standard path: fetch + Authorization header, with backoff retries. */
+  async function sendViaFetch(batch: AnalyticsEvent[]): Promise<void> {
+    const doFetch = resolveFetch()
+    const body = JSON.stringify(envelope(batch))
+
+    for (let attempt = 0; ; attempt++) {
+      let status: number
+      try {
+        const res = await doFetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: authHeader,
+          },
+          body,
+          keepalive: true,
+        })
+        status = res.status
+      } catch {
+        // Network error — treat as transient.
+        status = 0
+      }
+
+      if (status >= 200 && status < 300) return // accepted-and-queued
+      if (NO_RETRY.has(status)) return // 400/401/413 — drop, never retry
+
+      // 429 / 5xx / network (0) → backoff retry.
+      if (attempt >= maxRetries) return
+      const delay = backoffBaseMs * 2 ** attempt
+      await sleep(delay)
+    }
+  }
+
+  return {
+    name: 'http',
+    consentCategories,
+
+    async deliver(
+      batch: AnalyticsEvent[],
+      ctx: SinkDeliverContext,
+    ): Promise<void> {
+      if (batch.length === 0) return
+      const { batches, dropped } = splitBatch(
+        batch,
+        maxBatchBytes,
+        maxEventBytes,
+      )
+      void dropped // oversized events are unsendable by contract — silently dropped
+
+      for (const part of batches) {
+        if (ctx.unload) {
+          // Unload path: try beacon first; fall back to keepalive fetch.
+          if (sendViaBeacon(part)) continue
+          void sendViaFetch(part)
+        } else {
+          await sendViaFetch(part)
+        }
+      }
+    },
+  }
+}

--- a/packages/analytics/src/identity.ts
+++ b/packages/analytics/src/identity.ts
@@ -1,0 +1,64 @@
+import type { AnalyticsStorage, IdentityConfig } from './types.js'
+import { resolveStorage } from './storage.js'
+import { uuidv4, isUuidV4 } from './uuid.js'
+
+const DEFAULT_KEY = 'rfx:analytics:anon'
+
+/**
+ * Identity engine.
+ *
+ * - `anonymousId`: persistent, non-PII, resettable UUIDv4 stored cross-tab.
+ * - `userId`: opaque, app-supplied; never persisted by the library (the app
+ *   owns the user record) — kept only in memory for the active page.
+ * - `alias`: records a previous→current stitch for the wire envelope.
+ */
+export function createIdentity(config?: IdentityConfig) {
+  const storage: AnalyticsStorage = resolveStorage(config?.storage)
+  const key = config?.storageKey ?? DEFAULT_KEY
+
+  let userId: string | undefined
+
+  function loadOrMintAnon(): string {
+    const existing = storage.get(key)
+    if (isUuidV4(existing)) return existing as string
+    const fresh = uuidv4()
+    storage.set(key, fresh)
+    return fresh
+  }
+
+  let anonymousId = loadOrMintAnon()
+
+  return {
+    anonymousId(): string {
+      return anonymousId
+    },
+    userId(): string | undefined {
+      return userId
+    },
+    /** identify(): bind an opaque app user id (no validation, no persistence). */
+    setUserId(id: string): void {
+      userId = id
+    },
+    /**
+     * alias(): returns the stitch pair for the envelope. `previousId`
+     * defaults to the current user or anonymous id.
+     */
+    alias(nextUserId: string, previousId?: string): { userId: string; previousId: string } {
+      const prev = previousId ?? userId ?? anonymousId
+      userId = nextUserId
+      return { userId: nextUserId, previousId: prev }
+    },
+    /**
+     * reset(): privacy-safe logout. Drops the user binding and mints a brand
+     * new anonymousId so the next visitor is not stitched to the old one.
+     */
+    reset(): string {
+      userId = undefined
+      anonymousId = uuidv4()
+      storage.set(key, anonymousId)
+      return anonymousId
+    },
+  }
+}
+
+export type Identity = ReturnType<typeof createIdentity>

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,60 @@
+// Types
+export type {
+  Analytics,
+  AnalyticsConfig,
+  AnalyticsEvent,
+  AnalyticsEventType,
+  AnalyticsProperties,
+  AnalyticsContext,
+  AnalyticsSink,
+  AnalyticsStorage,
+  SinkInitContext,
+  SinkDeliverContext,
+  SessionConfig,
+  SessionAPI,
+  IdentityConfig,
+  ConsentConfig,
+  ConsentAPI,
+  HttpSinkOptions,
+  CallOptions,
+} from './types.js'
+export { SCHEMA_VERSION } from './types.js'
+
+// Manager
+export { createAnalytics } from './analytics-manager.js'
+
+// Built-in sinks
+export { createHttpSink } from './http-sink.js'
+export { createConsoleSink } from './console-sink.js'
+export type { ConsoleSinkOptions } from './console-sink.js'
+
+// Mock sink (for testing)
+export { createMockSink } from './mock-sink.js'
+export type { MockSink, CreateMockSinkOptions } from './mock-sink.js'
+
+// Engines (advanced / standalone use)
+export {
+  createSession,
+  campaignFingerprint,
+  DEFAULT_SESSION_TIMEOUT_MS,
+} from './session.js'
+export { createIdentity } from './identity.js'
+export { createConsent } from './consent.js'
+export {
+  createRedactor,
+  PII_DENY_LIST,
+  PII_EXACT_KEYS,
+  REDACTED,
+} from './redaction.js'
+export type { Redactor } from './redaction.js'
+
+// Storage adapters
+export {
+  createMemoryStorage,
+  createLocalStorageAdapter,
+  createCookieAdapter,
+  resolveStorage,
+} from './storage.js'
+
+// Utilities
+export { uuidv4, isUuidV4, UUID_V4_RE } from './uuid.js'

--- a/packages/analytics/src/mock-sink.ts
+++ b/packages/analytics/src/mock-sink.ts
@@ -1,0 +1,62 @@
+import type {
+  AnalyticsEvent,
+  AnalyticsSink,
+  SinkDeliverContext,
+  SinkInitContext,
+} from './types.js'
+
+/** A mock sink that records every call — used for testing the router. */
+export interface MockSink extends AnalyticsSink {
+  /** All events received across all deliver() calls (flattened). */
+  events: AnalyticsEvent[]
+  /** Each deliver() call's batch + context. */
+  deliveries: Array<{ batch: AnalyticsEvent[]; ctx: SinkDeliverContext }>
+  /** init() call contexts. */
+  initCalls: SinkInitContext[]
+  /** flush() invocation count. */
+  flushCalls: number
+  /** shutdown() invocation count. */
+  shutdownCalls: number
+}
+
+export interface CreateMockSinkOptions {
+  name?: string
+  consentCategories?: string[]
+}
+
+/**
+ * createMockSink — an `AnalyticsSink` that captures everything for assertion.
+ * Mirrors the testing ergonomics of `@refraction-ui/ai`'s mock providers.
+ */
+export function createMockSink(
+  options: CreateMockSinkOptions = {},
+): MockSink {
+  const sink: MockSink = {
+    name: options.name ?? 'mock',
+    consentCategories: options.consentCategories,
+    events: [],
+    deliveries: [],
+    initCalls: [],
+    flushCalls: 0,
+    shutdownCalls: 0,
+
+    init(ctx: SinkInitContext): void {
+      sink.initCalls.push(ctx)
+    },
+
+    deliver(batch: AnalyticsEvent[], ctx: SinkDeliverContext): void {
+      sink.deliveries.push({ batch, ctx })
+      for (const ev of batch) sink.events.push(ev)
+    },
+
+    flush(): void {
+      sink.flushCalls++
+    },
+
+    shutdown(): void {
+      sink.shutdownCalls++
+    },
+  }
+
+  return sink
+}

--- a/packages/analytics/src/noop.ts
+++ b/packages/analytics/src/noop.ts
@@ -1,0 +1,48 @@
+import type { Analytics } from './types.js'
+
+/**
+ * The noop collector returned when `enabled: false`.
+ *
+ * Every method is an empty function so calls are free and the surrounding
+ * vendor/sink code can be tree-shaken out of a production bundle when
+ * analytics is compiled off. Kept in its own module so bundlers can drop the
+ * live collector entirely on the `enabled:false` path.
+ */
+export function createNoopAnalytics(): Analytics {
+  const sessionId = '00000000-0000-4000-8000-000000000000'
+  const noop = (): void => {}
+
+  const api: Analytics = {
+    track: noop,
+    identify: noop,
+    page: noop,
+    screen: noop,
+    group: noop,
+    alias: noop,
+    session: {
+      id: () => sessionId,
+      start: () => sessionId,
+      end: noop,
+      set: noop,
+    },
+    consent: {
+      grant: noop,
+      revoke: noop,
+      granted: () => [],
+      isGranted: () => false,
+    },
+    anonymousId: () => sessionId,
+    userId: () => undefined,
+    with: () => api,
+    addSink: noop,
+    removeSink: noop,
+    get sinks() {
+      return []
+    },
+    flush: async () => {},
+    reset: noop,
+    enabled: false,
+  }
+
+  return api
+}

--- a/packages/analytics/src/redaction.ts
+++ b/packages/analytics/src/redaction.ts
@@ -1,0 +1,93 @@
+import type { AnalyticsProperties } from './types.js'
+
+/**
+ * PII redaction.
+ *
+ * A built-in deny-list of well-known PII key names (email/phone/name and
+ * common variants) plus any caller-supplied `redactKeys`. Matching is
+ * case-insensitive and substring-based so `userEmail`, `email_address`,
+ * `phoneNumber`, `fullName`, etc. are all caught. Redaction recurses into
+ * nested objects and arrays so PII cannot hide one level down.
+ */
+
+/**
+ * Built-in PII deny-list (substring, case-insensitive, separator-insensitive).
+ * These match anywhere in a key, so `userEmail`, `email_address`,
+ * `phoneNumber`, `firstName`, etc. are all caught.
+ */
+export const PII_DENY_LIST: readonly string[] = [
+  'email',
+  'phone',
+  'mobile',
+  'firstname',
+  'lastname',
+  'fullname',
+  'givenname',
+  'surname',
+  'password',
+  'passwd',
+  'ssn',
+  'creditcard',
+  'cardnumber',
+  'cvv',
+  'dob',
+  'dateofbirth',
+  'address',
+]
+
+/**
+ * Keys that are PII only as an *exact* (normalised) match. `name` belongs
+ * here so genuine name fields redact while `username`, `eventName`,
+ * `fileName`, `firstName`-style compounds (handled by the deny-list) do not
+ * over-redact every key that merely contains "name".
+ */
+export const PII_EXACT_KEYS: readonly string[] = ['name']
+
+/** Replacement token written in place of a redacted value. */
+export const REDACTED = '[REDACTED]'
+
+function normalize(key: string): string {
+  return key.toLowerCase().replace(/[_\-\s]/g, '')
+}
+
+/**
+ * Build a key matcher from the deny-list + extra keys. `extra` entries match
+ * exactly (case-insensitive, normalised); deny-list entries match as
+ * substrings.
+ */
+export function createRedactor(extraKeys: string[] = []) {
+  const exact = new Set([
+    ...extraKeys.map(normalize),
+    ...PII_EXACT_KEYS.map(normalize),
+  ])
+  const deny = PII_DENY_LIST.map(normalize)
+
+  const shouldRedact = (key: string): boolean => {
+    const n = normalize(key)
+    if (exact.has(n)) return true
+    return deny.some((d) => n.includes(d))
+  }
+
+  const walk = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(walk)
+    if (value && typeof value === 'object') {
+      const out: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = shouldRedact(k) ? REDACTED : walk(v)
+      }
+      return out
+    }
+    return value
+  }
+
+  return {
+    shouldRedact,
+    /** Redact a properties/traits bag (returns a new object). */
+    redact(props?: AnalyticsProperties): AnalyticsProperties | undefined {
+      if (!props) return props
+      return walk(props) as AnalyticsProperties
+    },
+  }
+}
+
+export type Redactor = ReturnType<typeof createRedactor>

--- a/packages/analytics/src/session.ts
+++ b/packages/analytics/src/session.ts
@@ -1,0 +1,162 @@
+import type {
+  AnalyticsProperties,
+  AnalyticsStorage,
+  SessionConfig,
+} from './types.js'
+import { resolveStorage } from './storage.js'
+import { uuidv4 } from './uuid.js'
+
+/** GA4 parity: 30 minutes of inactivity ends a session. */
+export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000
+
+const DEFAULT_KEY = 'rfx:analytics:session'
+
+interface PersistedSession {
+  id: string
+  /** Last activity epoch ms. */
+  lastActivity: number
+  /** Campaign fingerprint at session start (for campaign-reset). */
+  campaign?: string
+  /** Session-scoped properties (set via session.set). */
+  props?: AnalyticsProperties
+}
+
+/** Recognised campaign params (UTM + common click ids). GA4 parity. */
+const CAMPAIGN_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'gclid',
+  'fbclid',
+  'msclkid',
+]
+
+/**
+ * Derive a stable campaign fingerprint from a URL's query string. A change in
+ * this fingerprint (a *new* campaign, not its absence) forces a new session,
+ * matching GA4's "campaign change resets the session" behaviour.
+ */
+export function campaignFingerprint(search?: string): string | undefined {
+  if (!search) return undefined
+  let qs = search
+  const q = qs.indexOf('?')
+  if (q !== -1) qs = qs.slice(q + 1)
+  let params: URLSearchParams
+  try {
+    params = new URLSearchParams(qs)
+  } catch {
+    return undefined
+  }
+  const pairs: string[] = []
+  for (const p of CAMPAIGN_PARAMS) {
+    const v = params.get(p)
+    if (v) pairs.push(`${p}=${v}`)
+  }
+  return pairs.length ? pairs.join('&') : undefined
+}
+
+/**
+ * Session engine.
+ *
+ * A session is a span of continuous activity. It ends after `timeoutMs` of
+ * inactivity (GA4 parity, default 30 min) or when a *new* campaign is
+ * detected. State is persisted cross-tab so multiple tabs share one session.
+ */
+export function createSession(
+  config?: SessionConfig,
+  now: () => number = () => Date.now(),
+) {
+  const storage: AnalyticsStorage = resolveStorage(config?.storage)
+  const key = config?.storageKey ?? DEFAULT_KEY
+  const timeoutMs = config?.timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS
+  const resetOnCampaign = config?.resetOnCampaign ?? true
+
+  function read(): PersistedSession | null {
+    const raw = storage.get(key)
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw) as PersistedSession
+      if (parsed && typeof parsed.id === 'string') return parsed
+    } catch {
+      /* corrupt — treat as none */
+    }
+    return null
+  }
+
+  function write(s: PersistedSession): void {
+    storage.set(key, JSON.stringify(s))
+  }
+
+  function mint(campaign?: string): PersistedSession {
+    const s: PersistedSession = {
+      id: uuidv4(),
+      lastActivity: now(),
+      campaign,
+    }
+    write(s)
+    return s
+  }
+
+  /**
+   * Return the live session, creating/rotating it as required by the
+   * inactivity timeout and (optionally) a campaign change.
+   */
+  function ensure(campaign?: string): PersistedSession {
+    const existing = read()
+    const t = now()
+
+    if (!existing) return mint(campaign)
+
+    // Inactivity timeout.
+    if (t - existing.lastActivity > timeoutMs) {
+      return mint(campaign)
+    }
+
+    // Campaign reset — only when a *new* campaign appears.
+    if (
+      resetOnCampaign &&
+      campaign !== undefined &&
+      existing.campaign !== campaign
+    ) {
+      return mint(campaign)
+    }
+
+    return existing
+  }
+
+  return {
+    /** Get the current session id, rotating if expired. */
+    id(campaign?: string): string {
+      return ensure(campaign).id
+    },
+    /** Force a brand-new session. */
+    start(campaign?: string): string {
+      return mint(campaign).id
+    },
+    /** End the current session (next id() mints a fresh one). */
+    end(): void {
+      storage.remove(key)
+    },
+    /** Touch activity so the inactivity window slides forward. */
+    touch(campaign?: string): string {
+      const s = ensure(campaign)
+      s.lastActivity = now()
+      write(s)
+      return s.id
+    },
+    /** Attach/merge session-scoped properties. */
+    set(props: AnalyticsProperties): void {
+      const s = ensure()
+      s.props = { ...(s.props ?? {}), ...props }
+      write(s)
+    },
+    /** Read session-scoped properties (undefined when none). */
+    props(): AnalyticsProperties | undefined {
+      return read()?.props
+    },
+  }
+}
+
+export type Session = ReturnType<typeof createSession>

--- a/packages/analytics/src/storage.ts
+++ b/packages/analytics/src/storage.ts
@@ -1,0 +1,119 @@
+import type { AnalyticsStorage } from './types.js'
+
+/**
+ * Storage adapters.
+ *
+ * Order of preference for the cross-tab default: localStorage → cookie →
+ * in-memory. The package is environment-agnostic; consumers can inject any
+ * `AnalyticsStorage` (e.g. an RN AsyncStorage shim) via config.
+ */
+
+/** Volatile per-process store (SSR / Node / no-DOM fallback). */
+export function createMemoryStorage(): AnalyticsStorage {
+  const map = new Map<string, string>()
+  return {
+    get: (k) => (map.has(k) ? (map.get(k) as string) : null),
+    set: (k, v) => {
+      map.set(k, v)
+    },
+    remove: (k) => {
+      map.delete(k)
+    },
+  }
+}
+
+/** `window.localStorage` adapter (cross-tab via the storage event). */
+export function createLocalStorageAdapter(
+  ls: Storage,
+): AnalyticsStorage {
+  return {
+    get: (k) => {
+      try {
+        return ls.getItem(k)
+      } catch {
+        return null
+      }
+    },
+    set: (k, v) => {
+      try {
+        ls.setItem(k, v)
+      } catch {
+        /* quota / disabled — degrade silently */
+      }
+    },
+    remove: (k) => {
+      try {
+        ls.removeItem(k)
+      } catch {
+        /* ignore */
+      }
+    },
+  }
+}
+
+interface CookieDoc {
+  cookie: string
+}
+
+/** `document.cookie` adapter (cross-tab + cross-subdomain capable). */
+export function createCookieAdapter(
+  doc: CookieDoc,
+  maxAgeSeconds = 60 * 60 * 24 * 365,
+): AnalyticsStorage {
+  const read = (k: string): string | null => {
+    const target = encodeURIComponent(k) + '='
+    const parts = doc.cookie ? doc.cookie.split(';') : []
+    for (const part of parts) {
+      const c = part.trim()
+      if (c.startsWith(target)) {
+        return decodeURIComponent(c.slice(target.length))
+      }
+    }
+    return null
+  }
+  return {
+    get: read,
+    set: (k, v) => {
+      doc.cookie = `${encodeURIComponent(k)}=${encodeURIComponent(
+        v,
+      )}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax`
+    },
+    remove: (k) => {
+      doc.cookie = `${encodeURIComponent(k)}=; path=/; max-age=0; SameSite=Lax`
+    },
+  }
+}
+
+/**
+ * Resolve the default storage for the current environment. A caller-supplied
+ * storage always wins. Browser → localStorage (falls back to cookie if
+ * localStorage throws), otherwise in-memory.
+ */
+export function resolveStorage(
+  override?: AnalyticsStorage,
+): AnalyticsStorage {
+  if (override) return override
+
+  const g = globalThis as unknown as {
+    localStorage?: Storage
+    document?: CookieDoc
+  }
+
+  if (g.localStorage) {
+    try {
+      // Probe — Safari private mode throws on setItem.
+      const probe = '__rfx_a_probe__'
+      g.localStorage.setItem(probe, '1')
+      g.localStorage.removeItem(probe)
+      return createLocalStorageAdapter(g.localStorage)
+    } catch {
+      /* fall through to cookie */
+    }
+  }
+
+  if (g.document && typeof g.document.cookie === 'string') {
+    return createCookieAdapter(g.document)
+  }
+
+  return createMemoryStorage()
+}

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,0 +1,273 @@
+/**
+ * @refraction-ui/analytics — type contracts.
+ *
+ * The library is a neutral Segment-spec collector/router. The app instruments
+ * once via the canonical API; the router fans the canonical envelope out to
+ * N pluggable sinks. There is NO privileged engine — every vendor is a sink.
+ */
+
+/** Canonical Segment event types. */
+export type AnalyticsEventType =
+  | 'track'
+  | 'identify'
+  | 'page'
+  | 'screen'
+  | 'group'
+  | 'alias'
+
+/** Schema version stamped onto every envelope and the wire contract path. */
+export const SCHEMA_VERSION = 1
+
+/** Arbitrary, JSON-serialisable bag of values. */
+export type AnalyticsProperties = Record<string, unknown>
+
+/**
+ * The context block attached to every event. `library` identifies the
+ * collector; `app`/`env` identify the product instance.
+ */
+export interface AnalyticsContext {
+  app: string
+  env: string
+  page?: {
+    path?: string
+    url?: string
+    referrer?: string
+    title?: string
+    search?: string
+  }
+  library: {
+    name: string
+    version: string
+  }
+  /** Free-form additions contributed by `with(context)` children. */
+  [key: string]: unknown
+}
+
+/**
+ * The canonical Segment envelope. Every sink receives events in exactly this
+ * shape; the built-in HTTP sink ships it verbatim over the wire contract.
+ */
+export interface AnalyticsEvent {
+  /** Segment call type. */
+  type: AnalyticsEventType
+  /** Event name (track/screen) or page name (page). */
+  event?: string
+  /** Idempotency key — backends MUST dedupe on this. */
+  messageId: string
+  /** Persistent, non-PII, resettable client id. */
+  anonymousId: string
+  /** Opaque app-supplied id (set after identify). */
+  userId?: string
+  /** Group id (group calls). */
+  groupId?: string
+  /** Previous id (alias calls). */
+  previousId?: string
+  /** Analytics session id (UUIDv4, minted at session start). */
+  sessionId: string
+  /** track/page/screen/group payload. */
+  properties?: AnalyticsProperties
+  /** identify/group trait payload. */
+  traits?: AnalyticsProperties
+  /** Collector + product context. */
+  context: AnalyticsContext
+  /** ISO-8601 client timestamp. */
+  timestamp: string
+  /** Envelope schema version. */
+  schemaVersion: number
+}
+
+/**
+ * Sink SPI — implemented by adapter packages (GA4, Azure, PostHog) and by the
+ * built-in HTTP sink. A sink declares the consent categories it requires; the
+ * router will not deliver to a sink whose categories are not all granted.
+ */
+export interface AnalyticsSink {
+  /** Stable sink identifier. */
+  name: string
+  /** Consent categories this sink requires (e.g. ['analytics']). */
+  consentCategories?: string[]
+  /** Called once before the first delivery. */
+  init?(ctx: SinkInitContext): void | Promise<void>
+  /** Deliver a batch of canonical events. */
+  deliver(batch: AnalyticsEvent[], ctx: SinkDeliverContext): void | Promise<void>
+  /** Flush any buffered state (best-effort). */
+  flush?(): void | Promise<void>
+  /** Release resources on reset()/shutdown. */
+  shutdown?(): void | Promise<void>
+}
+
+/** Context handed to `sink.init`. */
+export interface SinkInitContext {
+  app: string
+  env: string
+  endpoint?: string
+}
+
+/** Context handed to every `sink.deliver`. */
+export interface SinkDeliverContext {
+  /** True on the unload path — sinks should prefer sendBeacon. */
+  unload: boolean
+}
+
+/** Cross-tab persistence SPI. Defaults pick localStorage/cookie/memory. */
+export interface AnalyticsStorage {
+  get(key: string): string | null
+  set(key: string, value: string): void
+  remove(key: string): void
+}
+
+/** Session engine configuration. */
+export interface SessionConfig {
+  /** Inactivity timeout in ms before a new session is minted. GA4 = 30min. */
+  timeoutMs?: number
+  /** Reset the session when a campaign/utm change is detected. */
+  resetOnCampaign?: boolean
+  /** Persistence backend; defaults to localStorage→cookie→memory. */
+  storage?: AnalyticsStorage
+  /** Storage key namespace. */
+  storageKey?: string
+}
+
+/** Identity engine configuration. */
+export interface IdentityConfig {
+  /** Persistence backend; defaults to localStorage→cookie→memory. */
+  storage?: AnalyticsStorage
+  /** Storage key namespace. */
+  storageKey?: string
+}
+
+/** Consent gate configuration. */
+export interface ConsentConfig {
+  /** Categories granted at boot. */
+  granted?: string[]
+  /**
+   * If true, an event is dropped entirely when NO sink can receive it.
+   * If false (default), events are still buffered until consent is granted.
+   */
+  strict?: boolean
+}
+
+/** Consent gate runtime API. */
+export interface ConsentAPI {
+  grant(...categories: string[]): void
+  revoke(...categories: string[]): void
+  granted(): string[]
+  isGranted(category: string): boolean
+}
+
+/** Session runtime API. */
+export interface SessionAPI {
+  /** Current session id (mints one lazily if none active). */
+  id(): string
+  /** Force-start a new session, returning the new id. */
+  start(): string
+  /** End the current session. */
+  end(): void
+  /** Attach arbitrary session-scoped properties. */
+  set(props: AnalyticsProperties): void
+}
+
+/** Built-in HTTP sink options (Segment HTTP Tracking API wire contract). */
+export interface HttpSinkOptions {
+  /** Base endpoint; events POST to `{endpoint}/v{schemaVersion}/batch`. */
+  endpoint: string
+  /** Write key — sent as `Authorization: Basic base64(writeKey:)`. */
+  writeKey: string
+  /** Max retries for 429/5xx (exponential backoff). Default 3. */
+  maxRetries?: number
+  /** Base backoff delay in ms. Default 500. */
+  backoffBaseMs?: number
+  /** Injected fetch (defaults to global fetch). */
+  fetchImpl?: typeof fetch
+  /** Injected sendBeacon (defaults to navigator.sendBeacon). */
+  beaconImpl?: (url: string, body: string) => boolean
+  /** Consent categories this sink requires. Default ['analytics']. */
+  consentCategories?: string[]
+  /** Soft per-batch byte cap (Segment ≈ 500KB). Default 500_000. */
+  maxBatchBytes?: number
+  /** Soft per-event byte cap (Segment ≈ 32KB). Default 32_000. */
+  maxEventBytes?: number
+}
+
+/** `createAnalytics` configuration. */
+export interface AnalyticsConfig {
+  /** Product/app identifier (stamped into context.app). */
+  app: string
+  /** Environment, e.g. 'development' | 'production'. Drives presets. */
+  env: string
+  /** When set, a built-in HTTP sink is auto-registered to this endpoint. */
+  endpoint?: string
+  /** Write key for the auto-registered HTTP sink. */
+  writeKey?: string
+  /** Kill switch — when false, a tree-shakeable noop is returned. Default true. */
+  enabled?: boolean
+  /** 0..1 sampling rate applied per top-level call. Default 1. */
+  sampleRate?: number
+  /** Extra property/trait keys to redact (in addition to the PII deny-list). */
+  redactKeys?: string[]
+  /** Explicit sinks (in addition to / instead of the auto HTTP sink). */
+  sinks?: AnalyticsSink[]
+  /** Session engine config. */
+  session?: SessionConfig
+  /** Identity engine config. */
+  identity?: IdentityConfig
+  /** Consent gate config. */
+  consent?: ConsentConfig
+  /**
+   * Force a preset. Defaults: env==='production' → 'prod', else 'dev'.
+   * dev = sync + console; prod = batch + sample + beacon flush on unload.
+   */
+  preset?: 'dev' | 'prod'
+  /** Batch size before an automatic flush (prod). Default 20. */
+  batchSize?: number
+  /** Auto-flush interval in ms (prod). Default 10_000. */
+  flushIntervalMs?: number
+}
+
+/** Options accepted by every top-level call. */
+export interface CallOptions {
+  /** Per-call timestamp override (ISO-8601). */
+  timestamp?: string
+  /** Per-call context overrides (shallow-merged). */
+  context?: Partial<AnalyticsContext>
+}
+
+/** The public analytics surface returned by `createAnalytics`. */
+export interface Analytics {
+  track(event: string, properties?: AnalyticsProperties, opts?: CallOptions): void
+  identify(userId: string, traits?: AnalyticsProperties, opts?: CallOptions): void
+  page(name?: string, properties?: AnalyticsProperties, opts?: CallOptions): void
+  screen(name?: string, properties?: AnalyticsProperties, opts?: CallOptions): void
+  group(groupId: string, traits?: AnalyticsProperties, opts?: CallOptions): void
+  alias(userId: string, previousId?: string, opts?: CallOptions): void
+
+  /** Analytics-session API (NOT replay). */
+  session: SessionAPI
+  /** Consent gate API. */
+  consent: ConsentAPI
+
+  /** Persistent, non-PII anonymous id. */
+  anonymousId(): string
+  /** Current opaque user id (if identified). */
+  userId(): string | undefined
+
+  /** Derive a child that merges extra context into every event. */
+  with(context: Partial<AnalyticsContext>): Analytics
+
+  /** Register an additional sink at runtime. */
+  addSink(sink: AnalyticsSink): void
+  /** Remove a sink by name. */
+  removeSink(name: string): void
+  /** Registered sink names. */
+  readonly sinks: string[]
+
+  /** Flush all sinks (and the internal batch). */
+  flush(): Promise<void>
+  /**
+   * Reset identity + session (privacy-safe logout). Mints a fresh
+   * anonymousId and ends the session.
+   */
+  reset(): void
+  /** Whether this is a live collector (false for the noop). */
+  readonly enabled: boolean
+}

--- a/packages/analytics/src/uuid.ts
+++ b/packages/analytics/src/uuid.ts
@@ -1,0 +1,63 @@
+/**
+ * uuidv4 — RFC 4122 version 4 UUID.
+ *
+ * Prefers `crypto.randomUUID` / `crypto.getRandomValues` when available
+ * (browser, modern Node) and degrades to `Math.random` only as a last
+ * resort. No external dependency by design (this is the neutral router).
+ */
+export function uuidv4(): string {
+  const c: Crypto | undefined =
+    typeof globalThis !== 'undefined'
+      ? (globalThis.crypto as Crypto | undefined)
+      : undefined
+
+  if (c && typeof c.randomUUID === 'function') {
+    return c.randomUUID()
+  }
+
+  const bytes = new Uint8Array(16)
+  if (c && typeof c.getRandomValues === 'function') {
+    c.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256)
+  }
+
+  // Per RFC 4122 §4.4: set version (4) and variant (10xx) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex: string[] = []
+  for (let i = 0; i < 256; i++) hex.push((i + 0x100).toString(16).slice(1))
+
+  return (
+    hex[bytes[0]] +
+    hex[bytes[1]] +
+    hex[bytes[2]] +
+    hex[bytes[3]] +
+    '-' +
+    hex[bytes[4]] +
+    hex[bytes[5]] +
+    '-' +
+    hex[bytes[6]] +
+    hex[bytes[7]] +
+    '-' +
+    hex[bytes[8]] +
+    hex[bytes[9]] +
+    '-' +
+    hex[bytes[10]] +
+    hex[bytes[11]] +
+    hex[bytes[12]] +
+    hex[bytes[13]] +
+    hex[bytes[14]] +
+    hex[bytes[15]]
+  )
+}
+
+/** RFC 4122 v4 shape matcher (case-insensitive). */
+export const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/** True when `value` is a well-formed v4 UUID. */
+export function isUuidV4(value: unknown): value is string {
+  return typeof value === 'string' && UUID_V4_RE.test(value)
+}

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/analytics/tsup.config.ts
+++ b/packages/analytics/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+})

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,12 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/analytics:
+    dependencies:
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+
   packages/angular-accordion:
     dependencies:
       '@angular/core':


### PR DESCRIPTION
Wave 0 of epic #213. Neutral Segment-spec collector/router — no privileged engine; vendors are sinks. `createAnalytics()` (track/identify/page/screen/group/alias), session + identity + consent engine (UUIDv4 sessionId, 30-min GA4-parity timeout, non-PII anonymousId, per-sink consent), and the built-in **HTTP sink implementing the Segment HTTP Tracking API wire contract** (batch envelope, messageId idempotency, sendBeacon `?writeKey=` fallback, 400/401/413/429/5xx semantics + backoff). dev/prod presets, tree-shakeable noop.

✅ build / typecheck / lint exit 0 · **95/95 tests passing** (incl. wire-contract tests vs mock backend) on latest `main`.

Closes #214.