### PR TITLE
feat(shared): devWarn + library-origin error envelope (#248)

### DIFF
--- a/.changeset/devwarn-error-feedback.md
+++ b/.changeset/devwarn-error-feedback.md
@@ -1,0 +1,8 @@
+---
+"@refraction-ui/shared": minor
+---
+
+feat: add zero-dep devWarn/devError dev-feedback primitives + library-origin error envelope
+
+- `devWarn(code, message, detail?)` / `devError(...)`: `process.env.NODE_ENV !== 'production'` guarded (dead-code-strippable), warn-once dedupe per code, no dependency on `@refraction-ui/logger`; optional forwarding to a consumer-injected telemetry sink via `setDevFeedbackSink` (inversion of control — never an import, off until explicitly wired).
+- `libraryOriginError` / `libraryOriginEnvelope` / `stackFingerprint`: build the redacted library-origin envelope (package, componentName, version, normalized app-data-free stack fingerprint hash, framework) expressed through the existing telemetry record contract — contract reused, not redefined.

--- a/packages/shared/__tests__/dev-feedback.test.ts
+++ b/packages/shared/__tests__/dev-feedback.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  devWarn,
+  devError,
+  setDevFeedbackSink,
+  resetDevFeedback,
+  type DevFeedbackRecord,
+} from '../src/dev-feedback.js'
+
+describe('dev-feedback', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    setDevFeedbackSink(null)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    setDevFeedbackSink(null)
+    resetDevFeedback()
+  })
+
+  describe('prod env guard', () => {
+    it('does NOT warn when NODE_ENV is production', () => {
+      process.env.NODE_ENV = 'production'
+      devWarn('a/b', 'should be stripped at runtime')
+      devError('c/d', 'also stripped')
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+    })
+
+    it('does NOT forward to an injected sink in production', () => {
+      process.env.NODE_ENV = 'production'
+      const records: DevFeedbackRecord[] = []
+      setDevFeedbackSink({ log: (r) => records.push(r) })
+      devWarn('a/b', 'msg')
+      devError('a/c', 'msg')
+      expect(records).toHaveLength(0)
+    })
+
+    it('builds the guard from a string compare (statically strippable)', () => {
+      // The source must use a NODE_ENV string comparison so bundlers can
+      // dead-code-eliminate. Assert the literal is present in the source.
+      // (Behavioral proof of strip is the two tests above.)
+      const src = readSource()
+      expect(src).toContain("process.env?.NODE_ENV !== 'production'")
+    })
+  })
+
+  describe('warn-once dedupe', () => {
+    it('warns only once per code', () => {
+      process.env.NODE_ENV = 'development'
+      devWarn('react/footgun', 'first')
+      devWarn('react/footgun', 'second (suppressed)')
+      devWarn('react/footgun', 'third (suppressed)')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('errors only once per code', () => {
+      process.env.NODE_ENV = 'development'
+      devError('react/invariant', 'first')
+      devError('react/invariant', 'second (suppressed)')
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('different codes are reported independently', () => {
+      process.env.NODE_ENV = 'development'
+      devWarn('code/one', 'm1')
+      devWarn('code/two', 'm2')
+      expect(warnSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('a warn and an error sharing a code are not collapsed', () => {
+      process.env.NODE_ENV = 'development'
+      devWarn('shared/code', 'as warn')
+      devError('shared/code', 'as error')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('resetDevFeedback clears dedupe state', () => {
+      process.env.NODE_ENV = 'development'
+      devWarn('x/y', 'one')
+      resetDevFeedback()
+      devWarn('x/y', 'two')
+      expect(warnSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('zero hard dependency on @refraction-ui/logger', () => {
+    it('dev-feedback source never imports the logger', () => {
+      const src = readSource()
+      // No ESM/CJS/dynamic import of the telemetry lib (prose mentions in
+      // JSDoc are fine — the contract is mirrored structurally, not imported).
+      expect(src).not.toMatch(
+        /(?:import|require|from)\s*\(?\s*['"]@refraction-ui\/logger['"]/,
+      )
+      expect(src).not.toMatch(/from\s+['"]@refraction-ui\/logger['"]/)
+    })
+
+    it('shared package.json declares no dependencies at all', async () => {
+      const pkg = await import('../package.json', {
+        with: { type: 'json' },
+      })
+      const deps = (pkg.default ?? pkg) as {
+        dependencies?: Record<string, string>
+      }
+      expect(deps.dependencies ?? {}).toEqual({})
+    })
+  })
+
+  describe('optional sink forwarding (inversion, opt-in only)', () => {
+    it('does NOT forward when no sink is injected', () => {
+      process.env.NODE_ENV = 'development'
+      // No setDevFeedbackSink call — nothing should phone home.
+      expect(() => devWarn('no/sink', 'msg')).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('forwards a structured record ONLY when a sink is injected', () => {
+      process.env.NODE_ENV = 'development'
+      const records: DevFeedbackRecord[] = []
+      setDevFeedbackSink({ log: (r) => records.push(r) })
+
+      devWarn('w/code', 'warn message', { extra: 1 })
+      devError('e/code', 'error message')
+
+      expect(records).toHaveLength(2)
+      expect(records[0]).toMatchObject({
+        level: 'warn',
+        message: 'w/code: warn message',
+        context: { code: 'w/code', extra: 1 },
+      })
+      expect(typeof records[0].timestamp).toBe('number')
+      expect(records[1]).toMatchObject({
+        level: 'error',
+        message: 'e/code: error message',
+        context: { code: 'e/code' },
+      })
+    })
+
+    it('a throwing sink never breaks the caller', () => {
+      process.env.NODE_ENV = 'development'
+      setDevFeedbackSink({
+        log() {
+          throw new Error('sink boom')
+        },
+      })
+      expect(() => devWarn('safe/code', 'msg')).not.toThrow()
+    })
+
+    it('unwiring with null stops forwarding', () => {
+      process.env.NODE_ENV = 'development'
+      const records: DevFeedbackRecord[] = []
+      setDevFeedbackSink({ log: (r) => records.push(r) })
+      devWarn('a/1', 'm')
+      setDevFeedbackSink(null)
+      devWarn('a/2', 'm')
+      expect(records).toHaveLength(1)
+    })
+  })
+})
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readSource(): string {
+  const path = fileURLToPath(
+    new URL('../src/dev-feedback.ts', import.meta.url),
+  )
+  return readFileSync(path, 'utf8')
+}

--- a/packages/shared/__tests__/library-origin-error.test.ts
+++ b/packages/shared/__tests__/library-origin-error.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import {
+  libraryOriginError,
+  libraryOriginEnvelope,
+  stackFingerprint,
+  type LibraryOriginErrorInput,
+} from '../src/library-origin-error.js'
+
+const REFRACTION_STACK = [
+  'Error: boom',
+  '    at Dialog (/abs/path/node_modules/@refraction-ui/react/dist/index.js:120:15)',
+  '    at renderWithHooks (/abs/path/node_modules/react-dom/cjs/react-dom.development.js:14985:18)',
+  '    at App (/Users/someuser/secret-project/src/App.tsx:42:7)',
+].join('\n')
+
+const SAME_ERROR_DIFFERENT_PATHS = [
+  'Error: boom',
+  '    at Dialog (/totally/different/machine/node_modules/@refraction-ui/react/dist/index.js:120:15)',
+  '    at renderWithHooks (/x/react-dom.development.js:99999:1)',
+  '    at App (/home/otheruser/another-app/src/Main.tsx:7:3)',
+].join('\n')
+
+function input(over: Partial<LibraryOriginErrorInput> = {}): LibraryOriginErrorInput {
+  return {
+    package: '@refraction-ui/react',
+    componentName: 'Dialog',
+    version: '0.1.5',
+    framework: 'react',
+    error: Object.assign(new Error('boom'), { stack: REFRACTION_STACK }),
+    ...over,
+  }
+}
+
+describe('library-origin-error', () => {
+  describe('envelope shape (reuses telemetry record contract)', () => {
+    it('libraryOriginError returns a LogRecord-shaped record', () => {
+      const rec = libraryOriginError(input())
+      expect(rec.level).toBe('error')
+      expect(typeof rec.message).toBe('string')
+      expect(typeof rec.timestamp).toBe('number')
+      expect(typeof rec.context).toBe('object')
+    })
+
+    it('envelope carries exactly the five identifying fields + origin', () => {
+      const env = libraryOriginEnvelope(input())
+      expect(env).toEqual({
+        origin: 'refraction-ui',
+        package: '@refraction-ui/react',
+        componentName: 'Dialog',
+        version: '0.1.5',
+        framework: 'react',
+        fingerprint: expect.any(String),
+      })
+    })
+
+    it('the envelope rides inside context (the telemetry record field)', () => {
+      const rec = libraryOriginError(input())
+      expect(rec.context.origin).toBe('refraction-ui')
+      expect(rec.context.package).toBe('@refraction-ui/react')
+      expect(rec.context.fingerprint).toEqual(expect.any(String))
+    })
+  })
+
+  describe('fingerprint stability + app-data-free', () => {
+    it('is stable across runs for the same normalized stack', () => {
+      const a = stackFingerprint(input().error)
+      const b = stackFingerprint(input().error)
+      expect(a).toBe(b)
+      expect(a).toMatch(/^[0-9a-f]+$/)
+    })
+
+    it('is identical for the same error from different machines/paths', () => {
+      const a = stackFingerprint(
+        Object.assign(new Error('boom'), { stack: REFRACTION_STACK }),
+      )
+      const b = stackFingerprint(
+        Object.assign(new Error('boom'), {
+          stack: SAME_ERROR_DIFFERENT_PATHS,
+        }),
+      )
+      expect(a).toBe(b)
+    })
+
+    it('contains NO app paths, usernames, line numbers, or PII', () => {
+      const fp = stackFingerprint(
+        Object.assign(new Error('boom'), { stack: REFRACTION_STACK }),
+      )
+      expect(fp).not.toContain('someuser')
+      expect(fp).not.toContain('secret-project')
+      expect(fp).not.toContain('App.tsx')
+      expect(fp).not.toContain('/abs/path')
+      expect(fp).not.toMatch(/\d+:\d+/)
+    })
+
+    it('the envelope contains no app data beyond the fingerprint hash', () => {
+      const env = libraryOriginEnvelope(input())
+      const serialized = JSON.stringify(env)
+      expect(serialized).not.toContain('someuser')
+      expect(serialized).not.toContain('secret-project')
+      expect(serialized).not.toContain('App.tsx')
+      expect(serialized).not.toContain('/Users/')
+    })
+
+    it('different refraction-ui components produce different fingerprints', () => {
+      const dialogStack = REFRACTION_STACK
+      const tooltipStack = REFRACTION_STACK.replace(
+        'Dialog (',
+        'Tooltip (',
+      ).replace('/dist/index.js', '/dist/tooltip.js')
+      const a = stackFingerprint(
+        Object.assign(new Error('x'), { stack: dialogStack }),
+      )
+      const b = stackFingerprint(
+        Object.assign(new Error('x'), { stack: tooltipStack }),
+      )
+      expect(a).not.toBe(b)
+    })
+
+    it('app-only stacks (no refraction-ui frames) yield a stable no-frames hash', () => {
+      const appOnly = [
+        'Error: boom',
+        '    at App (/Users/someuser/app/src/App.tsx:1:1)',
+        '    at main (/Users/someuser/app/src/main.tsx:2:2)',
+      ].join('\n')
+      const a = stackFingerprint(
+        Object.assign(new Error('boom'), { stack: appOnly }),
+      )
+      const b = stackFingerprint(
+        Object.assign(new Error('boom'), {
+          stack: appOnly.replace('someuser', 'otheruser'),
+        }),
+      )
+      // Identical (app frames dropped) and leak-free.
+      expect(a).toBe(b)
+      const env = libraryOriginEnvelope(input({ error: appOnly }))
+      expect(JSON.stringify(env)).not.toContain('someuser')
+    })
+
+    it('accepts a raw stack string as well as an Error', () => {
+      const a = stackFingerprint(REFRACTION_STACK)
+      const b = stackFingerprint(
+        Object.assign(new Error('boom'), { stack: REFRACTION_STACK }),
+      )
+      expect(a).toBe(b)
+    })
+
+    it('handles missing/undefined error without throwing', () => {
+      expect(() => stackFingerprint(undefined)).not.toThrow()
+      expect(stackFingerprint(undefined)).toEqual(expect.any(String))
+    })
+  })
+
+  describe('zero dependency on @refraction-ui/logger', () => {
+    it('source mirrors the contract structurally, never imports the logger', () => {
+      const src = readSource()
+      // No ESM/CJS/dynamic import of the telemetry lib — the LogRecord
+      // contract is reused via the structural mirror, not imported.
+      expect(src).not.toMatch(
+        /(?:import|require|from)\s*\(?\s*['"]@refraction-ui\/logger['"]/,
+      )
+      expect(src).not.toMatch(/from\s+['"]@refraction-ui\/logger['"]/)
+      expect(src).toContain("from './dev-feedback.js'")
+    })
+  })
+})
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+function readSource(): string {
+  const path = fileURLToPath(
+    new URL('../src/library-origin-error.ts', import.meta.url),
+  )
+  return readFileSync(path, 'utf8')
+}

--- a/packages/shared/src/dev-feedback.ts
+++ b/packages/shared/src/dev-feedback.ts
@@ -1,0 +1,154 @@
+/**
+ * dev-feedback — zero-dependency `devWarn` / `devError` primitives.
+ *
+ * Design constraints (epic #247, issue #248):
+ * - Guarded by `process.env.NODE_ENV !== 'production'` so production bundlers
+ *   dead-code-strip every call (the guard is a static string compare that
+ *   minifiers fold to `false` in prod builds).
+ * - Warn-once dedupe per `code` — a footgun is reported once, not on every
+ *   render.
+ * - NO import of `@refraction-ui/logger` (no hard dependency on the telemetry
+ *   lib). Forwarding to a telemetry sink happens ONLY if the consumer
+ *   explicitly injects one (dependency inversion, never an import).
+ */
+
+/**
+ * Minimal structural shape of the record a telemetry sink consumes. This is a
+ * deliberate structural mirror of `@refraction-ui/logger`'s `LogRecord` — it is
+ * NOT imported, so `@refraction-ui/shared` keeps zero dependency on the
+ * telemetry lib. A consumer that wires the real logger sink satisfies this
+ * shape structurally.
+ */
+export interface DevFeedbackRecord {
+  level: 'warn' | 'error'
+  message: string
+  timestamp: number
+  /** Structured detail — the library-origin envelope lives here. */
+  context: Record<string, unknown>
+}
+
+/**
+ * The narrow contract a consumer-injected telemetry sink must satisfy. Kept
+ * intentionally minimal and structural so the real `TelemetrySink` from
+ * `@refraction-ui/logger` is assignable WITHOUT shared importing the logger.
+ */
+export interface DevFeedbackSink {
+  /** Receive a single dev-feedback record. Must never throw to the caller. */
+  log(record: DevFeedbackRecord): void
+}
+
+/**
+ * Minimal ambient view of `process.env` so we can read `NODE_ENV` WITHOUT
+ * pulling `@types/node` into this zero-dependency package. Accessed defensively
+ * (the `typeof process === 'undefined'` guard) so this is safe in browsers too.
+ */
+declare const process:
+  | { env?: { NODE_ENV?: string } }
+  | undefined
+
+/** Per-code dedupe set — module-scoped so it survives across calls. */
+const seen = new Set<string>()
+
+/**
+ * Optional, consumer-injected sink. `null` until a consumer explicitly wires
+ * one via {@link setDevFeedbackSink}. Nothing phones home implicitly.
+ */
+let injectedSink: DevFeedbackSink | null = null
+
+/**
+ * Wire an optional telemetry sink that {@link devWarn} / {@link devError}
+ * forward to (in addition to the console). Inversion of control: the consumer
+ * owns the sink; this package never imports it. Pass `null` to unwire.
+ *
+ * Forwarding still only happens in non-production (the calls themselves are
+ * stripped in prod), and still respects warn-once dedupe.
+ */
+export function setDevFeedbackSink(sink: DevFeedbackSink | null): void {
+  injectedSink = sink
+}
+
+/** Test-only / consumer-only escape hatch to reset warn-once dedupe state. */
+export function resetDevFeedback(): void {
+  seen.clear()
+}
+
+function isDev(): boolean {
+  // String compare (not a negated truthiness) so bundlers can statically fold
+  // `process.env.NODE_ENV` and strip the whole branch in production builds.
+  return (
+    typeof process === 'undefined' ||
+    process.env?.NODE_ENV !== 'production'
+  )
+}
+
+function emit(
+  level: 'warn' | 'error',
+  code: string,
+  message: string,
+  detail?: Record<string, unknown>,
+): void {
+  if (!isDev()) return
+
+  // Warn-once dedupe, keyed by (level, code) so an error and a warning sharing
+  // a code are not collapsed into one.
+  const key = `${level}:${code}`
+  if (seen.has(key)) return
+  seen.add(key)
+
+  const text = `[refraction-ui] ${code}: ${message}`
+
+  if (level === 'error') {
+    console.error(text, detail ?? '')
+  } else {
+    console.warn(text, detail ?? '')
+  }
+
+  // Forward to the consumer-injected sink ONLY if one was explicitly wired.
+  if (injectedSink) {
+    const record: DevFeedbackRecord = {
+      level,
+      message: `${code}: ${message}`,
+      timestamp: Date.now(),
+      context: { code, ...(detail ?? {}) },
+    }
+    try {
+      injectedSink.log(record)
+    } catch {
+      // A broken sink must never break the consumer app.
+    }
+  }
+}
+
+/**
+ * Emit a development-only warning for a refraction-ui footgun.
+ *
+ * @param code    Stable, greppable identifier (e.g. `'react/no-controlled-prop'`).
+ * @param message Human-readable explanation.
+ * @param detail  Optional structured detail (forwarded to an injected sink).
+ *
+ * Stripped entirely in production. Warned at most once per `code`.
+ */
+export function devWarn(
+  code: string,
+  message: string,
+  detail?: Record<string, unknown>,
+): void {
+  emit('warn', code, message, detail)
+}
+
+/**
+ * Emit a development-only error for a refraction-ui misuse / invariant break.
+ *
+ * @param code    Stable, greppable identifier.
+ * @param message Human-readable explanation.
+ * @param detail  Optional structured detail (forwarded to an injected sink).
+ *
+ * Stripped entirely in production. Reported at most once per `code`.
+ */
+export function devError(
+  code: string,
+  message: string,
+  detail?: Record<string, unknown>,
+): void {
+  emit('error', code, message, detail)
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,6 +48,17 @@ export type {
   SkipLinkProps,
 } from './skip-link.js'
 
+export type {
+  DevFeedbackRecord,
+  DevFeedbackSink,
+} from './dev-feedback.js'
+
+export type {
+  LibraryFramework,
+  LibraryOriginErrorInput,
+  LibraryOriginEnvelope,
+} from './library-origin-error.js'
+
 // Functions
 export { mergeAriaProps, generateId, resetIdCounter } from './aria.js'
 export { Keys, createKeyboardHandler } from './keyboard.js'
@@ -58,3 +69,14 @@ export { FOCUSABLE_SELECTOR, getFocusableElements, createFocusTrap } from './foc
 export { createLiveRegion } from './live-region.js'
 export { prefersReducedMotion, getAnimationDuration } from './motion.js'
 export { createSkipLink } from './skip-link.js'
+export {
+  devWarn,
+  devError,
+  setDevFeedbackSink,
+  resetDevFeedback,
+} from './dev-feedback.js'
+export {
+  libraryOriginError,
+  libraryOriginEnvelope,
+  stackFingerprint,
+} from './library-origin-error.js'

--- a/packages/shared/src/library-origin-error.ts
+++ b/packages/shared/src/library-origin-error.ts
@@ -1,0 +1,173 @@
+/**
+ * library-origin-error — builds the **library-origin error envelope** for
+ * errors that originate inside a `@refraction-ui/*` package.
+ *
+ * The envelope is expressed THROUGH the existing telemetry record contract
+ * (`@refraction-ui/logger`'s `LogRecord`) — the contract is reused, NOT
+ * redefined. To keep `@refraction-ui/shared` zero-dependency, the record is
+ * mirrored structurally (see {@link DevFeedbackRecord}) rather than imported;
+ * a consumer wiring the real logger sink satisfies it structurally.
+ *
+ * Aggressive redaction (epic #247 guardrails): the payload is package,
+ * componentName, version, a normalized stack **fingerprint hash**, and
+ * framework only. Never app state, props values, user data, PII, or full app
+ * stack frames.
+ */
+
+import type { DevFeedbackRecord } from './dev-feedback.js'
+
+/** Frameworks a refraction-ui adapter can run under. */
+export type LibraryFramework =
+  | 'react'
+  | 'angular'
+  | 'astro'
+  | 'vue'
+  | 'svelte'
+  | 'vanilla'
+  | 'unknown'
+
+/** Inputs describing where a library-origin error came from. */
+export interface LibraryOriginErrorInput {
+  /** Originating package, e.g. `@refraction-ui/react`. */
+  package: string
+  /** refraction-ui component the error originated in, e.g. `Dialog`. */
+  componentName: string
+  /** Originating package version, e.g. `0.1.5`. */
+  version: string
+  /** Host framework the component was running under. */
+  framework: LibraryFramework
+  /** The thrown error (or its stack string). Used ONLY to derive a hash. */
+  error?: unknown
+}
+
+/**
+ * The redacted, library-origin payload carried in `LogRecord.context`. Contains
+ * NO app data — only the five identifying fields plus a stack fingerprint hash.
+ */
+export interface LibraryOriginEnvelope {
+  /** Marks this record as a library-origin error (for downstream routing). */
+  origin: 'refraction-ui'
+  package: string
+  componentName: string
+  version: string
+  framework: LibraryFramework
+  /** Stable, app-data-free hash of the normalized stack. */
+  fingerprint: string
+}
+
+/**
+ * Normalize a stack trace into a deterministic, app-data-free string before
+ * hashing:
+ * - keep only frames that reference a `@refraction-ui/*` package (drop the
+ *   app's own frames — library-origin only),
+ * - strip absolute paths, line/column numbers, query strings, and hashes,
+ * - sort-free (preserve call order) but whitespace-collapsed.
+ *
+ * If no refraction-ui frames are present the function returns an empty string,
+ * which yields a stable "no-frames" fingerprint rather than leaking app frames.
+ */
+function normalizeStack(stack: string): string {
+  const frames = stack
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('at ') || line.includes('@'))
+    .filter((line) => /@refraction-ui\//.test(line))
+    .map((line) =>
+      line
+        // drop everything from the path/url onward, keep the symbol
+        .replace(/\((?:.*?)(@refraction-ui\/[^):]+)[^)]*\)/, '($1)')
+        .replace(/(@refraction-ui\/[^\s:?#]+)[^\s)]*/g, '$1')
+        // strip :line:col
+        .replace(/:\d+:\d+/g, '')
+        // strip line:col without colon prefix
+        .replace(/:\d+\b/g, '')
+        // strip query/hash
+        .replace(/[?#][^\s)]*/g, '')
+        .replace(/\s+/g, ' ')
+        .trim(),
+    )
+
+  return frames.join('\n')
+}
+
+/**
+ * Deterministic, dependency-free 53-bit string hash (cyrb53). Stable across
+ * runs and processes for the same input — required so the intake can dedupe by
+ * fingerprint. NOT cryptographic; it only needs to be collision-resistant
+ * enough to group identical normalized stacks.
+ */
+function cyrb53(str: string, seed = 0): string {
+  let h1 = 0xdeadbeef ^ seed
+  let h2 = 0x41c6ce57 ^ seed
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507)
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  const out = 4294967296 * (2097151 & h2) + (h1 >>> 0)
+  return out.toString(16).padStart(14, '0')
+}
+
+function stackOf(error: unknown): string {
+  if (typeof error === 'string') return error
+  if (
+    error &&
+    typeof error === 'object' &&
+    'stack' in error &&
+    typeof (error as { stack?: unknown }).stack === 'string'
+  ) {
+    return (error as { stack: string }).stack
+  }
+  return ''
+}
+
+/**
+ * Compute the stable stack fingerprint for a library-origin error. Exposed
+ * separately so capture seams / tests can assert fingerprint stability without
+ * building the whole record.
+ */
+export function stackFingerprint(error: unknown): string {
+  const normalized = normalizeStack(stackOf(error))
+  return cyrb53(normalized)
+}
+
+/**
+ * Build the redacted library-origin envelope for an error.
+ */
+export function libraryOriginEnvelope(
+  input: LibraryOriginErrorInput,
+): LibraryOriginEnvelope {
+  return {
+    origin: 'refraction-ui',
+    package: input.package,
+    componentName: input.componentName,
+    version: input.version,
+    framework: input.framework,
+    fingerprint: stackFingerprint(input.error),
+  }
+}
+
+/**
+ * Build the full library-origin error record, expressed THROUGH the existing
+ * telemetry record contract (`LogRecord`, mirrored as {@link DevFeedbackRecord}
+ * to avoid a hard logger dependency). The redacted envelope rides in
+ * `context`; no app data, props, PII, or app stack frames are included.
+ *
+ * This record is exactly what a consumer-wired telemetry sink (or the
+ * `devWarn`/`devError` injected sink) consumes.
+ */
+export function libraryOriginError(
+  input: LibraryOriginErrorInput,
+): DevFeedbackRecord {
+  const envelope = libraryOriginEnvelope(input)
+  return {
+    level: 'error',
+    message: `${input.package}/${input.componentName}: library-origin error`,
+    timestamp: Date.now(),
+    context: { ...envelope },
+  }
+}


### PR DESCRIPTION
Epic #247 Wave 0. Zero-dependency `devWarn`/`devError` in `@refraction-ui/shared` (prod-stripped, warn-once, opt-in consumer-injected sink — no hard `@refraction-ui/logger` dep) + redacted `libraryOriginError` envelope reusing the existing telemetry record (no contract redefinition). Additive only. Changeset: shared `minor`.

✅ turbo build/test/typecheck/lint exit 0 · full shared suite 111 tests. Closes #248. Unblocks #249 + the #254 React rollout.