### PR TITLE
feat(analytics): GA4 sink, dual-mode gtag + Measurement Protocol (#216)

### DIFF
--- a/.changeset/analytics-sink-ga4-init.md
+++ b/.changeset/analytics-sink-ga4-init.md
@@ -1,0 +1,5 @@
+---
+"@refraction-ui/analytics-sink-ga4": minor
+---
+
+feat: add @refraction-ui/analytics-sink-ga4 — dual-mode GA4 sink (lazy gtag.js client-sdk + Measurement Protocol http) with canonical-envelope mapping and Consent Mode bridge

--- a/packages/analytics-sink-ga4/README.md
+++ b/packages/analytics-sink-ga4/README.md
@@ -1,0 +1,73 @@
+# @refraction-ui/analytics-sink-ga4
+
+A **GA4 sink** for [`@refraction-ui/analytics`](../analytics). In the epic's
+model GA4 is **just a sink** — there is no privileged engine. The app
+instruments **once** via the neutral router; this adapter maps the canonical
+Segment envelope to GA4 in one of two interchangeable modes.
+
+No hard vendor dependency: gtag.js is **dynamically loaded** only when the
+`client-sdk` mode actually delivers, and the `http` mode never loads any
+browser library at all.
+
+---
+
+## Modes
+
+| Mode | Transport | Vendor lib |
+|------|-----------|------------|
+| `http` *(default)* | GA4 **Measurement Protocol** (`/mp/collect`) | none — server-relay friendly |
+| `client-sdk` | gtag.js in the browser | lazily injected on first delivery only |
+
+```ts
+import { createAnalytics } from '@refraction-ui/analytics'
+import { createGA4Sink } from '@refraction-ui/analytics-sink-ga4'
+
+// http (Measurement Protocol) — no browser library, ad-blocker-proof
+const analytics = createAnalytics({
+  app: 'my-app',
+  env: process.env.NODE_ENV,
+  consent: { granted: ['analytics'] },
+  sinks: [
+    createGA4Sink({
+      mode: 'http',
+      measurementId: 'G-XXXXXXXXXX',
+      apiSecret: process.env.GA4_API_SECRET!,
+    }),
+  ],
+})
+
+// client-sdk — lazy gtag.js + GA4 Consent Mode bridge
+createGA4Sink({
+  mode: 'client-sdk',
+  measurementId: 'G-XXXXXXXXXX',
+  consentMode: {
+    default: { analytics_storage: 'denied' },
+    map: { analytics: ['analytics_storage'] },
+  },
+})
+```
+
+## Canonical envelope → GA4 mapping
+
+| Canonical | GA4 |
+|-----------|-----|
+| `anonymousId` | `client_id` |
+| `userId` | `user_id` (GA4 User-ID) |
+| `properties` | event params |
+| `identify` / `group` traits | `user_properties` |
+| `sessionId` | `session_id` param (GA4 sessionisation alignment) |
+| `page` / `screen` | `page_view` / `screen_view` (Enhanced-Measurement parity) |
+| event names | lower_snake_cased, reserved prefixes escaped |
+
+`identify` carries no GA4 event — it only sets `user_id` / `user_properties`.
+
+## Consent
+
+The sink declares `consentCategories` (default `['analytics']`); the router
+will not deliver until they are granted. In `client-sdk` mode an optional
+**GA4 Consent Mode bridge** pushes `gtag('consent', 'default', …)` on init and
+`gtag('consent', 'update', …)` once the router permits delivery.
+
+## License
+
+MIT

--- a/packages/analytics-sink-ga4/__tests__/client-sdk-sink.test.ts
+++ b/packages/analytics-sink-ga4/__tests__/client-sdk-sink.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createGA4ClientSdkSink } from '../src/client-sdk-sink.js'
+import { createGA4Sink } from '../src/ga4-sink.js'
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+import type { GtagFn } from '../src/types.js'
+
+function makeEvent(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'Signup Clicked',
+    messageId: 'mid-1',
+    anonymousId: 'anon-1',
+    sessionId: 'sess-1',
+    properties: { plan: 'pro' },
+    context: {
+      app: 'app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: '2026-05-17T00:00:00.000Z',
+    schemaVersion: 1,
+    ...overrides,
+  }
+}
+
+/** A mock gtag function that records every invocation (no network). */
+function mockGtag() {
+  const calls: unknown[][] = []
+  const fn: GtagFn = (...args: unknown[]) => {
+    calls.push(args)
+  }
+  return { calls, fn }
+}
+
+describe('GA4 client-sdk sink — gtag mapping', () => {
+  it('configures gtag and maps anonymousId→client_id via config + event', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-ABC',
+      gtag: g.fn,
+    })
+    await sink.deliver([makeEvent()], { unload: false })
+
+    // js + config bootstrap happens once
+    expect(g.calls.some((c) => c[0] === 'js')).toBe(true)
+    const config = g.calls.find((c) => c[0] === 'config')
+    expect(config?.[1]).toBe('G-ABC')
+    // the track event is mapped + sent
+    const evCall = g.calls.find((c) => c[0] === 'event')
+    expect(evCall?.[1]).toBe('signup_clicked')
+    expect((evCall?.[2] as Record<string, unknown>).plan).toBe('pro')
+    expect((evCall?.[2] as Record<string, unknown>).session_id).toBe(
+      'sess-1',
+    )
+  })
+
+  it('userId → gtag set user_id (GA4 User-ID)', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    await sink.deliver([makeEvent({ userId: 'user_42' })], {
+      unload: false,
+    })
+    const setUser = g.calls.find(
+      (c) =>
+        c[0] === 'set' &&
+        typeof c[1] === 'object' &&
+        (c[1] as Record<string, unknown>).user_id === 'user_42',
+    )
+    expect(setUser).toBeDefined()
+  })
+
+  it('identify traits → gtag set user_properties (unwrapped)', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    await sink.deliver(
+      [
+        makeEvent({
+          type: 'identify',
+          event: undefined,
+          traits: { plan: 'enterprise' },
+        }),
+      ],
+      { unload: false },
+    )
+    const setUP = g.calls.find(
+      (c) => c[0] === 'set' && c[1] === 'user_properties',
+    )
+    expect(setUP?.[2]).toEqual({ plan: 'enterprise' })
+    // identify emits no GA4 event
+    expect(g.calls.some((c) => c[0] === 'event')).toBe(false)
+  })
+
+  it('page → page_view event', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    await sink.deliver(
+      [makeEvent({ type: 'page', event: 'Pricing' })],
+      { unload: false },
+    )
+    expect(g.calls.some((c) => c[0] === 'event' && c[1] === 'page_view')).toBe(
+      true,
+    )
+  })
+})
+
+describe('GA4 client-sdk sink — lazy gtag.js loading (no hard dep)', () => {
+  it('injects the gtag.js script lazily on first delivery only', async () => {
+    const loaded: string[] = []
+    const scriptLoader = vi.fn(async (src: string) => {
+      loaded.push(src)
+    })
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-LAZY',
+      // no gtag injected → loader path is used
+      scriptLoader,
+      gtagSrcBase: 'https://gtm.test/gtag/js',
+    })
+    // Provide a gtag stub via globalThis so post-load calls work.
+    ;(globalThis as Record<string, unknown>).gtag = g.fn
+
+    expect(scriptLoader).not.toHaveBeenCalled() // not loaded at construction
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(scriptLoader).toHaveBeenCalledTimes(1)
+    expect(loaded[0]).toBe('https://gtm.test/gtag/js?id=G-LAZY')
+
+    // second delivery does NOT re-load the script
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(scriptLoader).toHaveBeenCalledTimes(1)
+
+    delete (globalThis as Record<string, unknown>).gtag
+  })
+
+  it('does not inject any script when an app-supplied gtag is given', async () => {
+    const scriptLoader = vi.fn(async () => {})
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+      scriptLoader,
+    })
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(scriptLoader).not.toHaveBeenCalled()
+  })
+})
+
+describe('GA4 client-sdk sink — Consent Mode bridge', () => {
+  it('pushes consent default on init (before the tag loads)', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+      consentMode: {
+        default: { analytics_storage: 'denied', ad_storage: 'denied' },
+        map: { analytics: ['analytics_storage'] },
+      },
+    })
+    await sink.init?.({ app: 'a', env: 'test' })
+    const def = g.calls.find(
+      (c) => c[0] === 'consent' && c[1] === 'default',
+    )
+    expect(def?.[2]).toEqual({
+      analytics_storage: 'denied',
+      ad_storage: 'denied',
+    })
+  })
+
+  it('pushes consent update for granted categories on deliver', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+      consentCategories: ['analytics'],
+      consentMode: {
+        default: { analytics_storage: 'denied' },
+        map: { analytics: ['analytics_storage'] },
+      },
+    })
+    // deliver is only called by the router once consent is granted; the
+    // bridge reflects that to GA4.
+    await sink.deliver([makeEvent()], { unload: false })
+    const upd = g.calls.find(
+      (c) => c[0] === 'consent' && c[1] === 'update',
+    )
+    expect(upd?.[2]).toEqual({ analytics_storage: 'granted' })
+  })
+
+  it('no consent commands when no bridge configured', async () => {
+    const g = mockGtag()
+    const sink = createGA4ClientSdkSink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    await sink.init?.({ app: 'a', env: 'test' })
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(g.calls.some((c) => c[0] === 'consent')).toBe(false)
+  })
+})
+
+describe('createGA4Sink — mode dispatch + consent', () => {
+  it('mode:client-sdk builds the gtag adapter', async () => {
+    const g = mockGtag()
+    const sink = createGA4Sink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    expect(sink.name).toBe('ga4')
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(g.calls.some((c) => c[0] === 'event')).toBe(true)
+  })
+
+  it('defaults consentCategories to [analytics] in client-sdk mode', () => {
+    const g = mockGtag()
+    const sink = createGA4Sink({
+      mode: 'client-sdk',
+      measurementId: 'G-X',
+      gtag: g.fn,
+    })
+    expect(sink.consentCategories).toEqual(['analytics'])
+  })
+})

--- a/packages/analytics-sink-ga4/__tests__/http-sink.test.ts
+++ b/packages/analytics-sink-ga4/__tests__/http-sink.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createGA4HttpSink } from '../src/http-sink.js'
+import { createGA4Sink } from '../src/ga4-sink.js'
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+
+function makeEvent(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'Signup Clicked',
+    messageId: 'mid-' + Math.random().toString(36).slice(2),
+    anonymousId: 'anon-1',
+    sessionId: 'sess-1',
+    properties: { plan: 'pro' },
+    context: {
+      app: 'app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: '2026-05-17T00:00:00.000Z',
+    schemaVersion: 1,
+    ...overrides,
+  }
+}
+
+/** A mock GA4 Measurement Protocol backend (no network). */
+function mockMP() {
+  const calls: Array<{ url: string; method: string; body: unknown }> = []
+  const fetchImpl = vi.fn(
+    async (url: string, init?: RequestInit): Promise<Response> => {
+      calls.push({
+        url,
+        method: init?.method ?? 'GET',
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      })
+      return { status: 204, ok: true } as Response
+    },
+  )
+  return { calls, fetchImpl: fetchImpl as unknown as typeof fetch }
+}
+
+describe('GA4 http sink — Measurement Protocol wire format', () => {
+  it('POSTs to /mp/collect with measurement_id + api_secret query', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-ABC123',
+      apiSecret: 'secret/with+special',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], { unload: false })
+
+    expect(mp.calls).toHaveLength(1)
+    const call = mp.calls[0]
+    expect(call.method).toBe('POST')
+    expect(call.url).toBe(
+      'https://www.google-analytics.com/mp/collect' +
+        '?measurement_id=G-ABC123' +
+        '&api_secret=' +
+        encodeURIComponent('secret/with+special'),
+    )
+  })
+
+  it('maps anonymousId→client_id, userId→user_id, properties→event params', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver(
+      [
+        makeEvent({
+          anonymousId: 'anon-99',
+          userId: 'user_7',
+          event: 'Add To Cart',
+          properties: { value: 42 },
+        }),
+      ],
+      { unload: false },
+    )
+    const body = mp.calls[0].body as {
+      client_id: string
+      user_id: string
+      events: Array<{ name: string; params: Record<string, unknown> }>
+    }
+    expect(body.client_id).toBe('anon-99')
+    expect(body.user_id).toBe('user_7')
+    expect(body.events[0].name).toBe('add_to_cart')
+    expect(body.events[0].params.value).toBe(42)
+    expect(body.events[0].params.session_id).toBe('sess-1')
+  })
+
+  it('identify maps traits → user_properties with no event', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver(
+      [
+        makeEvent({
+          type: 'identify',
+          event: undefined,
+          userId: 'user_1',
+          traits: { plan: 'pro' },
+        }),
+      ],
+      { unload: false },
+    )
+    const body = mp.calls[0].body as {
+      user_id: string
+      user_properties: Record<string, { value: unknown }>
+      events: unknown[]
+    }
+    expect(body.user_id).toBe('user_1')
+    expect(body.user_properties).toEqual({ plan: { value: 'pro' } })
+    expect(body.events).toHaveLength(0)
+  })
+
+  it('chunks to GA4 25-events-per-request limit', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl: mp.fetchImpl,
+    })
+    const batch = Array.from({ length: 60 }, (_, i) =>
+      makeEvent({ event: `e${i}` }),
+    )
+    await sink.deliver(batch, { unload: false })
+    // 60 events → 3 requests (25 + 25 + 10)
+    expect(mp.calls).toHaveLength(3)
+    const total = mp.calls.reduce(
+      (n, c) => n + (c.body as { events: unknown[] }).events.length,
+      0,
+    )
+    expect(total).toBe(60)
+  })
+
+  it('does nothing for an empty batch', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver([], { unload: false })
+    expect(mp.calls).toHaveLength(0)
+  })
+
+  it('uses the debug validation endpoint when debug:true', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      debug: true,
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(mp.calls[0].url).toContain('/debug/mp/collect')
+  })
+
+  it('honours a custom endpoint (e.g. EU region / proxy)', async () => {
+    const mp = mockMP()
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      endpoint: 'https://relay.example.com/',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.deliver([makeEvent()], { unload: false })
+    expect(mp.calls[0].url).toBe(
+      'https://relay.example.com/mp/collect?measurement_id=G-X&api_secret=s',
+    )
+  })
+
+  it('swallows network failures (fire-and-forget MP)', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down')
+    }) as unknown as typeof fetch
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl,
+    })
+    await expect(
+      sink.deliver([makeEvent()], { unload: false }),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('GA4 http sink — consent gating', () => {
+  it('defaults to requiring the analytics category', () => {
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+    })
+    expect(sink.consentCategories).toEqual(['analytics'])
+  })
+
+  it('honours a custom consentCategories list', () => {
+    const sink = createGA4HttpSink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      consentCategories: ['marketing', 'analytics'],
+    })
+    expect(sink.consentCategories).toEqual(['marketing', 'analytics'])
+  })
+
+  it('exposes a stable sink name (default ga4, overridable)', () => {
+    expect(
+      createGA4HttpSink({ mode: 'http', measurementId: 'G', apiSecret: 's' })
+        .name,
+    ).toBe('ga4')
+    expect(
+      createGA4HttpSink({
+        mode: 'http',
+        measurementId: 'G',
+        apiSecret: 's',
+        name: 'ga4-eu',
+      }).name,
+    ).toBe('ga4-eu')
+  })
+})
+
+describe('GA4 http sink — no vendor library loaded', () => {
+  const realDoc = (globalThis as Record<string, unknown>).document
+  const realDL = (globalThis as Record<string, unknown>).dataLayer
+
+  beforeEach(() => {
+    // Spy on document.createElement to prove no <script> is injected.
+    ;(globalThis as Record<string, unknown>).document = {
+      createElement: vi.fn(() => {
+        throw new Error('http mode must not create DOM script elements')
+      }),
+    }
+    delete (globalThis as Record<string, unknown>).dataLayer
+  })
+  afterEach(() => {
+    ;(globalThis as Record<string, unknown>).document = realDoc
+    ;(globalThis as Record<string, unknown>).dataLayer = realDL
+  })
+
+  it('never creates a gtag.js <script> and never installs window.gtag/dataLayer', async () => {
+    const mp = mockMP()
+    const sink = createGA4Sink({
+      mode: 'http',
+      measurementId: 'G-X',
+      apiSecret: 's',
+      fetchImpl: mp.fetchImpl,
+    })
+    await sink.init?.({ app: 'a', env: 'test' })
+    await sink.deliver([makeEvent(), makeEvent()], { unload: false })
+
+    const doc = (globalThis as Record<string, unknown>).document as {
+      createElement: ReturnType<typeof vi.fn>
+    }
+    expect(doc.createElement).not.toHaveBeenCalled()
+    expect(
+      (globalThis as Record<string, unknown>).dataLayer,
+    ).toBeUndefined()
+    expect(
+      (globalThis as Record<string, unknown>).gtag,
+    ).toBeUndefined()
+    expect(mp.calls.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/analytics-sink-ga4/__tests__/mapping.test.ts
+++ b/packages/analytics-sink-ga4/__tests__/mapping.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { mapEvent, ga4EventName, toGa4Name } from '../src/mapping.js'
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+
+function makeEvent(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'Signup Clicked',
+    messageId: 'mid-1',
+    anonymousId: 'anon-abc',
+    sessionId: 'sess-xyz',
+    properties: { plan: 'pro' },
+    context: {
+      app: 'app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: '2026-05-17T00:00:00.000Z',
+    schemaVersion: 1,
+    ...overrides,
+  }
+}
+
+describe('toGa4Name', () => {
+  it('lower_snake_cases names and strips spaces/punctuation', () => {
+    expect(toGa4Name('Signup Clicked')).toBe('signup_clicked')
+    expect(toGa4Name('Add to Cart!')).toBe('add_to_cart')
+    expect(toGa4Name('camelCaseEvent')).toBe('camel_case_event')
+    expect(toGa4Name('  trailing  ')).toBe('trailing')
+  })
+
+  it('prefixes names that do not start with a letter', () => {
+    expect(toGa4Name('123abc')).toBe('e_123abc')
+  })
+
+  it('escapes GA4 reserved prefixes', () => {
+    expect(toGa4Name('google_thing')).toBe('x_google_thing')
+    expect(toGa4Name('firebase_x')).toBe('x_firebase_x')
+  })
+})
+
+describe('ga4EventName', () => {
+  it('maps page → page_view and screen → screen_view', () => {
+    expect(ga4EventName(makeEvent({ type: 'page' }))).toBe('page_view')
+    expect(ga4EventName(makeEvent({ type: 'screen' }))).toBe('screen_view')
+  })
+
+  it('returns undefined for identify (no event emitted)', () => {
+    expect(ga4EventName(makeEvent({ type: 'identify' }))).toBeUndefined()
+  })
+
+  it('snake_cases track event names', () => {
+    expect(ga4EventName(makeEvent({ event: 'Signup Clicked' }))).toBe(
+      'signup_clicked',
+    )
+  })
+})
+
+describe('mapEvent — identity mapping (epic #213)', () => {
+  it('anonymousId → client_id', () => {
+    const m = mapEvent(makeEvent({ anonymousId: 'anon-123' }))
+    expect(m.clientId).toBe('anon-123')
+  })
+
+  it('userId → user_id (GA4 User-ID)', () => {
+    const m = mapEvent(makeEvent({ userId: 'user_42' }))
+    expect(m.userId).toBe('user_42')
+  })
+
+  it('omits user_id when not identified', () => {
+    const m = mapEvent(makeEvent())
+    expect(m.userId).toBeUndefined()
+  })
+
+  it('properties → event params', () => {
+    const m = mapEvent(makeEvent({ properties: { plan: 'pro', seats: 5 } }))
+    expect(m.event?.params.plan).toBe('pro')
+    expect(m.event?.params.seats).toBe(5)
+    expect(m.event?.params.session_id).toBe('sess-xyz')
+  })
+
+  it('identify traits → user_properties (wrapped in { value })', () => {
+    const m = mapEvent(
+      makeEvent({
+        type: 'identify',
+        event: undefined,
+        traits: { plan: 'enterprise', tier: 3 },
+      }),
+    )
+    expect(m.userProperties).toEqual({
+      plan: { value: 'enterprise' },
+      tier: { value: 3 },
+    })
+    // identify emits no GA4 event
+    expect(m.event).toBeUndefined()
+  })
+
+  it('group traits → user_properties + group_id param', () => {
+    const m = mapEvent(
+      makeEvent({
+        type: 'group',
+        event: undefined,
+        groupId: 'org_7',
+        traits: { name: 'Acme' },
+      }),
+    )
+    expect(m.userProperties).toEqual({ name: { value: 'Acme' } })
+    expect(m.event?.name).toBe('group')
+    expect(m.event?.params.group_id).toBe('org_7')
+  })
+
+  it('page/screen carry GA4 page_* / screen_name params', () => {
+    const page = mapEvent(
+      makeEvent({
+        type: 'page',
+        event: 'Pricing',
+        properties: {},
+        context: {
+          app: 'app',
+          env: 'test',
+          page: {
+            url: 'https://x.com/pricing',
+            path: '/pricing',
+            referrer: 'https://x.com',
+            title: 'Pricing',
+          },
+          library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+        },
+      }),
+    )
+    expect(page.event?.name).toBe('page_view')
+    expect(page.event?.params.page_location).toBe('https://x.com/pricing')
+    expect(page.event?.params.page_path).toBe('/pricing')
+    expect(page.event?.params.page_referrer).toBe('https://x.com')
+
+    const screen = mapEvent(makeEvent({ type: 'screen', event: 'Dashboard' }))
+    expect(screen.event?.name).toBe('screen_view')
+    expect(screen.event?.params.screen_name).toBe('Dashboard')
+  })
+
+  it('alias maps user_id + previous_id params', () => {
+    const m = mapEvent(
+      makeEvent({
+        type: 'alias',
+        event: undefined,
+        userId: 'user_42',
+        previousId: 'anon-old',
+      }),
+    )
+    expect(m.event?.name).toBe('alias')
+    expect(m.event?.params.user_id).toBe('user_42')
+    expect(m.event?.params.previous_id).toBe('anon-old')
+  })
+})

--- a/packages/analytics-sink-ga4/__tests__/router-integration.test.ts
+++ b/packages/analytics-sink-ga4/__tests__/router-integration.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createAnalytics } from '@refraction-ui/analytics'
+import { createGA4Sink } from '../src/ga4-sink.js'
+
+/**
+ * End-to-end: the GA4 sink is "just a sink" registered on the neutral router.
+ * The app instruments once (never naming GA4); the router fans the canonical
+ * envelope into the GA4 adapter, with the consent gate honoured.
+ */
+function mockMP() {
+  const calls: Array<{ url: string; body: unknown }> = []
+  const fetchImpl = vi.fn(
+    async (url: string, init?: RequestInit): Promise<Response> => {
+      calls.push({
+        url,
+        body: init?.body ? JSON.parse(init.body as string) : undefined,
+      })
+      return { status: 204, ok: true } as Response
+    },
+  )
+  return { calls, fetchImpl: fetchImpl as unknown as typeof fetch }
+}
+
+describe('GA4 sink via the neutral router', () => {
+  it('http sink receives mapped envelopes when consent granted', async () => {
+    const mp = mockMP()
+    const analytics = createAnalytics({
+      app: 'demo',
+      env: 'production',
+      consent: { granted: ['analytics'] },
+      sinks: [
+        createGA4Sink({
+          mode: 'http',
+          measurementId: 'G-DEMO',
+          apiSecret: 'sec',
+          fetchImpl: mp.fetchImpl,
+        }),
+      ],
+    })
+
+    analytics.identify('user_9', { plan: 'pro' })
+    analytics.track('Signup Clicked', { ref: 'hero' })
+    await analytics.flush()
+
+    expect(mp.calls.length).toBeGreaterThan(0)
+    const bodies = mp.calls.map((c) => c.body as Record<string, unknown>)
+    // client_id always carries the anonymousId
+    expect(typeof bodies[0].client_id).toBe('string')
+    // user_id propagates after identify
+    const withUser = bodies.find((b) => b.user_id === 'user_9')
+    expect(withUser).toBeDefined()
+  })
+
+  it('consent gate blocks delivery until the category is granted', async () => {
+    const mp = mockMP()
+    const analytics = createAnalytics({
+      app: 'demo',
+      env: 'production',
+      // analytics NOT granted
+      consent: { granted: [] },
+      sinks: [
+        createGA4Sink({
+          mode: 'http',
+          measurementId: 'G-DEMO',
+          apiSecret: 'sec',
+          consentCategories: ['analytics'],
+          fetchImpl: mp.fetchImpl,
+        }),
+      ],
+    })
+
+    analytics.track('Blocked Event')
+    await analytics.flush()
+    expect(mp.calls).toHaveLength(0) // gated out
+
+    analytics.consent.grant('analytics')
+    analytics.track('Allowed Event')
+    await analytics.flush()
+    expect(mp.calls.length).toBeGreaterThan(0) // now delivered
+  })
+})

--- a/packages/analytics-sink-ga4/package.json
+++ b/packages/analytics-sink-ga4/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@refraction-ui/analytics-sink-ga4",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@refraction-ui/analytics": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "devDependencies": {},
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/analytics-sink-ga4"
+  },
+  "homepage": "https://elloloop.github.io/refraction-ui/"
+}

--- a/packages/analytics-sink-ga4/src/client-sdk-sink.ts
+++ b/packages/analytics-sink-ga4/src/client-sdk-sink.ts
@@ -1,0 +1,191 @@
+/**
+ * GA4 `client-sdk` adapter — lazy gtag.js.
+ *
+ * The vendor library is NEVER a hard dependency and is NEVER bundled. On the
+ * first delivery the adapter:
+ *   1. installs the gtag stub + dataLayer,
+ *   2. pushes the Consent Mode default (if a bridge is configured),
+ *   3. lazily injects `https://www.googletagmanager.com/gtag/js?id=<id>`
+ *      via a `<script>` tag (or an injected loader for tests/SSR),
+ *   4. runs `gtag('js', Date)` + `gtag('config', <id>, { send_page_view:false })`.
+ *
+ * Subsequent deliveries map each canonical envelope through the shared mapper
+ * and call `gtag('set', 'user_properties', …)` / `gtag('set', { user_id })` /
+ * `gtag('event', name, params)`.
+ *
+ * Consent Mode bridge: `init` pushes `consent: default`; `deliver` is only
+ * reached when the router's consent gate already allows this sink, at which
+ * point `consent: update` is pushed for the mapped GA4 consent types.
+ */
+
+import type {
+  AnalyticsEvent,
+  AnalyticsSink,
+  SinkInitContext,
+} from '@refraction-ui/analytics'
+import type { GA4ClientSdkOptions, GtagFn } from './types.js'
+import { mapEvent } from './mapping.js'
+
+const DEFAULT_SRC_BASE = 'https://www.googletagmanager.com/gtag/js'
+
+interface GtagGlobal {
+  dataLayer?: unknown[]
+  gtag?: GtagFn
+  document?: {
+    createElement(tag: string): {
+      async: boolean
+      src: string
+      onload: (() => void) | null
+      onerror: (() => void) | null
+    }
+    head?: { appendChild(node: unknown): void }
+    getElementsByTagName(tag: string): ArrayLike<{
+      parentNode?: { insertBefore(a: unknown, b: unknown): void }
+    }>
+  }
+}
+
+/** DOM `<script>` injector (browser only). */
+function defaultScriptLoader(src: string): Promise<void> {
+  const g = globalThis as unknown as GtagGlobal
+  const doc = g.document
+  if (!doc || typeof doc.createElement !== 'function') {
+    return Promise.reject(
+      new Error('GA4 client-sdk sink: no DOM to inject gtag.js'),
+    )
+  }
+  return new Promise<void>((resolve, reject) => {
+    const el = doc.createElement('script')
+    el.async = true
+    el.src = src
+    el.onload = () => resolve()
+    el.onerror = () => reject(new Error('GA4 client-sdk: gtag.js failed'))
+    if (doc.head?.appendChild) {
+      doc.head.appendChild(el)
+    } else {
+      const first = doc.getElementsByTagName('script')[0]
+      first?.parentNode?.insertBefore(el, first)
+    }
+  })
+}
+
+/**
+ * Create the GA4 gtag.js (`client-sdk`) sink. The vendor script is dynamically
+ * loaded on first delivery only — there is no static import of any GA4/gtag
+ * library, so `http`-mode consumers never pull this code path.
+ */
+export function createGA4ClientSdkSink(
+  options: GA4ClientSdkOptions,
+): AnalyticsSink {
+  const {
+    measurementId,
+    consentCategories = ['analytics'],
+    name = 'ga4',
+    consentMode,
+  } = options
+
+  const g = globalThis as unknown as GtagGlobal
+
+  let gtag: GtagFn | undefined = options.gtag
+  let loaded = false
+  let loadPromise: Promise<void> | undefined
+
+  function ensureGtagStub(): GtagFn {
+    if (gtag) return gtag
+    // Standard gtag bootstrap: dataLayer-backed shim available synchronously.
+    g.dataLayer = g.dataLayer ?? []
+    const dl = g.dataLayer
+    const fn: GtagFn = (...args: unknown[]) => {
+      dl.push(args)
+    }
+    g.gtag = g.gtag ?? fn
+    gtag = g.gtag
+    return gtag
+  }
+
+  function pushConsentDefault(): void {
+    if (!consentMode?.default || !gtag) return
+    gtag('consent', 'default', { ...consentMode.default })
+  }
+
+  function pushConsentUpdate(): void {
+    if (!consentMode?.map || !gtag) return
+    const update: Record<string, 'granted'> = {}
+    // deliver() only runs when the router's consent gate already permits this
+    // sink (all consentCategories granted) → reflect that to GA4.
+    for (const cat of consentCategories) {
+      for (const ga4Type of consentMode.map[cat] ?? []) {
+        update[ga4Type] = 'granted'
+      }
+    }
+    if (Object.keys(update).length > 0) {
+      gtag('consent', 'update', update)
+    }
+  }
+
+  function ensureLoaded(): Promise<void> {
+    if (loaded) return Promise.resolve()
+    if (loadPromise) return loadPromise
+
+    ensureGtagStub()
+    pushConsentDefault()
+
+    // App/test supplied its own gtag → never inject a vendor script.
+    if (options.gtag) {
+      gtag!('js', new Date())
+      gtag!('config', measurementId, { send_page_view: false })
+      loaded = true
+      return Promise.resolve()
+    }
+
+    const base = options.gtagSrcBase ?? DEFAULT_SRC_BASE
+    const src = `${base}?id=${encodeURIComponent(measurementId)}`
+    const load = options.scriptLoader ?? defaultScriptLoader
+
+    loadPromise = load(src).then(() => {
+      gtag!('js', new Date())
+      gtag!('config', measurementId, { send_page_view: false })
+      loaded = true
+    })
+    return loadPromise
+  }
+
+  return {
+    name,
+    consentCategories,
+
+    init(_ctx: SinkInitContext): void {
+      // Install the stub + Consent Mode default eagerly so a `consent:
+      // default` is in dataLayer before the tag loads. The vendor script
+      // itself is still deferred to the first delivery.
+      ensureGtagStub()
+      pushConsentDefault()
+      void _ctx
+    },
+
+    async deliver(batch: AnalyticsEvent[]): Promise<void> {
+      if (batch.length === 0) return
+      await ensureLoaded()
+      const send = gtag!
+      pushConsentUpdate()
+
+      for (const ev of batch) {
+        const m = mapEvent(ev)
+
+        if (m.userId) {
+          send('set', { user_id: m.userId })
+        }
+        if (m.userProperties) {
+          const flat: Record<string, unknown> = {}
+          for (const [k, v] of Object.entries(m.userProperties)) {
+            flat[k] = v.value
+          }
+          send('set', 'user_properties', flat)
+        }
+        if (m.event) {
+          send('event', m.event.name, m.event.params)
+        }
+      }
+    },
+  }
+}

--- a/packages/analytics-sink-ga4/src/ga4-sink.ts
+++ b/packages/analytics-sink-ga4/src/ga4-sink.ts
@@ -1,0 +1,27 @@
+/**
+ * `createGA4Sink` — the single entry point. Dispatches on `mode`:
+ *   - `mode: 'client-sdk'` → lazy gtag.js adapter
+ *   - `mode: 'http'` (default) → Measurement Protocol adapter, no vendor lib
+ *
+ * Default is `http` to honour the epic's "default = protocol adapters (no
+ * vendor libs in the browser)" stance. GA4 is just a sink — register it via
+ * `createAnalytics({ sinks: [createGA4Sink(...)] })` or `analytics.addSink`.
+ *
+ * Both factories are independent modules. The `http` factory has ZERO
+ * references to gtag.js / DOM-script code, and the `client-sdk` factory only
+ * touches the vendor script lazily (first delivery). Selecting one mode never
+ * executes the other's load path; consumers that only ever construct an
+ * `http` sink never run any vendor code.
+ */
+
+import type { AnalyticsSink } from '@refraction-ui/analytics'
+import type { GA4SinkOptions } from './types.js'
+import { createGA4HttpSink } from './http-sink.js'
+import { createGA4ClientSdkSink } from './client-sdk-sink.js'
+
+export function createGA4Sink(options: GA4SinkOptions): AnalyticsSink {
+  if (options.mode === 'client-sdk') {
+    return createGA4ClientSdkSink(options)
+  }
+  return createGA4HttpSink(options)
+}

--- a/packages/analytics-sink-ga4/src/http-sink.ts
+++ b/packages/analytics-sink-ga4/src/http-sink.ts
@@ -1,0 +1,141 @@
+/**
+ * GA4 `http` adapter — Measurement Protocol (`/mp/collect`).
+ *
+ * Server-relay friendly: this path NEVER loads gtag.js or any browser
+ * library. It only POSTs JSON to the Measurement Protocol endpoint:
+ *
+ *   POST {endpoint}/mp/collect?measurement_id={id}&api_secret={secret}
+ *   Content-Type: application/json
+ *   { client_id, user_id?, user_properties?, events: [{ name, params }] }
+ *
+ * GA4 Measurement Protocol constraints honoured here:
+ *   - up to 25 events per request → batches are chunked.
+ *   - `identify` envelopes carry no event; they still POST so user_id /
+ *     user_properties propagate (events array may be empty for a user-props
+ *     only ping, which GA4 accepts).
+ *   - 2xx (incl. 204) = accepted. The MP endpoint always returns 2xx for
+ *     well-formed requests; the `debug` endpoint returns validation messages.
+ */
+
+import type {
+  AnalyticsEvent,
+  AnalyticsSink,
+  SinkInitContext,
+} from '@refraction-ui/analytics'
+import type { GA4HttpOptions } from './types.js'
+import { mapEvent } from './mapping.js'
+
+const DEFAULT_ENDPOINT = 'https://www.google-analytics.com'
+const MAX_EVENTS_PER_REQUEST = 25
+
+interface MPPayload {
+  client_id: string
+  user_id?: string
+  user_properties?: Record<string, { value: unknown }>
+  events: Array<{ name: string; params: Record<string, unknown> }>
+}
+
+function resolveFetch(opts: GA4HttpOptions): typeof fetch {
+  if (opts.fetchImpl) return opts.fetchImpl
+  const f = (globalThis as unknown as { fetch?: typeof fetch }).fetch
+  if (!f) throw new Error('GA4 http sink: no fetch implementation available')
+  return f
+}
+
+/**
+ * Group consecutive envelopes by GA4 identity (client_id + user_id) so each
+ * Measurement Protocol request carries a single identity, then chunk to the
+ * 25-event limit.
+ */
+function buildPayloads(batch: AnalyticsEvent[]): MPPayload[] {
+  const payloads: MPPayload[] = []
+
+  for (const ev of batch) {
+    const m = mapEvent(ev)
+    const last = payloads[payloads.length - 1]
+    const sameIdentity =
+      last &&
+      last.client_id === m.clientId &&
+      last.user_id === m.userId &&
+      last.events.length < MAX_EVENTS_PER_REQUEST &&
+      // user_properties must not silently differ within one request
+      JSON.stringify(last.user_properties) ===
+        JSON.stringify(m.userProperties)
+
+    const target: MPPayload = sameIdentity
+      ? last
+      : (() => {
+          const p: MPPayload = { client_id: m.clientId, events: [] }
+          if (m.userId) p.user_id = m.userId
+          if (m.userProperties) p.user_properties = m.userProperties
+          payloads.push(p)
+          return p
+        })()
+
+    if (m.event) {
+      target.events.push(m.event)
+    }
+  }
+
+  // Drop empty payloads that carry neither an event nor user identity
+  // signal (nothing to send to GA4).
+  return payloads.filter(
+    (p) =>
+      p.events.length > 0 ||
+      p.user_id !== undefined ||
+      p.user_properties !== undefined,
+  )
+}
+
+/**
+ * Create the GA4 Measurement-Protocol (`http`) sink.
+ *
+ * No vendor library is loaded on this path under any circumstance.
+ */
+export function createGA4HttpSink(options: GA4HttpOptions): AnalyticsSink {
+  const {
+    measurementId,
+    apiSecret,
+    consentCategories = ['analytics'],
+    name = 'ga4',
+    debug = false,
+  } = options
+  const base = (options.endpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, '')
+  const path = debug ? '/debug/mp/collect' : '/mp/collect'
+  const url =
+    `${base}${path}?measurement_id=${encodeURIComponent(measurementId)}` +
+    `&api_secret=${encodeURIComponent(apiSecret)}`
+
+  return {
+    name,
+    consentCategories,
+
+    init(_ctx: SinkInitContext): void {
+      // No-op: the Measurement Protocol is stateless and credential-driven.
+      // Explicitly NO vendor script / SDK is loaded here.
+      void _ctx
+    },
+
+    async deliver(batch: AnalyticsEvent[]): Promise<void> {
+      if (batch.length === 0) return
+      const payloads = buildPayloads(batch)
+      if (payloads.length === 0) return
+      const doFetch = resolveFetch(options)
+
+      for (const payload of payloads) {
+        try {
+          await doFetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+            keepalive: true,
+          })
+          // GA4 MP returns 2xx (204) for well-formed requests and never
+          // asks for client-side retries; transient failures are dropped.
+        } catch {
+          // Network failure — GA4 MP is fire-and-forget; drop silently.
+        }
+      }
+    },
+  }
+}

--- a/packages/analytics-sink-ga4/src/index.ts
+++ b/packages/analytics-sink-ga4/src/index.ts
@@ -1,0 +1,20 @@
+// Unified factory (dispatches on `mode`).
+export { createGA4Sink } from './ga4-sink.js'
+
+// Direct mode factories (for explicit selection / tree-shaking).
+export { createGA4HttpSink } from './http-sink.js'
+export { createGA4ClientSdkSink } from './client-sdk-sink.js'
+
+// Pure mapping (canonical envelope → GA4) — reusable / testable in isolation.
+export { mapEvent, ga4EventName, toGa4Name } from './mapping.js'
+export type { GA4Event, GA4Mapped } from './mapping.js'
+
+// Option contracts.
+export type {
+  GA4SinkOptions,
+  GA4HttpOptions,
+  GA4ClientSdkOptions,
+  GA4ConsentBridge,
+  ConsentState,
+  GtagFn,
+} from './types.js'

--- a/packages/analytics-sink-ga4/src/mapping.ts
+++ b/packages/analytics-sink-ga4/src/mapping.ts
@@ -1,0 +1,172 @@
+/**
+ * Canonical envelope → GA4 mapping.
+ *
+ * One mapper, two consumers: the `client-sdk` adapter feeds the result into
+ * `gtag('event', name, params)` / `gtag('set', ...)`, and the `http` adapter
+ * serialises it into a Measurement Protocol `/mp/collect` payload. Keeping the
+ * mapping in one place guarantees the two modes stay behaviourally identical.
+ *
+ * Identity / param mapping (issue #216, epic #213):
+ *   anonymousId  → client_id           (GA4 device/browser id)
+ *   userId       → user_id             (GA4 User-ID, cross-device)
+ *   properties   → event params        (track/page/screen/group payload)
+ *   identify     → user_properties     (traits become GA4 user properties)
+ *   sessionId    → session_id param    (so GA4 sessionisation can align)
+ *
+ * GA4 event-name normalisation: GA4 recommends snake_case event names and
+ * forbids spaces. `page` → `page_view`, `screen` → `screen_view` (GA4
+ * Enhanced-Measurement parity); everything else is lower_snake_cased.
+ */
+
+import type { AnalyticsEvent, AnalyticsProperties } from '@refraction-ui/analytics'
+
+/** A GA4 event ready for gtag.js or the Measurement Protocol. */
+export interface GA4Event {
+  /** GA4 event name (snake_case, no spaces). */
+  name: string
+  /** Event params (GA4 caps these; we pass them through verbatim). */
+  params: Record<string, unknown>
+}
+
+/** The fully-mapped result for a single canonical envelope. */
+export interface GA4Mapped {
+  /** GA4 client_id (from anonymousId). Always present. */
+  clientId: string
+  /** GA4 user_id (from userId). Present only after identify. */
+  userId?: string
+  /**
+   * GA4 user_properties (from identify/group traits). Each value is wrapped
+   * in `{ value }` as the Measurement Protocol requires; the gtag adapter
+   * unwraps when it calls `gtag('set', 'user_properties', ...)`.
+   */
+  userProperties?: Record<string, { value: unknown }>
+  /**
+   * The GA4 event to send. `identify` calls carry no event (they only set
+   * user_id / user_properties), so this is optional.
+   */
+  event?: GA4Event
+}
+
+const GA4_RESERVED_PREFIXES = ['google_', 'ga_', 'firebase_']
+
+/** Lower_snake_case an arbitrary event/trait name for GA4. */
+export function toGa4Name(name: string): string {
+  const snake = name
+    .trim()
+    .replace(/['"]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase()
+  // GA4 names must start with a letter and avoid reserved prefixes.
+  const safe = /^[a-z]/.test(snake) ? snake : `e_${snake}`
+  return GA4_RESERVED_PREFIXES.some((p) => safe.startsWith(p))
+    ? `x_${safe}`
+    : safe
+}
+
+/** Map a Segment call type + name to its GA4 event name. */
+export function ga4EventName(ev: AnalyticsEvent): string | undefined {
+  switch (ev.type) {
+    case 'identify':
+      // identify only sets identity/user_properties — no event is emitted.
+      return undefined
+    case 'page':
+      return 'page_view'
+    case 'screen':
+      return 'screen_view'
+    case 'group':
+      return 'group'
+    case 'alias':
+      return 'alias'
+    case 'track':
+      return ev.event ? toGa4Name(ev.event) : 'track'
+    default:
+      return undefined
+  }
+}
+
+/** Wrap traits as GA4 user_properties (`{ name: { value } }`). */
+function toUserProperties(
+  traits: AnalyticsProperties | undefined,
+): Record<string, { value: unknown }> | undefined {
+  if (!traits) return undefined
+  const out: Record<string, { value: unknown }> = {}
+  let any = false
+  for (const [k, v] of Object.entries(traits)) {
+    if (v === undefined) continue
+    out[toGa4Name(k)] = { value: v }
+    any = true
+  }
+  return any ? out : undefined
+}
+
+/** Build the GA4 event params from a canonical envelope. */
+function toParams(ev: AnalyticsEvent): Record<string, unknown> {
+  const params: Record<string, unknown> = {}
+
+  // Pass through the canonical payload as GA4 params.
+  for (const [k, v] of Object.entries(ev.properties ?? {})) {
+    if (v === undefined) continue
+    params[toGa4Name(k)] = v
+  }
+
+  // Align GA4 sessionisation with our analytics session.
+  params.session_id = ev.sessionId
+  // Stable client-supplied de-dupe / debugging aid.
+  params.engagement_time_msec = params.engagement_time_msec ?? 1
+
+  // page/screen context → GA4 page_* params (Enhanced-Measurement parity).
+  const page = ev.context.page
+  if (ev.type === 'page' || ev.type === 'screen') {
+    if (ev.event) {
+      if (ev.type === 'screen') params.screen_name = ev.event
+      else params.page_title = params.page_title ?? ev.event
+    }
+    if (page?.url && params.page_location === undefined) {
+      params.page_location = page.url
+    }
+    if (page?.path && params.page_path === undefined) {
+      params.page_path = page.path
+    }
+    if (page?.referrer && params.page_referrer === undefined) {
+      params.page_referrer = page.referrer
+    }
+    if (page?.title && params.page_title === undefined) {
+      params.page_title = page.title
+    }
+  }
+
+  if (ev.type === 'group' && ev.groupId) {
+    params.group_id = ev.groupId
+  }
+  if (ev.type === 'alias') {
+    if (ev.userId) params.user_id = ev.userId
+    if (ev.previousId) params.previous_id = ev.previousId
+  }
+
+  return params
+}
+
+/**
+ * Map one canonical envelope to its GA4 representation. Pure — no transport,
+ * no vendor lib; both the gtag and Measurement-Protocol adapters consume this.
+ */
+export function mapEvent(ev: AnalyticsEvent): GA4Mapped {
+  const name = ga4EventName(ev)
+  const mapped: GA4Mapped = {
+    clientId: ev.anonymousId,
+  }
+  if (ev.userId) mapped.userId = ev.userId
+
+  if (ev.type === 'identify' || ev.type === 'group') {
+    const up = toUserProperties(ev.traits)
+    if (up) mapped.userProperties = up
+  }
+
+  if (name) {
+    mapped.event = { name, params: toParams(ev) }
+  }
+  return mapped
+}

--- a/packages/analytics-sink-ga4/src/types.ts
+++ b/packages/analytics-sink-ga4/src/types.ts
@@ -1,0 +1,94 @@
+/**
+ * @refraction-ui/analytics-sink-ga4 — option contracts.
+ *
+ * GA4 is "just a sink" in the epic's model (no privileged engine). This
+ * adapter implements the `AnalyticsSink` SPI from `@refraction-ui/analytics`
+ * in two interchangeable modes:
+ *
+ *   - `client-sdk` — lazy-loads gtag.js in the browser (no hard vendor dep;
+ *     the script is injected on first delivery only). Bridges Consent Mode.
+ *   - `http`       — GA4 Measurement Protocol (`/mp/collect`). No browser
+ *     library is ever loaded — server-relay friendly.
+ *
+ * Default = `http` (protocol adapter, no vendor lib in the browser), matching
+ * the epic's "default = protocol adapters" stance.
+ */
+
+/** Minimal gtag.js function signature (we never import the real types). */
+export type GtagFn = (...args: unknown[]) => void
+
+/** GA4 Consent Mode signal values. */
+export type ConsentState = 'granted' | 'denied'
+
+/**
+ * GA4 Consent Mode bridge — maps our consent categories to the gtag
+ * `consent` command. Only used in `client-sdk` mode.
+ */
+export interface GA4ConsentBridge {
+  /**
+   * Default consent state pushed via `gtag('consent', 'default', …)` before
+   * the GA4 tag loads. Keys are GA4 consent types
+   * (`analytics_storage`, `ad_storage`, `ad_user_data`,
+   * `ad_personalization`, `functionality_storage`, …).
+   */
+  default?: Record<string, ConsentState>
+  /**
+   * Maps a refraction consent category → the GA4 consent types it controls.
+   * When the router reports the sink may deliver (category granted) the
+   * adapter pushes `gtag('consent', 'update', { <types>: 'granted' })`.
+   * Example: `{ analytics: ['analytics_storage'] }`.
+   */
+  map?: Record<string, string[]>
+}
+
+interface GA4CommonOptions {
+  /** GA4 Measurement ID, e.g. `G-XXXXXXXXXX`. */
+  measurementId: string
+  /**
+   * Consent categories this sink requires. The router will not deliver until
+   * all are granted. Default: `['analytics']`.
+   */
+  consentCategories?: string[]
+  /** Stable sink name. Default `'ga4'`. */
+  name?: string
+}
+
+/** `client-sdk` mode — runs gtag.js in the browser. */
+export interface GA4ClientSdkOptions extends GA4CommonOptions {
+  mode: 'client-sdk'
+  /**
+   * Inject the GA4 Consent Mode bridge. The default state (if any) is pushed
+   * before the tag loads; category grants drive `consent: update`.
+   */
+  consentMode?: GA4ConsentBridge
+  /**
+   * Inject an existing gtag function (tests / apps that manage the tag
+   * themselves). When provided, the script loader is NOT used and **no**
+   * vendor script is injected.
+   */
+  gtag?: GtagFn
+  /**
+   * Inject the script loader (tests / SSR-safe apps). Receives the gtag.js
+   * src URL; must resolve once the script has executed. Defaults to a DOM
+   * `<script>` injector (browser only).
+   */
+  scriptLoader?: (src: string) => Promise<void>
+  /** Override the gtag.js base URL (testing). */
+  gtagSrcBase?: string
+}
+
+/** `http` mode — GA4 Measurement Protocol. No browser library. */
+export interface GA4HttpOptions extends GA4CommonOptions {
+  mode?: 'http'
+  /** GA4 Measurement Protocol API secret (server-side credential). */
+  apiSecret: string
+  /** Override the `/mp/collect` base URL (testing / EU endpoint). */
+  endpoint?: string
+  /** Use the Measurement Protocol `/debug/mp/collect` validation endpoint. */
+  debug?: boolean
+  /** Injected fetch (defaults to global fetch). Never loads a vendor lib. */
+  fetchImpl?: typeof fetch
+}
+
+/** Discriminated union of the two modes. */
+export type GA4SinkOptions = GA4ClientSdkOptions | GA4HttpOptions

--- a/packages/analytics-sink-ga4/tsconfig.json
+++ b/packages/analytics-sink-ga4/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/analytics-sink-ga4/tsup.config.ts
+++ b/packages/analytics-sink-ga4/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+})

--- a/packages/analytics-sink-ga4/vitest.config.ts
+++ b/packages/analytics-sink-ga4/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,15 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/analytics-sink-ga4:
+    dependencies:
+      '@refraction-ui/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+
   packages/angular-accordion:
     dependencies:
       '@angular/core':


### PR DESCRIPTION
feat(analytics-sink-ga4): GA4 sink (client-sdk gtag + http Measurement Protocol), consent-gated (#216)