### PR TITLE
feat(angular-logger): @refraction-ui/angular-logger adapter (#210)

### DIFF
--- a/.changeset/angular-logger-init.md
+++ b/.changeset/angular-logger-init.md
@@ -1,0 +1,5 @@
+---
+"@refraction-ui/angular-logger": minor
+---
+
+feat: add @refraction-ui/angular-logger — injectable Angular service + provider wrapping the @refraction-ui/logger core (scoped child loggers + spans, vendor-neutral)

--- a/packages/angular-logger/__tests__/telemetry.service.test.ts
+++ b/packages/angular-logger/__tests__/telemetry.service.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import { createMockSink } from '@refraction-ui/logger'
+import {
+  TelemetryService,
+  provideTelemetry,
+  TELEMETRY,
+  TELEMETRY_CONFIG,
+} from '../src/telemetry.service.js'
+
+/**
+ * These tests exercise the *real* `@refraction-ui/logger` core through the
+ * Angular adapter's public surface (no mocking of the engine), mirroring how
+ * `packages/react-ai` tests its provider against the real `@refraction-ui/ai`
+ * core. The Angular DI provider factory wiring is verified directly without
+ * bootstrapping a browser platform.
+ */
+
+/** Resolve the provider array the way Angular's injector would. */
+function resolveService(
+  config: Parameters<typeof provideTelemetry>[0],
+): TelemetryService {
+  const providers = provideTelemetry(config)
+
+  const configProvider = providers.find(
+    (p): p is { provide: unknown; useValue: unknown } =>
+      typeof p === 'object' && p !== null && 'provide' in p && p.provide === TELEMETRY_CONFIG,
+  )
+  const telemetryProvider = providers.find(
+    (p): p is { provide: unknown; useFactory: (...a: unknown[]) => unknown; deps: unknown[] } =>
+      typeof p === 'object' && p !== null && 'provide' in p && p.provide === TELEMETRY,
+  )
+
+  expect(configProvider).toBeDefined()
+  expect(telemetryProvider).toBeDefined()
+
+  const cfg = (configProvider as { useValue: unknown }).useValue
+  const telemetry = (
+    telemetryProvider as { useFactory: (c: unknown) => unknown }
+  ).useFactory(cfg)
+
+  return new TelemetryService(telemetry as never)
+}
+
+describe('provideTelemetry', () => {
+  it('returns the config token, the telemetry factory, and the service', () => {
+    const providers = provideTelemetry({ app: 'test', env: 'development' })
+    expect(providers).toHaveLength(3)
+
+    const hasConfig = providers.some(
+      (p) => typeof p === 'object' && p !== null && 'provide' in p && p.provide === TELEMETRY_CONFIG,
+    )
+    const hasTelemetry = providers.some(
+      (p) => typeof p === 'object' && p !== null && 'provide' in p && p.provide === TELEMETRY,
+    )
+    expect(hasConfig).toBe(true)
+    expect(hasTelemetry).toBe(true)
+    expect(providers).toContain(TelemetryService)
+  })
+
+  it('the telemetry factory depends on the config token', () => {
+    const providers = provideTelemetry({ app: 'test', env: 'development' })
+    const telemetryProvider = providers.find(
+      (p): p is { provide: unknown; deps: unknown[] } =>
+        typeof p === 'object' && p !== null && 'provide' in p && p.provide === TELEMETRY,
+    )
+    expect(telemetryProvider?.deps).toEqual([TELEMETRY_CONFIG])
+  })
+
+  it('constructs a single telemetry instance from the supplied config', () => {
+    const svc = resolveService({ app: 'interview', env: 'development' })
+    expect(svc.telemetry).toBeDefined()
+    expect(Array.isArray(svc.sinks)).toBe(true)
+    // Zero-config dev → console-only transport is always present.
+    expect(svc.sinks).toContain('console')
+  })
+})
+
+describe('TelemetryService (real core)', () => {
+  it('forwards every level to the underlying telemetry sinks', () => {
+    const svc = resolveService({ app: 'app', env: 'development' })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    svc.debug('d', { a: 1 })
+    svc.info('i')
+    svc.warn('w')
+    svc.error('e')
+    svc.fatal('f')
+
+    const levels = sink.logs.map((r) => r.level)
+    expect(levels).toEqual(['debug', 'info', 'warn', 'error', 'fatal'])
+    expect(sink.logs[0]?.context).toMatchObject({ a: 1 })
+    expect(sink.logs[0]?.app).toBe('app')
+  })
+
+  it('scope() / child() produce loggers with bound context', () => {
+    const svc = resolveService({ app: 'app', env: 'development' })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    const scoped = svc.scope({ sessionId: 's1', interviewId: 'iv1' })
+    const turn = scoped.child({ turnId: 't1' })
+    turn.info('turn started')
+
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0]?.context).toMatchObject({
+      sessionId: 's1',
+      interviewId: 'iv1',
+      turnId: 't1',
+    })
+  })
+
+  it('startSpan() emits a span record on end()', () => {
+    const svc = resolveService({ app: 'app', env: 'development' })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    const span = svc.startSpan('load', { phase: 'init' })
+    span.end()
+
+    expect(sink.spans).toHaveLength(1)
+    expect(sink.spans[0]?.name).toBe('load')
+    expect(sink.spans[0]?.status).toBe('ok')
+    expect(sink.spans[0]?.context).toMatchObject({ phase: 'init' })
+  })
+
+  it('span end({ error }) records an error status', () => {
+    const svc = resolveService({ app: 'app', env: 'development' })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    const span = svc.startSpan('risky')
+    span.end({ error: new Error('boom') })
+
+    expect(sink.spans).toHaveLength(1)
+    expect(sink.spans[0]?.status).toBe('error')
+    expect(sink.spans[0]?.error).toMatchObject({ message: 'boom' })
+  })
+
+  it('flush() resolves and reaches every sink', async () => {
+    const svc = resolveService({ app: 'app', env: 'development' })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    await svc.flush()
+    expect(sink.flushCalls).toBeGreaterThanOrEqual(1)
+  })
+
+  it('enabled: false yields a noop telemetry (kill switch)', () => {
+    const svc = resolveService({ app: 'app', env: 'production', enabled: false })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    svc.error('should not be recorded')
+    svc.startSpan('noop').end()
+
+    expect(sink.logs).toHaveLength(0)
+    expect(sink.spans).toHaveLength(0)
+  })
+
+  it('redactKeys strips sensitive context before emission', () => {
+    const svc = resolveService({
+      app: 'app',
+      env: 'development',
+      redactKeys: ['password'],
+    })
+    const sink = createMockSink('capture')
+    svc.telemetry.addSink(sink)
+
+    svc.info('login', { user: 'a', password: 'secret' })
+
+    expect(sink.logs[0]?.context.password).toBe('[REDACTED]')
+    expect(sink.logs[0]?.context).toMatchObject({ user: 'a' })
+  })
+})

--- a/packages/angular-logger/package.json
+++ b/packages/angular-logger/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@refraction-ui/angular-logger",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/logger": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@angular/common": ">=18.0.0",
+    "@angular/core": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@angular/common": "19.2.20",
+    "@angular/core": "19.2.20",
+    "rxjs": "7.8.2",
+    "zone.js": "0.15.1"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/angular-logger"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/angular-logger/src/index.ts
+++ b/packages/angular-logger/src/index.ts
@@ -1,0 +1,22 @@
+// Injectable service + provider + DI tokens
+export {
+  TelemetryService,
+  provideTelemetry,
+  TELEMETRY,
+  TELEMETRY_CONFIG,
+} from './telemetry.service.js'
+
+// Re-export core types for convenience (vendor-neutral — no Faro/Grafana
+// types are exposed)
+export type {
+  LogLevel,
+  LogContext,
+  LogRecord,
+  SpanRecord,
+  TelemetrySink,
+  TelemetryEnv,
+  TelemetryConfig,
+  Logger,
+  Span,
+  Telemetry,
+} from '@refraction-ui/logger'

--- a/packages/angular-logger/src/telemetry.service.ts
+++ b/packages/angular-logger/src/telemetry.service.ts
@@ -1,0 +1,130 @@
+import { Inject, Injectable, InjectionToken, type Provider } from '@angular/core'
+import {
+  createTelemetry,
+  type LogContext,
+  type Logger,
+  type Span,
+  type Telemetry,
+  type TelemetryConfig,
+} from '@refraction-ui/logger'
+
+/**
+ * DI token carrying the {@link TelemetryConfig} supplied to
+ * {@link provideTelemetry}. Mirrors the `createAI` / `<AIProvider>` config
+ * surface — the consumer's only wiring is this config object.
+ */
+export const TELEMETRY_CONFIG = new InjectionToken<TelemetryConfig>(
+  '@refraction-ui/angular-logger:TELEMETRY_CONFIG',
+)
+
+/**
+ * DI token resolving to the singleton {@link Telemetry} instance. Provided by
+ * {@link provideTelemetry}; injected by {@link TelemetryService}. Exposed so
+ * advanced consumers can inject the raw telemetry instance directly.
+ */
+export const TELEMETRY = new InjectionToken<Telemetry>(
+  '@refraction-ui/angular-logger:TELEMETRY',
+)
+
+/**
+ * TelemetryService — an injectable Angular wrapper around the
+ * `@refraction-ui/logger` core. Manager/provider pattern, mirroring
+ * `createAI` + `<AIProvider>` (`packages/react-ai`).
+ *
+ * The Faro engine and every vendor type stay fully hidden behind the core;
+ * the only consumer wiring is the {@link TelemetryConfig} passed to
+ * {@link provideTelemetry}.
+ *
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideTelemetry({ app: 'interview', env: 'production', endpoint }),
+ *   ],
+ * })
+ *
+ * class InterviewComponent {
+ *   private readonly log = inject(TelemetryService).scope({ interviewId })
+ * }
+ * ```
+ */
+@Injectable()
+export class TelemetryService implements Logger {
+  /** The underlying telemetry instance from the core. */
+  readonly telemetry: Telemetry
+
+  constructor(@Inject(TELEMETRY) telemetry: Telemetry) {
+    this.telemetry = telemetry
+  }
+
+  debug(message: string, context?: LogContext): void {
+    this.telemetry.debug(message, context)
+  }
+
+  info(message: string, context?: LogContext): void {
+    this.telemetry.info(message, context)
+  }
+
+  warn(message: string, context?: LogContext): void {
+    this.telemetry.warn(message, context)
+  }
+
+  error(message: string, context?: LogContext): void {
+    this.telemetry.error(message, context)
+  }
+
+  fatal(message: string, context?: LogContext): void {
+    this.telemetry.fatal(message, context)
+  }
+
+  /**
+   * Derive a child logger with additional bound context (e.g.
+   * `{ sessionId, interviewId, turnId }`). Merges over the parent context.
+   */
+  child(context: LogContext): Logger {
+    return this.telemetry.child(context)
+  }
+
+  /**
+   * Alias for {@link child} — reads naturally in component code
+   * (`telemetry.scope({ interviewId })`).
+   */
+  scope(context: LogContext): Logger {
+    return this.telemetry.child(context)
+  }
+
+  /** Begin a span. Call {@link Span.end} to record its duration. */
+  startSpan(name: string, attributes?: LogContext): Span {
+    return this.telemetry.startSpan(name, attributes)
+  }
+
+  /** Force-deliver buffered records on every sink. */
+  flush(): Promise<void> {
+    return this.telemetry.flush()
+  }
+
+  /** Registered sink names, in insertion order. */
+  get sinks(): string[] {
+    return this.telemetry.sinks
+  }
+}
+
+/**
+ * provideTelemetry — registers the singleton {@link Telemetry} instance and
+ * {@link TelemetryService} for an Angular application.
+ *
+ * Pass to `bootstrapApplication(..., { providers: [...] })` or an
+ * `NgModule`'s `providers`. The telemetry instance is constructed once from
+ * the supplied config; no `endpoint` ⇒ console-only, `enabled: false` ⇒ a
+ * tree-shakeable noop — exactly as the core defines.
+ */
+export function provideTelemetry(config: TelemetryConfig): Provider[] {
+  return [
+    { provide: TELEMETRY_CONFIG, useValue: config },
+    {
+      provide: TELEMETRY,
+      useFactory: (cfg: TelemetryConfig): Telemetry => createTelemetry(cfg),
+      deps: [TELEMETRY_CONFIG],
+    },
+    TelemetryService,
+  ]
+}

--- a/packages/angular-logger/tsconfig.json
+++ b/packages/angular-logger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "useDefineForClassFields": false
+  },
+  "include": ["src"]
+}

--- a/packages/angular-logger/tsup.config.ts
+++ b/packages/angular-logger/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ['@angular/core', '@angular/common'],
+})

--- a/packages/angular-logger/vitest.config.ts
+++ b/packages/angular-logger/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,28 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/angular-logger:
+    dependencies:
+      '@refraction-ui/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@angular/common':
+        specifier: 19.2.20
+        version: 19.2.20(@angular/core@19.2.20(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core':
+        specifier: 19.2.20
+        version: 19.2.20(rxjs@7.8.2)(zone.js@0.15.1)
+      rxjs:
+        specifier: 7.8.2
+        version: 7.8.2
+      zone.js:
+        specifier: 0.15.1
+        version: 0.15.1
+
   packages/angular-meta:
     dependencies:
       '@angular/core':


### PR DESCRIPTION
Wave 2 of epic #206. Injectable `TelemetryService` + `provideTelemetry(config)` DI provider over `@refraction-ui/logger`; scoped child loggers + spans; vendor types hidden. Mirrors react-ai + angular sibling conventions. Changeset: angular-logger `minor`.

✅ turbo build/test/typecheck/lint exit 0 · 10 tests. Closes #210.