### PR TITLE
feat(analytics): reference server-relay backend + docs (#221)

### DIFF
--- a/docs-site/src/app/analytics/page.tsx
+++ b/docs-site/src/app/analytics/page.tsx
@@ -1,0 +1,392 @@
+import { CodeBlock } from '@/components/code-block'
+
+export const metadata = {
+  title: 'Analytics — Refraction UI',
+  description:
+    'Headless Segment-spec analytics router: consumer API, sessions/identity/consent, GA4 collection-parity, the backend wire contract, and the recommended server-relay topology.',
+}
+
+const consumerApi = `import { createAnalytics } from '@refraction-ui/analytics'
+
+const analytics = createAnalytics({
+  app: 'my-app',
+  env: process.env.NODE_ENV,           // drives dev/prod presets
+  endpoint: 'https://collect.example.com', // optional: auto-adds the http sink
+  writeKey: 'WRITE_KEY',
+  enabled: true,                       // false → tree-shakeable noop
+  sampleRate: 1,                       // 0..1, applied per call
+  redactKeys: ['internalScore'],       // extra PII keys to strip
+  consent: { granted: ['analytics'] },
+})
+
+// Segment Spec — the entire instrumentation surface (never name a vendor)
+analytics.track('Signup Clicked', { plan: 'pro' })
+analytics.identify('user_42', { plan: 'pro' })
+analytics.page('Pricing', { path: '/pricing' })
+analytics.screen('Dashboard')
+analytics.group('org_7', { name: 'Acme' })
+analytics.alias('user_42', 'anon-or-prev-id')
+
+// Analytics session (NOT replay) · consent gate · child context
+analytics.session.id()
+analytics.consent.grant('marketing')
+const checkout = analytics.with({ feature: 'checkout' })
+
+await analytics.flush()                // drain batch + flush all sinks
+analytics.reset()                      // privacy-safe logout`
+
+const reactApi = `import { AnalyticsProvider, useAnalytics, useTrackEvent } from '@refraction-ui/react-analytics'
+
+function App() {
+  return (
+    <AnalyticsProvider config={{ app: 'my-app', env: 'production', endpoint, writeKey }}>
+      <Pricing />
+    </AnalyticsProvider>
+  )
+}
+
+function Pricing() {
+  const analytics = useAnalytics()
+  const track = useTrackEvent()            // stable, memoised
+  return <button onClick={() => track('Plan Selected', { plan: 'pro' })}>Pro</button>
+}`
+
+const devProd = `// dev  (env !== 'production'): synchronous, unbatched + a console sink
+//                              so engineers see exactly what would ship.
+// prod (env === 'production'): batching + sampling + a sendBeacon flush
+//                              bound to pagehide / visibilitychange.
+// enabled: false             : returns a noop — the live collector and all
+//                              sink code tree-shake out of the bundle.
+
+createAnalytics({ app: 'my-app', env: 'production' })   // → prod preset
+createAnalytics({ app: 'my-app', env: 'development' })  // → dev preset
+createAnalytics({ app: 'my-app', env, enabled: false }) // → noop`
+
+const wireRequest = `POST {endpoint}/v{schemaVersion}/batch        (schemaVersion = 1 → /v1/batch)
+Content-Type: application/json                 (gzip optional)
+Authorization: Basic base64("{writeKey}:")     ← note the trailing colon
+
+{
+  "batch":   [ /* AnalyticsEvent[] — canonical envelope */ ],
+  "sentAt":  "2026-05-16T12:00:00.000Z",        // honest client send time
+  "batchId": "<uuid v4>"
+}`
+
+const wireEvent = `{
+  "type": "track",                  // track|identify|page|screen|group|alias
+  "event": "Signup Clicked",        // track/page/screen name (optional)
+  "messageId": "<uuid v4>",         // idempotency key — backends MUST dedupe
+  "anonymousId": "<uuid v4>",       // persistent, non-PII
+  "userId": "user_42",              // opaque, optional
+  "sessionId": "<uuid v4>",         // analytics session
+  "properties": { },                // track/page/screen/group payload
+  "traits": { },                    // identify/group traits
+  "context": { "app": "my-app", "env": "production",
+               "library": { "name": "@refraction-ui/analytics", "version": "0.1.0" } },
+  "timestamp": "2026-05-16T12:00:00.000Z",      // ISO-8601 client time
+  "schemaVersion": 1
+}`
+
+const beacon = `// Unload path: navigator.sendBeacon cannot set an Authorization header.
+// A conforming backend MUST also accept the write key via query + text/plain:
+POST {endpoint}/v1/batch?writeKey={writeKey}
+Content-Type: text/plain`
+
+const relayTopology = `Browser                         Your backend (the relay)        Vendors
+────────                         ─────────────────────────       ───────
+analytics.track(...)             POST /v1/batch                   GA4  (Measurement Protocol)
+   │  neutral router only   ───▶   ├─ auth (Basic | ?writeKey=)     ▲
+   │  (no vendor SDK)              ├─ dedupe messageId              │ server-side
+   ▼                              ├─ clock-skew correct            │ fan-out
+sendBeacon on unload  ─────────▶  ├─ size caps / schemaVersion ────┤ (ad-blocker-proof)
+                                  └─ 200 accept-and-queue          ▼
+                                                                  Azure App Insights`
+
+const referenceServer = `import {
+  createNodeRelayServer,
+  createGA4Forwarder,
+  createAzureForwarder,
+} from '@refraction-ui/analytics-relay-reference'
+
+const srv = createNodeRelayServer({
+  writeKeys: ['WRITE_KEY'],
+  forwarders: [
+    createGA4Forwarder({ measurementId: 'G-XXXX', apiSecret, fetchImpl }),
+    createAzureForwarder({ instrumentationKey, fetchImpl }),
+  ],
+})
+const base = await srv.listen(8080) // POST {base}/v1/batch`
+
+function Code({ code, language = 'tsx' }: { code: string; language?: string }) {
+  return <CodeBlock code={code} language={language} />
+}
+
+function StatusRow({
+  code,
+  meaning,
+  behaviour,
+}: {
+  code: string
+  meaning: string
+  behaviour: string
+}) {
+  return (
+    <tr className="border-b border-border last:border-0">
+      <td className="py-2 pr-4 font-mono text-sm text-foreground whitespace-nowrap">
+        {code}
+      </td>
+      <td className="py-2 pr-4 text-sm text-muted-foreground">{meaning}</td>
+      <td className="py-2 text-sm text-muted-foreground">{behaviour}</td>
+    </tr>
+  )
+}
+
+export default function AnalyticsPage() {
+  return (
+    <div className="max-w-3xl space-y-12 pb-16">
+      <header className="space-y-3">
+        <span className="inline-flex rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary ring-1 ring-inset ring-primary/20">
+          Headless library
+        </span>
+        <h1 className="text-4xl font-bold tracking-tight text-foreground">
+          Analytics
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed">
+          <code className="text-foreground">@refraction-ui/analytics</code> is a
+          neutral <strong>Segment-spec collector/router</strong>. The app
+          instruments <strong>once</strong> and never names a vendor; the
+          library fans the canonical event envelope out to N pluggable sinks
+          (GA4, Azure App Insights, PostHog, your own backend). There is{' '}
+          <strong>no privileged engine</strong> — every vendor is just a sink.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Consumer API
+        </h2>
+        <p className="text-muted-foreground leading-relaxed">
+          The entire public surface is the Segment Spec. Instrument once; the
+          router handles batching, sessions, identity, consent and fan-out.
+        </p>
+        <Code code={consumerApi} />
+        <h3 className="text-lg font-semibold text-foreground pt-2">React</h3>
+        <p className="text-muted-foreground leading-relaxed">
+          <code className="text-foreground">
+            @refraction-ui/react-analytics
+          </code>{' '}
+          mirrors <code className="text-foreground">react-ai</code>: a provider
+          plus hooks. No vendor SDK is loaded in the browser.
+        </p>
+        <Code code={reactApi} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Dev vs. prod
+        </h2>
+        <p className="text-muted-foreground leading-relaxed">
+          The <code className="text-foreground">env</code> drives a preset.
+          Development is synchronous with a console sink so engineers see
+          exactly what would ship; production batches, samples and flushes via{' '}
+          <code className="text-foreground">sendBeacon</code> on unload.
+        </p>
+        <Code code={devProd} language="ts" />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Sessions, identity &amp; consent
+        </h2>
+        <ul className="space-y-2 text-muted-foreground leading-relaxed list-disc pl-5">
+          <li>
+            <strong className="text-foreground">sessionId</strong> — client
+            UUIDv4 minted at session start. A session ends after 30&nbsp;min of
+            inactivity (GA4 parity, configurable) or when a new campaign
+            (UTM&nbsp;/ <code>gclid</code>&nbsp;/ <code>fbclid</code>&nbsp;/{' '}
+            <code>msclkid</code>) is detected. Persisted cross-tab via
+            localStorage&nbsp;→&nbsp;cookie&nbsp;→&nbsp;memory.
+          </li>
+          <li>
+            <strong className="text-foreground">anonymousId</strong> —
+            persistent, non-PII, resettable UUIDv4.{' '}
+            <code>reset()</code> mints a fresh one so a new visitor is never
+            stitched to the old one.
+          </li>
+          <li>
+            <strong className="text-foreground">userId</strong> — opaque,
+            app-supplied; never persisted by the library.{' '}
+            <code>alias</code> emits a <code>previousId&nbsp;→&nbsp;userId</code>{' '}
+            stitch event.
+          </li>
+          <li>
+            <strong className="text-foreground">PII</strong> — a built-in
+            deny-list (email&nbsp;/ phone&nbsp;/ name&nbsp;/ password&nbsp;/
+            card&nbsp;/ …) plus <code>redactKeys</code>; case- and
+            separator-insensitive, recursing into nested objects/arrays. Values
+            become <code>&quot;[REDACTED]&quot;</code>.
+          </li>
+          <li>
+            <strong className="text-foreground">Consent</strong> — each sink
+            declares the categories it requires; the router will not deliver to
+            a sink unless <strong>all</strong> its categories are granted
+            (per-sink consent).
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          GA4 collection-parity
+        </h2>
+        <p className="text-muted-foreground leading-relaxed">
+          GA4 is <strong>one sink</strong>. Collection reaches parity (and
+          beyond) via optional auto-capture plugins; identity and parameters map
+          directly — <code>anonymousId&nbsp;→&nbsp;client_id</code>,{' '}
+          <code>userId&nbsp;→&nbsp;user_id</code>,{' '}
+          <code>sessionId&nbsp;→&nbsp;session_id</code>,{' '}
+          <code>track&nbsp;→</code> a snake_cased GA4 event,{' '}
+          <code>page&nbsp;→&nbsp;page_view</code>,{' '}
+          <code>screen&nbsp;→&nbsp;screen_view</code>. Reporting is{' '}
+          <em>delegated</em>: route the GA4 sink and you get GA&rsquo;s exact
+          reports unchanged.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Backend wire contract
+        </h2>
+        <p className="text-muted-foreground leading-relaxed">
+          The built-in <code className="text-foreground">http</code> sink
+          implements the <strong>Segment HTTP Tracking API</strong> batch format
+          — <em>adopt, do not invent</em> — so RudderStack&nbsp;/ Jitsu&nbsp;/
+          Segment are drop-in conforming backends.
+        </p>
+
+        <h3 className="text-lg font-semibold text-foreground pt-2">Request</h3>
+        <Code code={wireRequest} language="bash" />
+
+        <h3 className="text-lg font-semibold text-foreground pt-2">
+          Canonical event envelope
+        </h3>
+        <Code code={wireEvent} language="json" />
+
+        <h3 className="text-lg font-semibold text-foreground pt-2">
+          Response semantics (accept-and-queue)
+        </h3>
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-muted/40 text-left">
+                <th className="py-2 px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Status
+                </th>
+                <th className="py-2 px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Meaning
+                </th>
+                <th className="py-2 px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Client behaviour
+                </th>
+              </tr>
+            </thead>
+            <tbody className="px-4">
+              <tr>
+                <td colSpan={3} className="px-4">
+                  <table className="w-full">
+                    <tbody>
+                      <StatusRow
+                        code="2xx"
+                        meaning="Accepted and queued (not yet processed)"
+                        behaviour="done"
+                      />
+                      <StatusRow
+                        code="400"
+                        meaning="Malformed"
+                        behaviour="drop, never retry"
+                      />
+                      <StatusRow
+                        code="401"
+                        meaning="Bad write key"
+                        behaviour="drop, never retry"
+                      />
+                      <StatusRow
+                        code="413"
+                        meaning="Payload too large"
+                        behaviour="drop (client also pre-splits)"
+                      />
+                      <StatusRow
+                        code="429 / 5xx"
+                        meaning="Transient / overload"
+                        behaviour="exponential backoff retry"
+                      />
+                      <StatusRow
+                        code="network err"
+                        meaning="—"
+                        behaviour="treated as transient → retry"
+                      />
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <ul className="space-y-2 text-muted-foreground leading-relaxed list-disc pl-5 pt-2">
+          <li>
+            <strong className="text-foreground">Idempotency</strong> — backends{' '}
+            <strong>MUST</strong> dedupe on <code>messageId</code>.
+          </li>
+          <li>
+            <strong className="text-foreground">Clock skew</strong> — the
+            backend corrects time as{' '}
+            <code>corrected = timestamp + (receivedAt − sentAt)</code>; the
+            client always stamps an honest <code>sentAt</code>.
+          </li>
+          <li>
+            <strong className="text-foreground">Size limits</strong> — soft caps
+            of ≈&nbsp;500&nbsp;KB&nbsp;/&nbsp;batch and
+            ≈&nbsp;32&nbsp;KB&nbsp;/&nbsp;event (Segment parity). The client
+            pre-splits oversized batches and drops over-cap events.
+          </li>
+          <li>
+            <strong className="text-foreground">Versioning</strong> — the path
+            carries <code>/v&#123;schemaVersion&#125;/</code>; every event also
+            carries <code>schemaVersion</code>.
+          </li>
+        </ul>
+
+        <h3 className="text-lg font-semibold text-foreground pt-2">
+          sendBeacon caveat (unload path)
+        </h3>
+        <Code code={beacon} language="bash" />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Recommended topology: server relay
+        </h2>
+        <p className="text-muted-foreground leading-relaxed">
+          The recommended production topology is a <strong>server relay</strong>
+          : the browser ships only our neutral router to <em>your</em>{' '}
+          <code>endpoint</code>; your backend fans out to vendors server-side.
+          This is ad-blocker-proof and keeps vendor SDKs out of the bundle.
+        </p>
+        <Code code={relayTopology} language="text" />
+        <p className="text-muted-foreground leading-relaxed">
+          The repo ships an executable, dependency-free reference relay,{' '}
+          <code className="text-foreground">
+            @refraction-ui/analytics-relay-reference
+          </code>{' '}
+          (internal — never published). It implements the wire contract above
+          and fans out to GA4 (Measurement Protocol) and Azure App Insights. The
+          core <code>http</code> sink is conformance-tested against it
+          end-to-end over a real socket (batch, beacon path, retry codes,
+          dedupe, clock-skew, fan-out).
+        </p>
+        <Code code={referenceServer} language="ts" />
+      </section>
+    </div>
+  )
+}

--- a/docs-site/src/components/sidebar.tsx
+++ b/docs-site/src/components/sidebar.tsx
@@ -150,6 +150,15 @@ const navigation = [
     ),
   },
   {
+    name: 'Analytics',
+    href: '/analytics',
+    icon: (
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+      </svg>
+    ),
+  },
+  {
     name: 'Flutter UI',
     href: '/flutter/',
     icon: (

--- a/packages/analytics-relay-reference/__tests__/collector.test.ts
+++ b/packages/analytics-relay-reference/__tests__/collector.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Focused unit tests for the transport-agnostic collector — the wire
+ * contract decision points, exercised without a socket.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createRelay, type RelayRequest } from '../src/collector.js'
+import { SCHEMA_VERSION } from '@refraction-ui/analytics'
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+
+const WK = 'k1'
+
+function event(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'E',
+    messageId: 'm-' + Math.random().toString(36).slice(2),
+    anonymousId: 'a',
+    sessionId: 's',
+    context: { app: 'x', env: 'test', library: { name: 'n', version: '1' } },
+    timestamp: new Date().toISOString(),
+    schemaVersion: SCHEMA_VERSION,
+    ...overrides,
+  }
+}
+
+function req(
+  body: unknown,
+  opts: Partial<RelayRequest> & { basic?: string; query?: string } = {},
+): RelayRequest {
+  const headers: Record<string, string | undefined> = {}
+  if (opts.basic !== undefined) {
+    headers.authorization =
+      'Basic ' + Buffer.from(`${opts.basic}:`).toString('base64')
+  }
+  return {
+    method: opts.method ?? 'POST',
+    url:
+      opts.url ?? `/v${SCHEMA_VERSION}/batch${opts.query ? '?' + opts.query : ''}`,
+    headers: { ...headers, ...(opts.headers ?? {}) },
+    rawBody:
+      typeof body === 'string' ? body : JSON.stringify(body),
+    receivedAt: opts.receivedAt ?? Date.now(),
+  }
+}
+
+describe('collector — auth', () => {
+  it('accepts Basic base64("writeKey:") (trailing colon)', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const res = await r.handleRequest(
+      req({ batch: [event()] }, { basic: WK }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts ?writeKey= beacon fallback (no Authorization header)', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const res = await r.handleRequest(
+      req({ batch: [event()] }, { query: `writeKey=${WK}` }),
+    )
+    expect(res.status).toBe(200)
+    expect(r.queued).toHaveLength(1)
+  })
+
+  it('401 for an unknown / missing write key', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    expect((await r.handleRequest(req({ batch: [event()] }))).status).toBe(401)
+    expect(
+      (await r.handleRequest(req({ batch: [event()] }, { basic: 'nope' })))
+        .status,
+    ).toBe(401)
+  })
+})
+
+describe('collector — routing & validation', () => {
+  it('400 for the wrong path', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const res = await r.handleRequest(
+      req({ batch: [event()] }, { basic: WK, url: '/v9/batch' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400 for non-POST', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const res = await r.handleRequest(
+      req({ batch: [event()] }, { basic: WK, method: 'GET' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('400 for invalid JSON and missing batch array', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    expect(
+      (await r.handleRequest(req('{bad', { basic: WK }))).status,
+    ).toBe(400)
+    expect(
+      (await r.handleRequest(req({ nope: true }, { basic: WK }))).status,
+    ).toBe(400)
+  })
+
+  it('400 for an unsupported schemaVersion', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const res = await r.handleRequest(
+      req({ batch: [event({ schemaVersion: 999 })] }, { basic: WK }),
+    )
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('collector — size limits', () => {
+  it('413 when the batch exceeds the per-batch cap', async () => {
+    const r = createRelay({ writeKeys: [WK], maxBatchBytes: 200 })
+    const res = await r.handleRequest(
+      req({ batch: [event(), event(), event()] }, { basic: WK }),
+    )
+    expect(res.status).toBe(413)
+  })
+
+  it('413 when a single event exceeds the per-event cap', async () => {
+    const r = createRelay({ writeKeys: [WK], maxEventBytes: 120 })
+    const res = await r.handleRequest(
+      req(
+        { batch: [event({ properties: { big: 'x'.repeat(500) } })] },
+        { basic: WK },
+      ),
+    )
+    expect(res.status).toBe(413)
+  })
+})
+
+describe('collector — idempotency', () => {
+  it('dedupes a repeated messageId, reporting the dedupe count', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const e = event({ messageId: 'dup' })
+    await r.handleRequest(req({ batch: [e] }, { basic: WK }))
+    const res = await r.handleRequest(req({ batch: [e] }, { basic: WK }))
+    expect(res.status).toBe(200)
+    expect(res.body.deduped).toBe(1)
+    expect(res.body.accepted).toBe(0)
+    expect(r.queued).toHaveLength(1)
+  })
+
+  it('evicts old ids once past the dedupe window (bounded memory)', async () => {
+    const r = createRelay({ writeKeys: [WK], dedupeWindow: 2 })
+    const e = event({ messageId: 'first' })
+    await r.handleRequest(req({ batch: [e] }, { basic: WK }))
+    await r.handleRequest(req({ batch: [event()] }, { basic: WK }))
+    await r.handleRequest(req({ batch: [event()] }, { basic: WK }))
+    // "first" has been evicted → it is accepted again.
+    const res = await r.handleRequest(req({ batch: [e] }, { basic: WK }))
+    expect(res.body.accepted).toBe(1)
+  })
+})
+
+describe('collector — clock skew', () => {
+  it('corrected = timestamp + (receivedAt − sentAt)', async () => {
+    const r = createRelay({ writeKeys: [WK] })
+    const eventTs = '2026-05-01T00:00:00.000Z'
+    const sentAt = '2026-05-01T00:00:05.000Z' // client sent 5s after stamping
+    const receivedAt = new Date('2026-05-01T00:00:30.000Z').getTime()
+    await r.handleRequest({
+      ...req(
+        { batch: [event({ timestamp: eventTs })], sentAt },
+        { basic: WK },
+      ),
+      receivedAt,
+    })
+    // offset = received − sent = 25s; corrected = eventTs + 25s.
+    expect(r.queued[0].correctedTimestamp).toBe('2026-05-01T00:00:25.000Z')
+  })
+
+  it('rejects an event outside the clock-skew window', async () => {
+    const r = createRelay({ writeKeys: [WK], maxClockSkewMs: 60_000 })
+    const res = await r.handleRequest(
+      req(
+        { batch: [event({ timestamp: new Date(Date.now() - 3_600_000).toISOString() })] },
+        { basic: WK },
+      ),
+    )
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/analytics-relay-reference/__tests__/conformance.test.ts
+++ b/packages/analytics-relay-reference/__tests__/conformance.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Conformance suite: the core `@refraction-ui/analytics` `http` sink
+ * round-tripped against the reference server-relay backend over a real
+ * Node HTTP socket.
+ *
+ * This is the contract test the issue calls for — it proves the sink and
+ * the documented wire contract actually agree on:
+ *   - the batch format + Basic-auth standard path
+ *   - the sendBeacon `?writeKey=` + text/plain unload path
+ *   - accept-and-queue 200 / 400 / 401 / 413 / 429 / 5xx semantics
+ *   - messageId idempotency (dedupe across batches)
+ *   - clock-skew correction (corrected = timestamp + (receivedAt − sentAt))
+ *   - server-side fan-out to GA4 + Azure (vendor endpoints mocked)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHttpSink } from '@refraction-ui/analytics'
+import { SCHEMA_VERSION } from '@refraction-ui/analytics'
+import type { AnalyticsEvent, SinkDeliverContext } from '@refraction-ui/analytics'
+import { createNodeRelayServer, type NodeRelayServer } from '../src/server.js'
+import {
+  createGA4Forwarder,
+  createAzureForwarder,
+  type ForwarderFetch,
+} from '../src/forwarders.js'
+
+const CTX_ONLINE: SinkDeliverContext = { unload: false }
+const CTX_UNLOAD: SinkDeliverContext = { unload: true }
+const WRITE_KEY = 'WK_conformance'
+
+function makeEvent(overrides: Partial<AnalyticsEvent> = {}): AnalyticsEvent {
+  return {
+    type: 'track',
+    event: 'Signup Clicked',
+    messageId: 'mid-' + Math.random().toString(36).slice(2),
+    anonymousId: 'anon-1',
+    sessionId: 'sess-1',
+    properties: { plan: 'pro' },
+    context: {
+      app: 'conformance-app',
+      env: 'test',
+      library: { name: '@refraction-ui/analytics', version: '0.1.0' },
+    },
+    timestamp: new Date().toISOString(),
+    schemaVersion: SCHEMA_VERSION,
+    ...overrides,
+  }
+}
+
+/** A real `node:http` beacon: POST text/plain to `?writeKey=` (no auth). */
+function nodeBeacon(base: string): (url: string, body: string) => boolean {
+  return (url, body) => {
+    // Fire-and-forget exactly like navigator.sendBeacon.
+    void fetch(url.startsWith('http') ? url : base + url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body,
+    })
+    return true
+  }
+}
+
+describe('conformance: http sink ↔ reference relay (real socket)', () => {
+  let srv: NodeRelayServer
+  let base: string
+
+  beforeEach(async () => {
+    srv = createNodeRelayServer({ writeKeys: [WRITE_KEY] })
+    base = await srv.listen()
+  })
+  afterEach(async () => {
+    await srv.close()
+  })
+
+  it('batch path: POST /v{n}/batch, Basic auth, accept-and-queue 200', async () => {
+    const sink = createHttpSink({ endpoint: base, writeKey: WRITE_KEY })
+    const events = [
+      makeEvent({ event: 'A' }),
+      makeEvent({ event: 'B', type: 'page' }),
+    ]
+    await sink.deliver(events, CTX_ONLINE)
+
+    expect(srv.relay.queued).toHaveLength(2)
+    expect(srv.relay.queued.map((q) => q.event.event)).toEqual(['A', 'B'])
+    // The canonical envelope survived the round-trip verbatim.
+    expect(srv.relay.queued[0].event.context.app).toBe('conformance-app')
+    expect(srv.relay.queued[0].event.schemaVersion).toBe(SCHEMA_VERSION)
+  })
+
+  it('beacon path: ?writeKey= + text/plain (no Authorization header)', async () => {
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      beaconImpl: nodeBeacon(base),
+    })
+    await sink.deliver([makeEvent({ event: 'unload-ev' })], CTX_UNLOAD)
+
+    // Beacon is fire-and-forget; poll until the relay has queued it.
+    await vi.waitFor(() => {
+      expect(srv.relay.queued).toHaveLength(1)
+    })
+    expect(srv.relay.queued[0].event.event).toBe('unload-ev')
+  })
+
+  it('401: a bad write key is rejected (client drops, never retries)', async () => {
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: 'WRONG_KEY',
+      maxRetries: 5,
+      backoffBaseMs: 1,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(srv.relay.queued).toHaveLength(0)
+  })
+
+  it('413: an over-cap event never reaches the relay (sink pre-drops)', async () => {
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      maxEventBytes: 80, // smaller than any real event → sink drops it
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(srv.relay.queued).toHaveLength(0)
+  })
+
+  it('413: a batch the sink does send but exceeds the server cap is rejected', async () => {
+    await srv.close()
+    srv = createNodeRelayServer({
+      writeKeys: [WRITE_KEY],
+      maxBatchBytes: 300, // server rejects; sink does NOT pre-split (its cap is high)
+    })
+    base = await srv.listen()
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      maxBatchBytes: 1_000_000,
+      maxRetries: 0,
+    })
+    await sink.deliver([makeEvent(), makeEvent(), makeEvent()], CTX_ONLINE)
+    expect(srv.relay.queued).toHaveLength(0)
+  })
+
+  it('429 then 200: sink backs off and the relay finally queues it', async () => {
+    await srv.close()
+    let calls = 0
+    // Wrap the relay server to 429 the first two requests.
+    const wrapped = createNodeRelayServer({ writeKeys: [WRITE_KEY] })
+    const realHandle = wrapped.relay.handleRequest.bind(wrapped.relay)
+    ;(wrapped.relay as { handleRequest: typeof realHandle }).handleRequest =
+      async (r) => {
+        if (calls++ < 2) {
+          return { status: 429, body: { success: false, error: 'slow down' } }
+        }
+        return realHandle(r)
+      }
+    srv = wrapped
+    base = await srv.listen()
+
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      maxRetries: 5,
+      backoffBaseMs: 5,
+    })
+    await sink.deliver([makeEvent({ event: 'eventually' })], CTX_ONLINE)
+    expect(calls).toBe(3) // 429, 429, 200
+    expect(srv.relay.queued).toHaveLength(1)
+    expect(srv.relay.queued[0].event.event).toBe('eventually')
+  })
+
+  it('5xx then 200: transient server failure is retried to success', async () => {
+    await srv.close()
+    let calls = 0
+    const wrapped = createNodeRelayServer({ writeKeys: [WRITE_KEY] })
+    const realHandle = wrapped.relay.handleRequest.bind(wrapped.relay)
+    ;(wrapped.relay as { handleRequest: typeof realHandle }).handleRequest =
+      async (r) => {
+        if (calls++ < 1) {
+          return { status: 503, body: { success: false, error: 'down' } }
+        }
+        return realHandle(r)
+      }
+    srv = wrapped
+    base = await srv.listen()
+
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      maxRetries: 5,
+      backoffBaseMs: 5,
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    expect(calls).toBe(2)
+    expect(srv.relay.queued).toHaveLength(1)
+  })
+
+  it('idempotency: a replayed messageId is deduped across batches', async () => {
+    const sink = createHttpSink({ endpoint: base, writeKey: WRITE_KEY })
+    const shared = makeEvent({ messageId: 'fixed-mid-1', event: 'once' })
+
+    await sink.deliver([shared], CTX_ONLINE)
+    await sink.deliver([shared], CTX_ONLINE) // exact replay (retry scenario)
+    await sink.deliver(
+      [shared, makeEvent({ messageId: 'fixed-mid-2', event: 'new' })],
+      CTX_ONLINE,
+    )
+
+    expect(srv.relay.queued).toHaveLength(2)
+    expect(srv.relay.queued.map((q) => q.event.event)).toEqual(['once', 'new'])
+  })
+
+  it('clock skew: relay applies corrected = timestamp + (receivedAt − sentAt)', async () => {
+    // Capture the honest `sentAt` the sink stamps so we can assert the
+    // exact wire-contract formula end-to-end (sink → relay).
+    let sentAt = ''
+    let receivedAt = 0
+    const baseFetch = globalThis.fetch
+    const spy: typeof fetch = async (input, init) => {
+      sentAt = JSON.parse(init?.body as string).sentAt as string
+      receivedAt = Date.now()
+      return baseFetch(input, init)
+    }
+    const sink = createHttpSink({
+      endpoint: base,
+      writeKey: WRITE_KEY,
+      fetchImpl: spy,
+    })
+    const eventTs = new Date(Date.now() - 10 * 60_000).toISOString()
+    await sink.deliver([makeEvent({ timestamp: eventTs })], CTX_ONLINE)
+
+    expect(srv.relay.queued).toHaveLength(1)
+    const q = srv.relay.queued[0]
+    expect(q.event.timestamp).toBe(eventTs) // original preserved verbatim
+
+    // corrected == timestamp + (receivedAt − sentAt). The relay's receivedAt
+    // is its own Date.now(); allow a few ms for the in-process round-trip.
+    const expected =
+      new Date(eventTs).getTime() + (receivedAt - new Date(sentAt).getTime())
+    const correctedMs = new Date(q.correctedTimestamp).getTime()
+    expect(Math.abs(correctedMs - expected)).toBeLessThan(1_000)
+  })
+
+  it('server-side fan-out: GA4 + Azure receive every accepted event', async () => {
+    const ga4Hits: Array<{ url: string; body: unknown }> = []
+    const azureHits: Array<{ url: string; body: unknown }> = []
+    const ga4Fetch: ForwarderFetch = async (url, init) => {
+      ga4Hits.push({ url, body: JSON.parse(init.body) })
+      return { status: 204 }
+    }
+    const azureFetch: ForwarderFetch = async (url, init) => {
+      azureHits.push({ url, body: JSON.parse(init.body) })
+      return { status: 200 }
+    }
+
+    await srv.close()
+    srv = createNodeRelayServer({
+      writeKeys: [WRITE_KEY],
+      forwarders: [
+        createGA4Forwarder({
+          measurementId: 'G-TEST',
+          apiSecret: 'secret',
+          fetchImpl: ga4Fetch,
+        }),
+        createAzureForwarder({
+          instrumentationKey: 'ikey-1',
+          fetchImpl: azureFetch,
+        }),
+      ],
+    })
+    base = await srv.listen()
+
+    const sink = createHttpSink({ endpoint: base, writeKey: WRITE_KEY })
+    await sink.deliver(
+      [
+        makeEvent({ event: 'Purchase', userId: 'user_42' }),
+        makeEvent({ type: 'page', event: 'Pricing' }),
+      ],
+      CTX_ONLINE,
+    )
+
+    expect(srv.relay.queued).toHaveLength(2)
+    expect(ga4Hits).toHaveLength(2)
+    expect(azureHits).toHaveLength(2)
+
+    // GA4 Measurement Protocol shape.
+    const ga4 = ga4Hits[0]
+    expect(ga4.url).toContain('/mp/collect')
+    expect(ga4.url).toContain('measurement_id=G-TEST')
+    const ga4Body = ga4.body as {
+      client_id: string
+      user_id?: string
+      events: Array<{ name: string; params: Record<string, unknown> }>
+    }
+    expect(ga4Body.client_id).toBe('anon-1')
+    expect(ga4Body.user_id).toBe('user_42')
+    expect(ga4Body.events[0].name).toBe('purchase')
+    expect(ga4Body.events[0].params.session_id).toBe('sess-1')
+
+    // Azure App Insights envelope shape.
+    const az = azureHits[1].body as {
+      name: string
+      iKey: string
+      data: { baseType: string; baseData: { name: string } }
+    }
+    expect(az.iKey).toBe('ikey-1')
+    expect(az.name).toBe('Microsoft.ApplicationInsights.PageView')
+    expect(az.data.baseType).toBe('PageViewData')
+    expect(az.data.baseData.name).toBe('Pricing')
+
+    // Fan-out results recorded; everything succeeded.
+    expect(srv.relay.forwarded.filter((f) => f.name === 'ga4')).toHaveLength(2)
+    expect(
+      srv.relay.forwarded.every((f) => f.ok),
+    ).toBe(true)
+  })
+
+  it('malformed JSON body → 400 (client drops, relay queues nothing)', async () => {
+    // Drive the relay directly with a corrupt body the sink would never send,
+    // proving the 400-no-retry branch of the contract.
+    const res = await srv.relay.handleRequest({
+      method: 'POST',
+      url: `/v${SCHEMA_VERSION}/batch`,
+      headers: {
+        authorization:
+          'Basic ' + Buffer.from(`${WRITE_KEY}:`).toString('base64'),
+      },
+      rawBody: '{ not json',
+      receivedAt: Date.now(),
+    })
+    expect(res.status).toBe(400)
+    expect(srv.relay.queued).toHaveLength(0)
+  })
+})

--- a/packages/analytics-relay-reference/package.json
+++ b/packages/analytics-relay-reference/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@refraction-ui/analytics-relay-reference",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Reference server-relay backend implementing the @refraction-ui/analytics Segment HTTP Tracking API wire contract. Internal — never published.",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext .ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@refraction-ui/analytics": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.0.0"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elloloop/refraction-ui.git",
+    "directory": "packages/analytics-relay-reference"
+  }
+}

--- a/packages/analytics-relay-reference/src/collector.ts
+++ b/packages/analytics-relay-reference/src/collector.ts
@@ -1,0 +1,330 @@
+/**
+ * Reference server-relay collector — the wire-contract brain.
+ *
+ * Implements the @refraction-ui/analytics Segment HTTP Tracking API batch
+ * contract (adopt, do not invent — RudderStack/Jitsu/Segment conform):
+ *
+ *   POST {endpoint}/v{schemaVersion}/batch
+ *   Content-Type: application/json   (or text/plain on the beacon path)
+ *   Authorization: Basic base64("{writeKey}:")    (note trailing colon)
+ *     — OR — ?writeKey={writeKey}  (sendBeacon unload path: no auth header)
+ *   Body: { batch: AnalyticsEvent[], sentAt, batchId }
+ *
+ * Response semantics (accept-and-queue):
+ *   200  accepted + queued (NOT processed)
+ *   400  malformed            → client drops, never retries
+ *   401  bad write key        → client drops, never retries
+ *   413  payload too large    → client drops (also pre-splits)
+ *   429/5xx  transient        → client backs off + retries
+ *
+ * - Idempotency: dedupe on event `messageId`.
+ * - Clock skew: corrected = timestamp + (receivedAt − sentAt).
+ * - Size limits: ≈500KB/batch, ≈32KB/event (Segment parity).
+ * - Versioning: path carries /v{schemaVersion}/; events carry schemaVersion.
+ *
+ * This module is transport-agnostic: `handleRequest` takes a parsed request
+ * and returns a status + JSON body, so it is unit-testable with no socket.
+ * `createNodeRelayServer` (server.ts) is the thin Node `http` binding.
+ */
+
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+import { SCHEMA_VERSION } from '@refraction-ui/analytics'
+import type { Forwarder } from './forwarders.js'
+
+/** Soft Segment-parity caps. */
+export const MAX_BATCH_BYTES = 500_000
+export const MAX_EVENT_BYTES = 32_000
+
+/** A request as seen by the transport-agnostic collector. */
+export interface RelayRequest {
+  method: string
+  /** Full request path incl. query string, e.g. `/v1/batch?writeKey=k`. */
+  url: string
+  headers: Record<string, string | undefined>
+  /** Raw request body (already read to a string). */
+  rawBody: string
+  /** Server receive time in ms (injectable for deterministic skew tests). */
+  receivedAt: number
+}
+
+export interface RelayResponse {
+  status: number
+  body: { success: boolean; error?: string; deduped?: number; accepted?: number }
+}
+
+export interface RelayOptions {
+  /** Accepted write keys. A request must present exactly one of these. */
+  writeKeys: string[]
+  /** Downstream destinations every accepted event is fanned out to. */
+  forwarders?: Forwarder[]
+  /**
+   * Reject events whose corrected timestamp is more than this far from
+   * `receivedAt` (ms). Default 24h. Set 0 to disable.
+   */
+  maxClockSkewMs?: number
+  /** Per-batch byte cap. Default 500KB. */
+  maxBatchBytes?: number
+  /** Per-event byte cap. Default 32KB. */
+  maxEventBytes?: number
+  /**
+   * Idempotency window: how many recently-seen messageIds to remember.
+   * Default 100_000. A bounded LRU keeps the reference server memory-safe.
+   */
+  dedupeWindow?: number
+}
+
+export interface RelayBatchEnvelope {
+  batch: unknown
+  sentAt?: unknown
+  batchId?: unknown
+}
+
+/** What the relay has durably "queued" — exposed for the conformance suite. */
+export interface QueuedEvent {
+  event: AnalyticsEvent
+  /** corrected = timestamp + (receivedAt − sentAt). */
+  correctedTimestamp: string
+}
+
+export interface AnalyticsRelay {
+  handleRequest(req: RelayRequest): Promise<RelayResponse>
+  /** Events accepted-and-queued, in order, post-dedupe. */
+  readonly queued: ReadonlyArray<QueuedEvent>
+  /** Per-forwarder server-side fan-out results. */
+  readonly forwarded: ReadonlyArray<{
+    name: string
+    messageId: string
+    ok: boolean
+    status: number
+  }>
+  /** Reset queue/dedupe/fan-out (test convenience). */
+  reset(): void
+}
+
+const ok = (accepted: number, deduped: number): RelayResponse => ({
+  status: 200,
+  body: { success: true, accepted, deduped },
+})
+const bad = (error: string): RelayResponse => ({
+  status: 400,
+  body: { success: false, error },
+})
+const unauthorized = (): RelayResponse => ({
+  status: 401,
+  body: { success: false, error: 'invalid write key' },
+})
+const tooLarge = (error: string): RelayResponse => ({
+  status: 413,
+  body: { success: false, error },
+})
+
+function byteLength(s: string): number {
+  return Buffer.byteLength(s, 'utf8')
+}
+
+/**
+ * Extract the write key from either:
+ *   - `Authorization: Basic base64("writeKey:")`  (standard path), or
+ *   - `?writeKey=...`                              (sendBeacon unload path).
+ * The standard path wins if both are present.
+ */
+function extractWriteKey(req: RelayRequest): string | undefined {
+  const auth = req.headers['authorization'] ?? req.headers['Authorization']
+  if (auth && /^Basic\s+/i.test(auth)) {
+    const b64 = auth.replace(/^Basic\s+/i, '')
+    let decoded = ''
+    try {
+      decoded = Buffer.from(b64, 'base64').toString('utf8')
+    } catch {
+      return undefined
+    }
+    // Format is "writeKey:" — strip the trailing colon (password is empty).
+    const colon = decoded.indexOf(':')
+    return colon >= 0 ? decoded.slice(0, colon) : decoded
+  }
+  const qIndex = req.url.indexOf('?')
+  if (qIndex >= 0) {
+    const params = new URLSearchParams(req.url.slice(qIndex + 1))
+    const wk = params.get('writeKey')
+    if (wk != null) return wk
+  }
+  return undefined
+}
+
+/** Path must be exactly `/v{SCHEMA_VERSION}/batch` (ignoring the query). */
+function isBatchPath(url: string): boolean {
+  const path = url.split('?', 1)[0].replace(/\/+$/, '') || '/'
+  return path === `/v${SCHEMA_VERSION}/batch`
+}
+
+function isAnalyticsEvent(v: unknown): v is AnalyticsEvent {
+  if (typeof v !== 'object' || v === null) return false
+  const e = v as Record<string, unknown>
+  return (
+    typeof e.type === 'string' &&
+    typeof e.messageId === 'string' &&
+    e.messageId.length > 0 &&
+    typeof e.anonymousId === 'string' &&
+    typeof e.sessionId === 'string' &&
+    typeof e.timestamp === 'string' &&
+    typeof e.schemaVersion === 'number' &&
+    typeof e.context === 'object' &&
+    e.context !== null
+  )
+}
+
+/** Bounded FIFO "set" for messageId idempotency without unbounded growth. */
+class DedupeWindow {
+  private set = new Set<string>()
+  private order: string[] = []
+  constructor(private readonly max: number) {}
+  has(id: string): boolean {
+    return this.set.has(id)
+  }
+  add(id: string): void {
+    this.set.add(id)
+    this.order.push(id)
+    if (this.order.length > this.max) {
+      const evicted = this.order.shift()
+      if (evicted !== undefined) this.set.delete(evicted)
+    }
+  }
+  clear(): void {
+    this.set.clear()
+    this.order = []
+  }
+}
+
+export function createRelay(options: RelayOptions): AnalyticsRelay {
+  const writeKeys = new Set(options.writeKeys)
+  const forwarders = options.forwarders ?? []
+  const maxSkew = options.maxClockSkewMs ?? 24 * 60 * 60 * 1000
+  const maxBatchBytes = options.maxBatchBytes ?? MAX_BATCH_BYTES
+  const maxEventBytes = options.maxEventBytes ?? MAX_EVENT_BYTES
+  const dedupe = new DedupeWindow(options.dedupeWindow ?? 100_000)
+
+  const queued: QueuedEvent[] = []
+  const forwarded: AnalyticsRelay['forwarded'] extends ReadonlyArray<infer T>
+    ? T[]
+    : never = []
+
+  async function handleRequest(req: RelayRequest): Promise<RelayResponse> {
+    if (req.method.toUpperCase() !== 'POST') {
+      return bad('method not allowed (POST only)')
+    }
+    if (!isBatchPath(req.url)) {
+      return bad(`not found — expected POST /v${SCHEMA_VERSION}/batch`)
+    }
+
+    // Auth (Basic header OR ?writeKey= beacon fallback).
+    const key = extractWriteKey(req)
+    if (!key || !writeKeys.has(key)) {
+      return unauthorized()
+    }
+
+    // Per-batch size cap (413 → client drops, never retries).
+    if (byteLength(req.rawBody) > maxBatchBytes) {
+      return tooLarge('batch exceeds size limit')
+    }
+
+    // Parse (400 → client drops, never retries).
+    let envelope: RelayBatchEnvelope
+    try {
+      envelope = JSON.parse(req.rawBody) as RelayBatchEnvelope
+    } catch {
+      return bad('invalid JSON')
+    }
+    if (
+      typeof envelope !== 'object' ||
+      envelope === null ||
+      !Array.isArray(envelope.batch)
+    ) {
+      return bad('missing or invalid `batch` array')
+    }
+
+    // Clock skew: corrected = timestamp + (receivedAt − sentAt).
+    const sentAtMs =
+      typeof envelope.sentAt === 'string'
+        ? new Date(envelope.sentAt).getTime()
+        : NaN
+    const skewOffset = Number.isFinite(sentAtMs)
+      ? req.receivedAt - sentAtMs
+      : 0
+
+    const toForward: AnalyticsEvent[] = []
+    let accepted = 0
+    let deduped = 0
+
+    for (const raw of envelope.batch) {
+      if (!isAnalyticsEvent(raw)) {
+        return bad('batch contains a malformed event')
+      }
+      if (raw.schemaVersion !== SCHEMA_VERSION) {
+        return bad(
+          `unsupported schemaVersion ${raw.schemaVersion} ` +
+            `(this relay speaks v${SCHEMA_VERSION})`,
+        )
+      }
+      // Per-event size cap.
+      if (byteLength(JSON.stringify(raw)) > maxEventBytes) {
+        return tooLarge('event exceeds per-event size limit')
+      }
+
+      // Idempotency — silently drop a messageId we already queued.
+      if (dedupe.has(raw.messageId)) {
+        deduped++
+        continue
+      }
+
+      const correctedMs = new Date(raw.timestamp).getTime() + skewOffset
+      if (
+        maxSkew > 0 &&
+        Number.isFinite(correctedMs) &&
+        Math.abs(correctedMs - req.receivedAt) > maxSkew
+      ) {
+        return bad('event timestamp outside the accepted clock-skew window')
+      }
+
+      dedupe.add(raw.messageId)
+      queued.push({
+        event: raw,
+        correctedTimestamp: new Date(correctedMs).toISOString(),
+      })
+      toForward.push(raw)
+      accepted++
+    }
+
+    // Accept-and-queue: respond 200 immediately; fan-out is "best effort"
+    // and does not change the response (the client only knows it's queued).
+    await Promise.all(
+      forwarders.flatMap((fwd) =>
+        toForward.map(async (ev) => {
+          const r = await fwd.forward(ev)
+          forwarded.push({
+            name: fwd.name,
+            messageId: ev.messageId,
+            ok: r.ok,
+            status: r.status,
+          })
+        }),
+      ),
+    )
+
+    return ok(accepted, deduped)
+  }
+
+  return {
+    handleRequest,
+    get queued() {
+      return queued
+    },
+    get forwarded() {
+      return forwarded
+    },
+    reset() {
+      queued.length = 0
+      forwarded.length = 0
+      dedupe.clear()
+    },
+  }
+}

--- a/packages/analytics-relay-reference/src/forwarders.ts
+++ b/packages/analytics-relay-reference/src/forwarders.ts
@@ -1,0 +1,202 @@
+/**
+ * Server-side fan-out forwarders.
+ *
+ * The reference relay accepts the canonical Segment-spec batch and then fans
+ * each event out to downstream destinations *server-side* (ad-blocker-proof —
+ * the browser only ever ships our neutral router to our own `endpoint`).
+ *
+ * Two reference forwarders are provided:
+ *
+ *   - GA4 Measurement Protocol  (`POST /mp/collect`)
+ *   - Azure Application Insights (`POST /v2/track`)
+ *
+ * Both are deliberately thin and use only an injectable `fetch` so the
+ * conformance suite can assert the exact downstream wire shape without any
+ * network or vendor SDK. The mapping is *collection parity*: identity and the
+ * canonical params map directly; reporting is delegated to the vendor.
+ */
+
+import type { AnalyticsEvent } from '@refraction-ui/analytics'
+
+export type ForwarderFetch = (
+  url: string,
+  init: {
+    method: string
+    headers: Record<string, string>
+    body: string
+  },
+) => Promise<{ status: number }>
+
+/** A downstream destination the relay fans every accepted event out to. */
+export interface Forwarder {
+  /** Stable id (used in delivery reports / logs). */
+  readonly name: string
+  /** Forward a single canonical event. Never throws — returns ok/!ok. */
+  forward(event: AnalyticsEvent): Promise<{ ok: boolean; status: number }>
+}
+
+/* ------------------------------------------------------------------ */
+/* GA4 Measurement Protocol                                            */
+/* ------------------------------------------------------------------ */
+
+export interface GA4ForwarderOptions {
+  measurementId: string
+  apiSecret: string
+  /** Override the MP base (defaults to the real Google endpoint). */
+  baseUrl?: string
+  fetchImpl: ForwarderFetch
+}
+
+/**
+ * GA4 has no `screen` call; map screen→page-like and identify→a `login`
+ * style event so collection parity holds. `userId` maps to GA4 `user_id`,
+ * `anonymousId` to the MP `client_id`.
+ */
+function ga4EventName(ev: AnalyticsEvent): string {
+  switch (ev.type) {
+    case 'page':
+      return 'page_view'
+    case 'screen':
+      return 'screen_view'
+    case 'identify':
+      return 'identify'
+    case 'group':
+      return 'group'
+    case 'alias':
+      return 'alias'
+    case 'track':
+    default:
+      return sanitizeGa4Name(ev.event ?? 'track')
+  }
+}
+
+/** GA4 event names must be snake_case-ish: [a-zA-Z0-9_], <=40 chars. */
+function sanitizeGa4Name(name: string): string {
+  return name
+    .trim()
+    .replace(/[^a-zA-Z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 40)
+    .toLowerCase()
+}
+
+export function createGA4Forwarder(opts: GA4ForwarderOptions): Forwarder {
+  const base = (opts.baseUrl ?? 'https://www.google-analytics.com').replace(
+    /\/+$/,
+    '',
+  )
+  return {
+    name: 'ga4',
+    async forward(ev) {
+      const url =
+        `${base}/mp/collect` +
+        `?measurement_id=${encodeURIComponent(opts.measurementId)}` +
+        `&api_secret=${encodeURIComponent(opts.apiSecret)}`
+
+      const params: Record<string, unknown> = {
+        ...(ev.properties ?? {}),
+        ...(ev.traits ?? {}),
+        session_id: ev.sessionId,
+        engagement_time_msec: 1,
+      }
+
+      const payload = {
+        client_id: ev.anonymousId,
+        ...(ev.userId ? { user_id: ev.userId } : {}),
+        timestamp_micros: new Date(ev.timestamp).getTime() * 1000,
+        non_personalized_ads: false,
+        events: [{ name: ga4EventName(ev), params }],
+      }
+
+      try {
+        const res = await opts.fetchImpl(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        return { ok: res.status >= 200 && res.status < 300, status: res.status }
+      } catch {
+        return { ok: false, status: 0 }
+      }
+    },
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Azure Application Insights                                          */
+/* ------------------------------------------------------------------ */
+
+export interface AzureForwarderOptions {
+  instrumentationKey: string
+  /** Override the ingestion base (defaults to the real Azure endpoint). */
+  baseUrl?: string
+  fetchImpl: ForwarderFetch
+}
+
+/**
+ * Azure App Insights ingests an `Envelope` with a typed `data.baseData`.
+ * track/page → `EventData` / `PageViewData`; identify maps onto the
+ * `ai.user.authUserId` / `ai.user.id` context tags. We keep only the
+ * subset needed to demonstrate collection parity.
+ */
+export function createAzureForwarder(opts: AzureForwarderOptions): Forwarder {
+  const base = (opts.baseUrl ?? 'https://dc.services.visualstudio.com').replace(
+    /\/+$/,
+    '',
+  )
+  return {
+    name: 'azure-app-insights',
+    async forward(ev) {
+      const isPageView = ev.type === 'page' || ev.type === 'screen'
+      const baseType = isPageView ? 'PageViewData' : 'EventData'
+      const name = ev.event ?? ev.type
+
+      const envelope = {
+        name: `Microsoft.ApplicationInsights.${
+          isPageView ? 'PageView' : 'Event'
+        }`,
+        time: ev.timestamp,
+        iKey: opts.instrumentationKey,
+        tags: {
+          'ai.user.id': ev.anonymousId,
+          ...(ev.userId ? { 'ai.user.authUserId': ev.userId } : {}),
+          'ai.session.id': ev.sessionId,
+          'ai.cloud.role': ev.context.app,
+        },
+        data: {
+          baseType,
+          baseData: {
+            ver: 2,
+            name,
+            properties: stringifyValues({
+              ...(ev.properties ?? {}),
+              ...(ev.traits ?? {}),
+              env: ev.context.env,
+              messageId: ev.messageId,
+            }),
+          },
+        },
+      }
+
+      try {
+        const res = await opts.fetchImpl(`${base}/v2/track`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(envelope),
+        })
+        return { ok: res.status >= 200 && res.status < 300, status: res.status }
+      } catch {
+        return { ok: false, status: 0 }
+      }
+    },
+  }
+}
+
+/** App Insights `properties` is a string→string map. */
+function stringifyValues(o: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [k, v] of Object.entries(o)) {
+    out[k] = typeof v === 'string' ? v : JSON.stringify(v)
+  }
+  return out
+}

--- a/packages/analytics-relay-reference/src/index.ts
+++ b/packages/analytics-relay-reference/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @refraction-ui/analytics-relay-reference
+ *
+ * A minimal, dependency-free **reference server-relay backend** that
+ * implements the @refraction-ui/analytics Segment HTTP Tracking API wire
+ * contract and fans accepted events out, server-side, to GA4 (Measurement
+ * Protocol) and Azure Application Insights.
+ *
+ * INTERNAL — never published (`"private": true`, version 0.0.0). It exists so
+ * the core `http` sink can be conformance-tested against a real backend and
+ * so the documented wire contract has an executable reference implementation.
+ *
+ * The browser only ever ships our neutral router to *your* `endpoint`; the
+ * relay does the vendor fan-out — that is the recommended ad-blocker-proof
+ * production topology.
+ */
+
+export {
+  createRelay,
+  MAX_BATCH_BYTES,
+  MAX_EVENT_BYTES,
+} from './collector.js'
+export type {
+  AnalyticsRelay,
+  RelayOptions,
+  RelayRequest,
+  RelayResponse,
+  RelayBatchEnvelope,
+  QueuedEvent,
+} from './collector.js'
+
+export { createNodeRelayServer } from './server.js'
+export type { NodeRelayServer } from './server.js'
+
+export {
+  createGA4Forwarder,
+  createAzureForwarder,
+} from './forwarders.js'
+export type {
+  Forwarder,
+  ForwarderFetch,
+  GA4ForwarderOptions,
+  AzureForwarderOptions,
+} from './forwarders.js'

--- a/packages/analytics-relay-reference/src/server.ts
+++ b/packages/analytics-relay-reference/src/server.ts
@@ -1,0 +1,89 @@
+/**
+ * Thin Node `http` binding for the reference relay.
+ *
+ * Zero dependencies — uses only Node's built-in `http`. The collector
+ * (collector.ts) holds all wire-contract logic; this only reads the body
+ * and maps the {status, body} result onto the response. The conformance
+ * suite drives a real socket through this so the core `http` sink is
+ * validated against the actual on-the-wire behaviour.
+ */
+
+import { createServer, type Server } from 'node:http'
+import { AddressInfo } from 'node:net'
+import { createRelay, type RelayOptions, type AnalyticsRelay } from './collector.js'
+
+export interface NodeRelayServer {
+  /** The underlying relay (queue/dedupe/fan-out introspection for tests). */
+  readonly relay: AnalyticsRelay
+  /** Start listening; resolves with the bound base URL (e.g. http://127.0.0.1:PORT). */
+  listen(port?: number): Promise<string>
+  close(): Promise<void>
+  readonly server: Server
+}
+
+const MAX_BODY_BYTES = 2_000_000 // hard ceiling — refuse abusive bodies early
+
+export function createNodeRelayServer(
+  options: RelayOptions,
+): NodeRelayServer {
+  const relay = createRelay(options)
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    let aborted = false
+
+    req.on('data', (c: Buffer) => {
+      size += c.length
+      if (size > MAX_BODY_BYTES) {
+        aborted = true
+        res.writeHead(413, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: false, error: 'body too large' }))
+        req.destroy()
+        return
+      }
+      chunks.push(c)
+    })
+
+    req.on('end', () => {
+      if (aborted) return
+      void (async () => {
+        const result = await relay.handleRequest({
+          method: req.method ?? 'GET',
+          url: req.url ?? '/',
+          headers: req.headers as Record<string, string | undefined>,
+          rawBody: Buffer.concat(chunks).toString('utf8'),
+          receivedAt: Date.now(),
+        })
+        res.writeHead(result.status, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify(result.body))
+      })()
+    })
+
+    req.on('error', () => {
+      if (!res.headersSent) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: false, error: 'request error' }))
+      }
+    })
+  })
+
+  return {
+    relay,
+    server,
+    listen(port = 0) {
+      return new Promise<string>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(port, '127.0.0.1', () => {
+          const addr = server.address() as AddressInfo
+          resolve(`http://127.0.0.1:${addr.port}`)
+        })
+      })
+    },
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      })
+    },
+  }
+}

--- a/packages/analytics-relay-reference/tsconfig.json
+++ b/packages/analytics-relay-reference/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/analytics-relay-reference/vitest.config.ts
+++ b/packages/analytics-relay-reference/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Resolve the core package to its TS source so the conformance suite
+      // round-trips the *actual* `http` sink without requiring a prior build.
+      '@refraction-ui/analytics': fileURLToPath(
+        new URL('../analytics/src/index.ts', import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,16 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/analytics-relay-reference:
+    dependencies:
+      '@refraction-ui/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+    devDependencies:
+      '@types/node':
+        specifier: 22.0.0
+        version: 22.0.0
+
   packages/analytics-sink-app-insights:
     dependencies:
       '@microsoft/applicationinsights-web':


### PR DESCRIPTION
Wave 3 of epic #213. Private `packages/analytics-relay-reference` implementing the Segment HTTP Tracking API wire contract (auth + `?writeKey=` beacon fallback, accept-and-queue codes, messageId idempotency, clock-skew, size caps, schemaVersion) with server-side GA4 Measurement Protocol + Azure App Insights fan-out. 24-test conformance suite round-trips the **real** `@refraction-ui/analytics` http sink over a real socket. docs-site analytics page (consumer API, full wire-contract spec, server-relay topology) + Analytics nav (merged alongside #212's Telemetry group). No changeset (reference pkg private).

✅ relay test/typecheck/lint exit 0 (24 tests) · docs build exit 0. Closes #221.