### PR TITLE
feat(react-analytics): @refraction-ui/react-analytics adapter (#215)

### DIFF
--- a/.changeset/react-analytics-init.md
+++ b/.changeset/react-analytics-init.md
@@ -1,0 +1,6 @@
+---
+"@refraction-ui/analytics": minor
+"@refraction-ui/react-analytics": minor
+---
+
+feat: add @refraction-ui/analytics events/sessions core and @refraction-ui/react-analytics adapter

--- a/packages/react-analytics/__tests__/analytics-provider.test.tsx
+++ b/packages/react-analytics/__tests__/analytics-provider.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  AnalyticsProvider,
+  useAnalytics,
+  useTrackEvent,
+} from '../src/analytics-provider.js'
+import { createAnalytics, createMockSink } from '@refraction-ui/analytics'
+
+function makeAnalytics() {
+  const sink = createMockSink()
+  const analytics = createAnalytics({
+    app: 'test-app',
+    env: 'development',
+    preset: 'dev',
+    sinks: [sink],
+    consent: { granted: ['analytics'] },
+  })
+  return { analytics, sink }
+}
+
+describe('AnalyticsProvider (SSR)', () => {
+  it('renders children', () => {
+    const { analytics } = makeAnalytics()
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement('div', null, 'Analytics App'),
+      ),
+    )
+    expect(html).toContain('Analytics App')
+  })
+
+  it('renders with a real analytics instance', () => {
+    const { analytics } = makeAnalytics()
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement('span', null, 'Hello Analytics'),
+      ),
+    )
+    expect(html).toContain('Hello Analytics')
+  })
+})
+
+describe('useAnalytics (SSR)', () => {
+  it('returns the provided Analytics instance', () => {
+    const { analytics } = makeAnalytics()
+    let received: unknown
+    function TestConsumer() {
+      received = useAnalytics()
+      return React.createElement('span', null, 'ok')
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('ok')
+    expect(received).toBe(analytics)
+  })
+
+  it('exposes the full Analytics surface', () => {
+    const { analytics } = makeAnalytics()
+    function TestConsumer() {
+      const a = useAnalytics()
+      return React.createElement('div', null,
+        React.createElement('span', null, typeof a.track === 'function' ? 'has-track' : 'missing'),
+        React.createElement('span', null, typeof a.identify === 'function' ? 'has-identify' : 'missing'),
+        React.createElement('span', null, typeof a.with === 'function' ? 'has-with' : 'missing'),
+        React.createElement('span', { 'data-enabled': String(a.enabled) }),
+      )
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('has-track')
+    expect(html).toContain('has-identify')
+    expect(html).toContain('has-with')
+    expect(html).toContain('data-enabled="true"')
+  })
+
+  it('returns a with() child when given a scope', () => {
+    const { analytics } = makeAnalytics()
+    let scoped: unknown
+    function TestConsumer() {
+      scoped = useAnalytics({ scope: { feature: 'checkout' } })
+      return React.createElement('span', null, 'scoped')
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('scoped')
+    expect(scoped).not.toBe(analytics)
+    expect(typeof (scoped as { track: unknown }).track).toBe('function')
+  })
+
+  it('throws when used outside AnalyticsProvider', () => {
+    function TestConsumer() {
+      useAnalytics()
+      return React.createElement('span', null, 'never')
+    }
+    expect(() => {
+      renderToString(React.createElement(TestConsumer))
+    }).toThrow(/useAnalytics.*AnalyticsProvider/i)
+  })
+})
+
+describe('useTrackEvent (SSR)', () => {
+  it('emits a track event to the underlying sink', () => {
+    const { analytics, sink } = makeAnalytics()
+    function TestConsumer() {
+      const track = useTrackEvent()
+      track('Signup Clicked', { plan: 'pro' })
+      return React.createElement('span', null, 'tracked')
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('tracked')
+    expect(sink.events).toHaveLength(1)
+    expect(sink.events[0]).toMatchObject({
+      type: 'track',
+      event: 'Signup Clicked',
+      properties: { plan: 'pro' },
+    })
+  })
+
+  it('emits scoped context when given a scope', () => {
+    const { analytics, sink } = makeAnalytics()
+    function TestConsumer() {
+      const track = useTrackEvent({ scope: { feature: 'checkout' } })
+      track('Card Added')
+      return React.createElement('span', null, 'tracked-scoped')
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('tracked-scoped')
+    expect(sink.events).toHaveLength(1)
+    expect(sink.events[0]).toMatchObject({
+      type: 'track',
+      event: 'Card Added',
+      context: { feature: 'checkout' },
+    })
+  })
+
+  it('provides a bound track function', () => {
+    const { analytics } = makeAnalytics()
+    let bound: unknown
+    function TestConsumer() {
+      bound = useTrackEvent()
+      return React.createElement('span', null, 'bound')
+    }
+    const html = renderToString(
+      React.createElement(AnalyticsProvider, { value: analytics },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('bound')
+    expect(typeof bound).toBe('function')
+  })
+})

--- a/packages/react-analytics/package.json
+++ b/packages/react-analytics/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@refraction-ui/react-analytics",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/analytics": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/react-analytics"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/react-analytics/src/analytics-provider.tsx
+++ b/packages/react-analytics/src/analytics-provider.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import type {
+  Analytics,
+  AnalyticsContext as AnalyticsEventContext,
+  AnalyticsProperties,
+  CallOptions,
+} from '@refraction-ui/analytics'
+
+const AnalyticsContext = React.createContext<Analytics | null>(null)
+
+export interface AnalyticsProviderProps {
+  children: React.ReactNode
+  /**
+   * The `Analytics` instance to expose. Construct it once with
+   * `createAnalytics(...)` from `@refraction-ui/analytics`.
+   */
+  value: Analytics
+}
+
+/**
+ * AnalyticsProvider — wraps your app with analytics context.
+ *
+ * ```tsx
+ * <AnalyticsProvider value={createAnalytics({ app: 'my-app', env: 'production' })}>
+ *   <App />
+ * </AnalyticsProvider>
+ * ```
+ */
+export function AnalyticsProvider({ children, value }: AnalyticsProviderProps) {
+  const analyticsRef = React.useRef<Analytics | null>(null)
+
+  if (!analyticsRef.current) {
+    analyticsRef.current = value
+  }
+
+  return React.createElement(
+    AnalyticsContext.Provider,
+    { value: analyticsRef.current },
+    children,
+  )
+}
+
+export interface UseAnalyticsOptions {
+  /** When set, returns a `with({ ...scope })` child bound to the context. */
+  scope?: Partial<AnalyticsEventContext>
+}
+
+/**
+ * useAnalytics — access the `Analytics` instance from context.
+ *
+ * Pass `{ scope }` to receive a `with(...)` child whose context is merged
+ * into every event. Must be used within an `<AnalyticsProvider>`.
+ */
+export function useAnalytics(options?: UseAnalyticsOptions): Analytics {
+  const ctx = React.useContext(AnalyticsContext)
+  if (!ctx) {
+    throw new Error('useAnalytics must be used within an <AnalyticsProvider>')
+  }
+  const scope = options?.scope
+  return React.useMemo<Analytics>(
+    () => (scope ? ctx.with(scope) : ctx),
+    [ctx, scope],
+  )
+}
+
+/**
+ * useTrackEvent — a stable, bound `track` for the current context.
+ *
+ * ```tsx
+ * const track = useTrackEvent()
+ * track('Signup Clicked', { plan: 'pro' })
+ * ```
+ */
+export function useTrackEvent(
+  options?: UseAnalyticsOptions,
+): (event: string, properties?: AnalyticsProperties, opts?: CallOptions) => void {
+  const analytics = useAnalytics(options)
+  return React.useCallback(
+    (event: string, properties?: AnalyticsProperties, opts?: CallOptions) =>
+      analytics.track(event, properties, opts),
+    [analytics],
+  )
+}

--- a/packages/react-analytics/src/index.ts
+++ b/packages/react-analytics/src/index.ts
@@ -1,0 +1,23 @@
+// Analytics Provider and hooks
+export {
+  AnalyticsProvider,
+  useAnalytics,
+  useTrackEvent,
+} from './analytics-provider.js'
+export type {
+  AnalyticsProviderProps,
+  UseAnalyticsOptions,
+} from './analytics-provider.js'
+
+// Re-export core types/factory for convenience
+export { createAnalytics } from '@refraction-ui/analytics'
+export type {
+  Analytics,
+  AnalyticsConfig,
+  AnalyticsEvent,
+  AnalyticsEventType,
+  AnalyticsProperties,
+  AnalyticsContext,
+  AnalyticsSink,
+  CallOptions,
+} from '@refraction-ui/analytics'

--- a/packages/react-analytics/tsconfig.json
+++ b/packages/react-analytics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/react-analytics/tsup.config.ts
+++ b/packages/react-analytics/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ['react', 'react-dom'],
+})

--- a/packages/react-analytics/vitest.config.ts
+++ b/packages/react-analytics/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2303,6 +2303,28 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
 
+  packages/react-analytics:
+    dependencies:
+      '@refraction-ui/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/react':
+        specifier: 19.0.0
+        version: 19.0.0
+      '@types/react-dom':
+        specifier: 19.0.0
+        version: 19.0.0
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+
   packages/react-animated-text:
     dependencies:
       '@refraction-ui/animated-text':


### PR DESCRIPTION
Wave 1 of epic #213. React adapter mirroring react-ai: `AnalyticsProvider` (instance via `value=`), `useAnalytics()` / `useAnalytics({scope})`, `useTrackEvent()`. Exercises the real analytics core via its mock sink. Includes Changeset (analytics + react-analytics `minor`) → triggers canary on merge per repo release flow.

✅ turbo build/test/typecheck/lint exit 0 · 9 tests. Closes #215.