### PR TITLE
feat(react-logger): @refraction-ui/react-logger adapter (#208)

### DIFF
--- a/.changeset/react-logger-init.md
+++ b/.changeset/react-logger-init.md
@@ -1,0 +1,6 @@
+---
+"@refraction-ui/logger": minor
+"@refraction-ui/react-logger": minor
+---
+
+feat: add @refraction-ui/logger telemetry core and @refraction-ui/react-logger adapter

--- a/packages/react-logger/__tests__/error-boundary.test.tsx
+++ b/packages/react-logger/__tests__/error-boundary.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { createTelemetry, createMockSink } from '@refraction-ui/logger'
+import { TelemetryErrorBoundary } from '../src/error-boundary.js'
+import { TelemetryProvider } from '../src/telemetry-provider.js'
+
+function Boom(): React.ReactElement {
+  throw new Error('render exploded')
+}
+
+describe('TelemetryErrorBoundary (SSR)', () => {
+  it('renders children when nothing throws', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement(
+          TelemetryErrorBoundary,
+          null,
+          React.createElement('div', null, 'safe content'),
+        ),
+      ),
+    )
+    expect(html).toContain('safe content')
+  })
+})
+
+/**
+ * React 19's legacy `renderToString` rethrows synchronous render errors
+ * instead of letting an error boundary recover (boundary recovery requires a
+ * browser/DOM commit, or a streaming renderer). The boundary's state + render
+ * logic is therefore covered directly here; a jsdom mount would additionally
+ * exercise the React commit wiring, but no DOM test infra exists in this
+ * monorepo and adding one is out of scope for this package.
+ */
+describe('TelemetryErrorBoundary fallback rendering', () => {
+  it('derives error state via getDerivedStateFromError', () => {
+    const error = new Error('render exploded')
+    expect(TelemetryErrorBoundary.getDerivedStateFromError(error)).toEqual({
+      error,
+    })
+  })
+
+  it('renders children while no error is held', () => {
+    const boundary = new TelemetryErrorBoundary({
+      children: React.createElement('div', null, 'safe content'),
+    })
+    expect(boundary.render()).toEqual(
+      React.createElement('div', null, 'safe content'),
+    )
+  })
+
+  it('renders a node fallback after an error', () => {
+    const boundary = new TelemetryErrorBoundary({
+      children: React.createElement(Boom),
+      fallback: React.createElement('p', null, 'fallback shown'),
+    })
+    boundary.state = { error: new Error('render exploded') }
+    expect(boundary.render()).toEqual(
+      React.createElement('p', null, 'fallback shown'),
+    )
+  })
+
+  it('renders a render-prop fallback receiving the error and reset', () => {
+    const error = new Error('render exploded')
+    const boundary = new TelemetryErrorBoundary({
+      children: React.createElement(Boom),
+      fallback: (e: Error) =>
+        React.createElement('p', null, `caught: ${e.message}`),
+    })
+    boundary.state = { error }
+    expect(boundary.render()).toEqual(
+      React.createElement('p', null, 'caught: render exploded'),
+    )
+  })
+
+  it('renders null fallback by default after an error', () => {
+    const boundary = new TelemetryErrorBoundary({
+      children: React.createElement(Boom),
+    })
+    boundary.state = { error: new Error('render exploded') }
+    expect(boundary.render()).toBeNull()
+  })
+})
+
+/**
+ * `componentDidCatch` is not invoked during `renderToString` (React only
+ * calls `getDerivedStateFromError` on the server). The reporting path is
+ * therefore exercised directly against the real `@refraction-ui/logger`
+ * core + a recording sink — no stubs. A full DOM mount (jsdom + RTL) would
+ * additionally cover the lifecycle wiring, but no DOM test infra exists in
+ * this monorepo and adding one is out of scope for this package.
+ */
+describe('TelemetryErrorBoundary reporting (componentDidCatch)', () => {
+  it('reports a captured error to the telemetry sink at error level', () => {
+    const telemetry = createTelemetry({ app: 'test-app', env: 'development' })
+    const sink = createMockSink('boundary-sink')
+    telemetry.addSink(sink)
+
+    const boundary = new TelemetryErrorBoundary({
+      children: null,
+      context: { sessionId: 's-9' },
+    })
+    boundary.context = { telemetry }
+
+    const error = new Error('render exploded')
+    boundary.componentDidCatch(error, {
+      componentStack: '\n    in Boom\n    in TelemetryErrorBoundary',
+    } as React.ErrorInfo)
+
+    expect(sink.logs).toHaveLength(1)
+    const record = sink.logs[0]
+    expect(record.level).toBe('error')
+    expect(record.message).toBe('render exploded')
+    expect(record.context.name).toBe('Error')
+    expect(record.context.sessionId).toBe('s-9')
+    expect(record.context.componentStack).toContain('in Boom')
+  })
+
+  it('invokes the onError callback after reporting', () => {
+    const telemetry = createTelemetry({ app: 'test-app', env: 'development' })
+    const sink = createMockSink('boundary-sink-2')
+    telemetry.addSink(sink)
+
+    let received: Error | null = null
+    const boundary = new TelemetryErrorBoundary({
+      children: null,
+      onError: (err) => {
+        received = err
+      },
+    })
+    boundary.context = { telemetry }
+
+    const error = new Error('callback path')
+    boundary.componentDidCatch(error, {
+      componentStack: '',
+    } as React.ErrorInfo)
+
+    expect(received).toBe(error)
+    expect(sink.logs).toHaveLength(1)
+  })
+
+  it('does not throw when rendered without a TelemetryProvider', () => {
+    const boundary = new TelemetryErrorBoundary({ children: null })
+    boundary.context = null
+    expect(() =>
+      boundary.componentDidCatch(new Error('no provider'), {
+        componentStack: '',
+      } as React.ErrorInfo),
+    ).not.toThrow()
+  })
+})

--- a/packages/react-logger/__tests__/telemetry-provider.test.tsx
+++ b/packages/react-logger/__tests__/telemetry-provider.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  TelemetryProvider,
+  useTelemetry,
+  useLogger,
+} from '../src/telemetry-provider.js'
+
+describe('TelemetryProvider (SSR)', () => {
+  it('renders children', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement('div', null, 'Telemetry App'),
+      ),
+    )
+    expect(html).toContain('Telemetry App')
+  })
+
+  it('renders with development config', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement('span', null, 'Hello Telemetry'),
+      ),
+    )
+    expect(html).toContain('Hello Telemetry')
+  })
+
+  it('renders with production config', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'production', sampleRate: 0.5 },
+        React.createElement('span', null, 'Configured Telemetry'),
+      ),
+    )
+    expect(html).toContain('Configured Telemetry')
+  })
+
+  it('renders with enabled:false (kill switch)', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development', enabled: false },
+        React.createElement('span', null, 'Noop Telemetry'),
+      ),
+    )
+    expect(html).toContain('Noop Telemetry')
+  })
+})
+
+describe('useTelemetry (SSR)', () => {
+  function TestConsumer() {
+    const telemetry = useTelemetry()
+    return React.createElement(
+      'div',
+      null,
+      React.createElement('span', {
+        'data-sinks': JSON.stringify(telemetry.sinks),
+      }),
+      React.createElement(
+        'span',
+        null,
+        typeof telemetry.info === 'function' ? 'has-info' : 'missing',
+      ),
+      React.createElement(
+        'span',
+        null,
+        typeof telemetry.child === 'function' ? 'has-child' : 'missing',
+      ),
+      React.createElement(
+        'span',
+        null,
+        typeof telemetry.startSpan === 'function' ? 'has-startSpan' : 'missing',
+      ),
+    )
+  }
+
+  it('provides the telemetry logger API', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('has-info')
+    expect(html).toContain('has-child')
+    expect(html).toContain('has-startSpan')
+  })
+
+  it('exposes the default console sink', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement(TestConsumer),
+      ),
+    )
+    expect(html).toContain('console')
+  })
+
+  it('throws when used outside TelemetryProvider', () => {
+    expect(() => {
+      renderToString(React.createElement(TestConsumer))
+    }).toThrow(/useTelemetry.*TelemetryProvider/i)
+  })
+})
+
+describe('useLogger (SSR)', () => {
+  function ScopedConsumer({ scope }: { scope?: Record<string, unknown> }) {
+    const logger = useLogger(scope)
+    const root = useTelemetry()
+    return React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'span',
+        null,
+        typeof logger.info === 'function' ? 'has-info' : 'missing',
+      ),
+      React.createElement('span', {
+        'data-is-root': String(logger === root),
+      }),
+    )
+  }
+
+  it('returns the root logger when no scope is given', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement(ScopedConsumer),
+      ),
+    )
+    expect(html).toContain('has-info')
+    expect(html).toContain('data-is-root="true"')
+  })
+
+  it('returns a distinct scoped child logger when a scope is given', () => {
+    const html = renderToString(
+      React.createElement(
+        TelemetryProvider,
+        { app: 'test-app', env: 'development' },
+        React.createElement(ScopedConsumer, { scope: { sessionId: 's-1' } }),
+      ),
+    )
+    expect(html).toContain('has-info')
+    expect(html).toContain('data-is-root="false"')
+  })
+
+  it('throws when used outside TelemetryProvider', () => {
+    expect(() => {
+      renderToString(React.createElement(ScopedConsumer))
+    }).toThrow(/useTelemetry.*TelemetryProvider/i)
+  })
+})

--- a/packages/react-logger/__tests__/use-span.test.tsx
+++ b/packages/react-logger/__tests__/use-span.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { createMockSink } from '@refraction-ui/logger'
+import { TelemetryProvider, useTelemetry } from '../src/telemetry-provider.js'
+import { useSpan, type UseSpanAPI } from '../src/use-span.js'
+
+/**
+ * `renderToString` does not run effects/state updates, so we capture the
+ * hook's API and the telemetry instance during render and exercise the span
+ * lifecycle against the real `@refraction-ui/logger` core afterwards.
+ */
+function renderSpanHarness(): {
+  api: UseSpanAPI
+  sink: ReturnType<typeof createMockSink>
+} {
+  let api!: UseSpanAPI
+  const sink = createMockSink('test-span-sink')
+
+  function Harness() {
+    const telemetry = useTelemetry()
+    // Register the recording sink once, on first render.
+    if (!telemetry.sinks.includes('test-span-sink')) {
+      telemetry.addSink(sink)
+    }
+    api = useSpan()
+    return React.createElement('span', null, 'span-harness')
+  }
+
+  const html = renderToString(
+    React.createElement(
+      TelemetryProvider,
+      // development preset: sync delivery, no batching/sampling.
+      { app: 'test-app', env: 'development' },
+      React.createElement(Harness),
+    ),
+  )
+  expect(html).toContain('span-harness')
+  return { api, sink }
+}
+
+describe('useSpan', () => {
+  it('provides start/end and isActive', () => {
+    const { api } = renderSpanHarness()
+    expect(typeof api.start).toBe('function')
+    expect(typeof api.end).toBe('function')
+    expect(api.isActive).toBe(false)
+  })
+
+  it('opens and closes a span, emitting a span record to the sink', () => {
+    const { api, sink } = renderSpanHarness()
+
+    api.start('llm-call', { model: 'gpt' })
+    expect(sink.spans).toHaveLength(0)
+
+    api.end()
+    expect(sink.spans).toHaveLength(1)
+    const span = sink.spans[0]
+    expect(span.name).toBe('llm-call')
+    expect(span.status).toBe('ok')
+    expect(span.context.model).toBe('gpt')
+    expect(span.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('records an error span when ended with an error', () => {
+    const { api, sink } = renderSpanHarness()
+
+    api.start('failing-op')
+    api.end({ error: new Error('boom') })
+
+    expect(sink.spans).toHaveLength(1)
+    expect(sink.spans[0].status).toBe('error')
+    expect(sink.spans[0].error).toEqual({ name: 'Error', message: 'boom' })
+  })
+
+  it('ends the previous span before starting a new one', () => {
+    const { api, sink } = renderSpanHarness()
+
+    api.start('first')
+    api.start('second')
+    expect(sink.spans).toHaveLength(1)
+    expect(sink.spans[0].name).toBe('first')
+
+    api.end()
+    expect(sink.spans).toHaveLength(2)
+    expect(sink.spans[1].name).toBe('second')
+  })
+
+  it('end() is a no-op when no span is in flight', () => {
+    const { api, sink } = renderSpanHarness()
+    api.end()
+    expect(sink.spans).toHaveLength(0)
+  })
+})

--- a/packages/react-logger/package.json
+++ b/packages/react-logger/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@refraction-ui/react-logger",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts,.tsx",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/logger": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/react-logger"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/react-logger/src/error-boundary.tsx
+++ b/packages/react-logger/src/error-boundary.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import type { LogContext } from '@refraction-ui/logger'
+import { TelemetryContext, type TelemetryContextValue } from './telemetry-provider.js'
+
+export interface TelemetryErrorBoundaryProps {
+  children: React.ReactNode
+  /**
+   * Fallback UI rendered after an error is caught. May be a node or a render
+   * function receiving the captured error and a reset callback.
+   */
+  fallback?:
+    | React.ReactNode
+    | ((error: Error, reset: () => void) => React.ReactNode)
+  /** Extra bound context attached to the reported error record. */
+  context?: LogContext
+  /** Invoked after the error has been reported to the telemetry sink. */
+  onError?: (error: Error, info: React.ErrorInfo) => void
+}
+
+interface TelemetryErrorBoundaryState {
+  error: Error | null
+}
+
+/**
+ * TelemetryErrorBoundary — a React error boundary that reports caught render
+ * errors to the provider's telemetry sink (at `error` level) before showing
+ * an optional fallback.
+ *
+ * ```tsx
+ * <TelemetryErrorBoundary fallback={<p>Something broke.</p>}>
+ *   <App />
+ * </TelemetryErrorBoundary>
+ * ```
+ *
+ * Must be used within <TelemetryProvider>.
+ */
+export class TelemetryErrorBoundary extends React.Component<
+  TelemetryErrorBoundaryProps,
+  TelemetryErrorBoundaryState
+> {
+  static contextType = TelemetryContext
+  declare context: TelemetryContextValue | null
+
+  state: TelemetryErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): TelemetryErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    const telemetry = this.context?.telemetry
+    if (telemetry) {
+      telemetry.error(error.message, {
+        ...this.props.context,
+        name: error.name,
+        stack: error.stack,
+        componentStack: info.componentStack,
+      })
+    }
+    this.props.onError?.(error, info)
+  }
+
+  reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state
+    if (error) {
+      const { fallback } = this.props
+      if (typeof fallback === 'function') {
+        return fallback(error, this.reset)
+      }
+      return fallback ?? null
+    }
+    return this.props.children
+  }
+}

--- a/packages/react-logger/src/index.ts
+++ b/packages/react-logger/src/index.ts
@@ -1,0 +1,28 @@
+// Telemetry provider and hooks
+export { TelemetryProvider, useTelemetry, useLogger } from './telemetry-provider.js'
+export type {
+  TelemetryProviderProps,
+  TelemetryContextValue,
+} from './telemetry-provider.js'
+
+// Span hook
+export { useSpan } from './use-span.js'
+export type { UseSpanAPI } from './use-span.js'
+
+// Error boundary
+export { TelemetryErrorBoundary } from './error-boundary.js'
+export type { TelemetryErrorBoundaryProps } from './error-boundary.js'
+
+// Re-export core types for convenience
+export type {
+  Telemetry,
+  Logger,
+  Span,
+  LogContext,
+  LogLevel,
+  LogRecord,
+  SpanRecord,
+  TelemetryConfig,
+  TelemetryEnv,
+  TelemetrySink,
+} from '@refraction-ui/logger'

--- a/packages/react-logger/src/telemetry-provider.tsx
+++ b/packages/react-logger/src/telemetry-provider.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import {
+  createTelemetry,
+  type TelemetryConfig,
+  type Telemetry,
+  type Logger,
+  type LogContext,
+} from '@refraction-ui/logger'
+
+export interface TelemetryContextValue {
+  /** The root telemetry instance (a logger bound to the empty root context). */
+  telemetry: Telemetry
+}
+
+export const TelemetryContext = React.createContext<TelemetryContextValue | null>(null)
+
+export interface TelemetryProviderProps extends TelemetryConfig {
+  children: React.ReactNode
+}
+
+/**
+ * TelemetryProvider — wraps your app with telemetry context.
+ *
+ * ```tsx
+ * <TelemetryProvider app="interview-service" env="production">
+ *   <App />
+ * </TelemetryProvider>
+ * ```
+ */
+export function TelemetryProvider({ children, ...config }: TelemetryProviderProps) {
+  const telemetryRef = React.useRef<Telemetry | null>(null)
+
+  if (!telemetryRef.current) {
+    telemetryRef.current = createTelemetry(config)
+  }
+
+  const value = React.useMemo<TelemetryContextValue>(
+    () => ({ telemetry: telemetryRef.current! }),
+    [],
+  )
+
+  return React.createElement(TelemetryContext.Provider, { value }, children)
+}
+
+/**
+ * useTelemetry — access the root telemetry instance.
+ * Must be used within <TelemetryProvider>.
+ */
+export function useTelemetry(): Telemetry {
+  const ctx = React.useContext(TelemetryContext)
+  if (!ctx) {
+    throw new Error('useTelemetry must be used within a <TelemetryProvider>')
+  }
+  return ctx.telemetry
+}
+
+/**
+ * useLogger — derive a scoped child logger with bound context (e.g.
+ * `{ sessionId, interviewId, turnId }`). The logger is memoized so it stays
+ * stable across renders for the same scope. With no scope, the root telemetry
+ * logger is returned.
+ *
+ * Must be used within <TelemetryProvider>.
+ */
+export function useLogger(scope?: LogContext): Logger {
+  const telemetry = useTelemetry()
+  const scopeKey = scope ? JSON.stringify(scope) : ''
+  return React.useMemo<Logger>(
+    () => (scope ? telemetry.child(scope) : telemetry),
+    [telemetry, scope, scopeKey],
+  )
+}

--- a/packages/react-logger/src/use-span.ts
+++ b/packages/react-logger/src/use-span.ts
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import type { LogContext, Span } from '@refraction-ui/logger'
+import { useTelemetry } from './telemetry-provider.js'
+
+export interface UseSpanAPI {
+  /**
+   * Begin a span tied to the provider's telemetry instance. Returns the
+   * {@link Span}; call {@link Span.end} (or {@link UseSpanAPI.end}) to record
+   * its duration. Starting a new span while one is active ends the previous
+   * one first so a single hook owns at most one in-flight span.
+   */
+  start: (name: string, attributes?: LogContext) => Span
+  /** End the active span (no-op if none is in flight). Idempotent per span. */
+  end: (opts?: { error?: unknown; attributes?: LogContext }) => void
+  /** Whether a span started by this hook is currently in flight. */
+  isActive: boolean
+}
+
+/**
+ * useSpan — start/end a telemetry span tied to the provider's telemetry
+ * instance. The active span is cleaned up automatically on unmount.
+ *
+ * ```tsx
+ * const span = useSpan()
+ * useEffect(() => {
+ *   span.start('llm-call', { model: 'gpt' })
+ *   return () => span.end()
+ * }, [])
+ * ```
+ *
+ * Must be used within <TelemetryProvider>.
+ */
+export function useSpan(): UseSpanAPI {
+  const telemetry = useTelemetry()
+  const spanRef = React.useRef<Span | null>(null)
+  const [isActive, setIsActive] = React.useState(false)
+
+  const end = React.useCallback(
+    (opts?: { error?: unknown; attributes?: LogContext }) => {
+      if (!spanRef.current) return
+      spanRef.current.end(opts)
+      spanRef.current = null
+      setIsActive(false)
+    },
+    [],
+  )
+
+  const start = React.useCallback(
+    (name: string, attributes?: LogContext): Span => {
+      if (spanRef.current) {
+        spanRef.current.end()
+      }
+      const span = telemetry.startSpan(name, attributes)
+      spanRef.current = span
+      setIsActive(true)
+      return span
+    },
+    [telemetry],
+  )
+
+  React.useEffect(() => {
+    return () => {
+      if (spanRef.current) {
+        spanRef.current.end()
+        spanRef.current = null
+      }
+    }
+  }, [])
+
+  return React.useMemo<UseSpanAPI>(
+    () => ({ start, end, isActive }),
+    [start, end, isActive],
+  )
+}

--- a/packages/react-logger/tsconfig.json
+++ b/packages/react-logger/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/react-logger/tsup.config.ts
+++ b/packages/react-logger/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ['react', 'react-dom'],
+})

--- a/packages/react-logger/vitest.config.ts
+++ b/packages/react-logger/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3291,6 +3291,28 @@ importers:
         specifier: 18.0.0
         version: 18.0.0(react@18.0.0)
 
+  packages/react-logger:
+    dependencies:
+      '@refraction-ui/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/react':
+        specifier: 19.0.0
+        version: 19.0.0
+      '@types/react-dom':
+        specifier: 19.0.0
+        version: 19.0.0
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+
   packages/react-markdown-renderer:
     dependencies:
       '@refraction-ui/markdown-renderer':


### PR DESCRIPTION
Wave 1 of epic #206. React adapter mirroring react-ai: `TelemetryProvider`, `useTelemetry()`, `useLogger(scope?)`, `useSpan()`, `TelemetryErrorBoundary` (reports to the sink). Exercises the real logger core + mock sink. Changeset (logger + react-logger `minor`) → canary on merge.

✅ turbo build/test/typecheck/lint exit 0 · 24 tests. Closes #208.