### PR TITLE
docs: instrumentation tier map + policy (#255)

### DIFF
--- a/docs/instrumentation/component-tiers.json
+++ b/docs/instrumentation/component-tiers.json
@@ -1,0 +1,1006 @@
+{
+  "$schema": "https://refraction-ui.dev/schemas/component-tiers-v1.json",
+  "version": 1,
+  "generatedFor": {
+    "epic": 254,
+    "wave0Issue": 255,
+    "primitiveEpic": 247
+  },
+  "policy": "docs/instrumentation/policy.md",
+  "lintSpec": "docs/instrumentation/eslint-rule-spec.md",
+  "tiers": {
+    "footgun": "Requires provider/context, has mutually-exclusive props, deprecations, or throwing/silent misuse paths. -> dev-only devWarn (warn-once, env-guarded) on the misuse seam. Existing throws are KEPT.",
+    "async-heavy": "AI / meeting / media / voice / video / realtime. -> optional telemetry spans + error-seam routing (only when a consumer wires a sink). No-op otherwise.",
+    "skip": "Pure presentational (thin wrapper over headless core). No instrumentation. Blanket logging is explicitly forbidden."
+  },
+  "rolloutScope": "React-first: react-* packages prioritized for Waves 1-3. Angular/Astro/Flutter mirror later under the same policy.",
+  "summary": {
+    "reactPackagesTotal": 84,
+    "footgun": 27,
+    "asyncHeavy": 4,
+    "skip": 53,
+    "dualTier": [
+      "react-ai"
+    ]
+  },
+  "components": [
+    {
+      "package": "react-accordion",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "AccordionItem throws if used outside <Accordion>",
+      "loc": 148,
+      "files": [
+        "accordion.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-ai",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "provider-context-throw",
+      "rationale": "useAI/useTTS throw outside <AIProvider>/<TTSProvider>",
+      "loc": 189,
+      "files": [
+        "tts-provider.tsx",
+        "ai-provider.tsx",
+        "index.ts"
+      ],
+      "secondaryTier": "async-heavy",
+      "asyncKind": "ai",
+      "secondaryRationale": "AIProvider.generateText/generateJSON + TTS are async LLM/network calls (dual-tier: devWarn for provider misuse + telemetry on async paths)"
+    },
+    {
+      "package": "react-analytics",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "provider-context-throw",
+      "rationale": "useAnalytics throws outside <AnalyticsProvider>",
+      "loc": 108,
+      "files": [
+        "analytics-provider.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-animated-text",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 158,
+      "files": [
+        "index.ts",
+        "animated-text.tsx"
+      ]
+    },
+    {
+      "package": "react-app-shell",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "AppShell/PageShell/AuthShell compound parts throw outside their root",
+      "loc": 676,
+      "files": [
+        "page-shell.tsx",
+        "auth-shell.tsx",
+        "index.ts",
+        "app-shell.tsx"
+      ]
+    },
+    {
+      "package": "react-auth",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "required-prop-throw + provider-context-throw",
+      "rationale": "AuthProvider throws without `adapter`; useAuth throws outside <AuthProvider>",
+      "loc": 163,
+      "files": [
+        "auth-guard.tsx",
+        "auth-provider.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-avatar",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 133,
+      "files": [
+        "avatar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-avatar-group",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 76,
+      "files": [
+        "avatar-group.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-badge",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 50,
+      "files": [
+        "badge.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-bottom-nav",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 61,
+      "files": [
+        "bottom-nav.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-breadcrumbs",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 94,
+      "files": [
+        "breadcrumbs.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-button",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 121,
+      "files": [
+        "index.ts",
+        "button.tsx"
+      ]
+    },
+    {
+      "package": "react-calendar",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 225,
+      "files": [
+        "calendar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-callout",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 93,
+      "files": [
+        "index.ts",
+        "callout.tsx"
+      ]
+    },
+    {
+      "package": "react-card",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 148,
+      "files": [
+        "card.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-card-grid",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 21,
+      "files": [
+        "card-grid.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-carousel",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "CarouselItem throws outside <Carousel>",
+      "loc": 148,
+      "files": [
+        "index.ts",
+        "carousel.tsx"
+      ]
+    },
+    {
+      "package": "react-charts",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "silent-default-context",
+      "rationale": "Sub-charts read ChartContext default (zero dimensions) when used outside <Chart> \u2014 silent misuse, no throw",
+      "loc": 568,
+      "files": [
+        "gradient.tsx",
+        "pie-chart.tsx",
+        "chart.tsx",
+        "circles.tsx",
+        "histogram.tsx",
+        "chart-context.ts",
+        "bars.tsx",
+        "index.ts",
+        "line.tsx",
+        "scatter-plot.tsx",
+        "y-axis.tsx",
+        "x-axis.tsx"
+      ]
+    },
+    {
+      "package": "react-checkbox",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 110,
+      "files": [
+        "index.ts",
+        "checkbox.tsx"
+      ]
+    },
+    {
+      "package": "react-code-block",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 58,
+      "files": [
+        "code-block.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-code-editor",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 97,
+      "files": [
+        "index.ts",
+        "CodeEditor.tsx"
+      ]
+    },
+    {
+      "package": "react-collapsible",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Collapsible compound parts throw outside <Collapsible>",
+      "loc": 192,
+      "files": [
+        "index.ts",
+        "collapsible.tsx"
+      ]
+    },
+    {
+      "package": "react-combobox",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Combobox compound parts throw outside <Combobox>",
+      "loc": 821,
+      "files": [
+        "combobox.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-command",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Command compound parts throw outside <Command>",
+      "loc": 361,
+      "files": [
+        "command.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-command-input",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 106,
+      "files": [
+        "command-input.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-content-protection",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 118,
+      "files": [
+        "index.ts",
+        "content-protection.tsx"
+      ]
+    },
+    {
+      "package": "react-data-table",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 204,
+      "files": [
+        "DataTable.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-date-picker",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 258,
+      "files": [
+        "date-picker.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-device-frame",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 85,
+      "files": [
+        "device-frame.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-dialog",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Dialog compound parts throw outside <Dialog>",
+      "loc": 484,
+      "files": [
+        "radix-adapter.tsx",
+        "dialog.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-diff-viewer",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 301,
+      "files": [
+        "DiffViewer.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-dropdown-menu",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "DropdownMenu compound parts throw outside <DropdownMenu>",
+      "loc": 277,
+      "files": [
+        "index.ts",
+        "dropdown-menu.tsx"
+      ]
+    },
+    {
+      "package": "react-emoji-picker",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 177,
+      "files": [
+        "index.ts",
+        "emoji-picker.tsx"
+      ]
+    },
+    {
+      "package": "react-feedback-dialog",
+      "framework": "react",
+      "tier": "async-heavy",
+      "asyncKind": "media",
+      "rationale": "Async onSubmit with network + try/catch failure path",
+      "loc": 200,
+      "files": [
+        "FeedbackDialog.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-file-tree",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Stub/re-export only (no component logic). Nothing to instrument.",
+      "loc": 5,
+      "files": [
+        "react-file-tree.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-file-upload",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 234,
+      "files": [
+        "file-upload.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-footer",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 95,
+      "files": [
+        "footer.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-form",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "useFormField throws outside <FormField>/<FormItem>",
+      "loc": 414,
+      "files": [
+        "slot.tsx",
+        "index.ts",
+        "form.tsx"
+      ]
+    },
+    {
+      "package": "react-icon-system",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Stub/re-export only (no component logic). Nothing to instrument.",
+      "loc": 5,
+      "files": [
+        "react-icon-system.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-inline-editor",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 159,
+      "files": [
+        "index.ts",
+        "InlineEditor.tsx"
+      ]
+    },
+    {
+      "package": "react-input",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 71,
+      "files": [
+        "index.ts",
+        "input.tsx"
+      ]
+    },
+    {
+      "package": "react-input-group",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 131,
+      "files": [
+        "input-group.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-install-prompt",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 135,
+      "files": [
+        "index.ts",
+        "install-prompt.tsx"
+      ]
+    },
+    {
+      "package": "react-keyboard-shortcut",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 227,
+      "files": [
+        "index.ts",
+        "keyboard-shortcut.tsx"
+      ]
+    },
+    {
+      "package": "react-language-selector",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "LanguageSelector compound parts throw outside root",
+      "loc": 268,
+      "files": [
+        "language-selector.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-link-card",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 19,
+      "files": [
+        "link-card.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-location-selector",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 92,
+      "files": [
+        "location-selector.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-logger",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "provider-context-throw",
+      "rationale": "useTelemetry/useSpan throw outside <TelemetryProvider> (instrumentation infra itself)",
+      "loc": 256,
+      "files": [
+        "error-boundary.tsx",
+        "telemetry-provider.tsx",
+        "use-span.ts",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-markdown-renderer",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 76,
+      "files": [
+        "MarkdownRenderer.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-meta",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 194,
+      "files": [
+        "form.ts",
+        "index.ts",
+        "theme.ts"
+      ]
+    },
+    {
+      "package": "react-mobile-nav",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "MobileNav compound parts throw outside <MobileNav>",
+      "loc": 224,
+      "files": [
+        "index.ts",
+        "mobile-nav.tsx"
+      ]
+    },
+    {
+      "package": "react-navbar",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 86,
+      "files": [
+        "navbar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-otp-input",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 186,
+      "files": [
+        "otp-input.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-pagination",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 14,
+      "files": [
+        "pagination.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-payment",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 91,
+      "files": [
+        "payment.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-popover",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Popover compound parts throw outside <Popover>",
+      "loc": 190,
+      "files": [
+        "popover.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-presence-indicator",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 53,
+      "files": [
+        "presence-indicator.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-progress-display",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 148,
+      "files": [
+        "progress-display.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-radio",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "RadioItem throws outside <RadioGroup>",
+      "loc": 113,
+      "files": [
+        "radio.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-reaction-bar",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 77,
+      "files": [
+        "reaction-bar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-resizable-layout",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Resizable compound parts throw outside <ResizableLayout>",
+      "loc": 261,
+      "files": [
+        "resizable-layout.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-rich-editor",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Stub/re-export only (no component logic). Nothing to instrument.",
+      "loc": 2,
+      "files": [
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-search-bar",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "SearchBar compound parts throw outside <SearchBar>",
+      "loc": 249,
+      "files": [
+        "search-bar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-select",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "silent-default-context",
+      "rationale": "Select parts read SelectContext default when used outside <Select> \u2014 silent misuse, no throw",
+      "loc": 311,
+      "files": [
+        "index.ts",
+        "select.tsx"
+      ]
+    },
+    {
+      "package": "react-sheet",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Sheet compound parts throw outside <Sheet>",
+      "loc": 474,
+      "files": [
+        "sheet.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-sidebar",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 94,
+      "files": [
+        "sidebar.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-skeleton",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 102,
+      "files": [
+        "index.ts",
+        "skeleton.tsx"
+      ]
+    },
+    {
+      "package": "react-skip-to-content",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 32,
+      "files": [
+        "skip-to-content.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-slide-viewer",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 174,
+      "files": [
+        "index.ts",
+        "SlideViewer.tsx"
+      ]
+    },
+    {
+      "package": "react-slider",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Stub/re-export only (no component logic). Nothing to instrument.",
+      "loc": 5,
+      "files": [
+        "slider.ts",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-status-indicator",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 57,
+      "files": [
+        "status-indicator.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-steps",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 118,
+      "files": [
+        "steps.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-switch",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 71,
+      "files": [
+        "switch.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-table-of-contents",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 67,
+      "files": [
+        "index.ts",
+        "table-of-contents.tsx"
+      ]
+    },
+    {
+      "package": "react-tabs",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Tabs compound parts throw outside <Tabs>",
+      "loc": 220,
+      "files": [
+        "tabs.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-textarea",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 56,
+      "files": [
+        "index.ts",
+        "textarea.tsx"
+      ]
+    },
+    {
+      "package": "react-theme",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "provider-context-throw",
+      "rationale": "useTheme throws outside <ThemeProvider>",
+      "loc": 221,
+      "files": [
+        "theme-provider.tsx",
+        "theme-script-component.tsx",
+        "index.ts",
+        "theme-toggle.tsx"
+      ]
+    },
+    {
+      "package": "react-thread-view",
+      "framework": "react",
+      "tier": "skip",
+      "rationale": "Pure presentational thin wrapper over headless core; no provider/context throw, no mutually-exclusive props, no async/media. devWarn would be noise.",
+      "loc": 171,
+      "files": [
+        "thread-view.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-toast",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "provider-context-throw",
+      "rationale": "useToast throws outside <ToastProvider>",
+      "loc": 197,
+      "files": [
+        "index.ts",
+        "toast.tsx"
+      ]
+    },
+    {
+      "package": "react-tooltip",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "Tooltip compound parts throw outside <Tooltip>",
+      "loc": 211,
+      "files": [
+        "tooltip.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-version-selector",
+      "framework": "react",
+      "tier": "footgun",
+      "footgunKind": "compound-context-throw",
+      "rationale": "VersionSelector compound parts throw outside root",
+      "loc": 207,
+      "files": [
+        "version-selector.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-video-player",
+      "framework": "react",
+      "tier": "async-heavy",
+      "asyncKind": "video",
+      "rationale": "Video playback lifecycle: play/pause/seek/buffering via headless engine",
+      "loc": 139,
+      "files": [
+        "video-player.tsx",
+        "index.ts"
+      ]
+    },
+    {
+      "package": "react-voice-pill",
+      "framework": "react",
+      "tier": "async-heavy",
+      "asyncKind": "voice",
+      "rationale": "Voice/speaker activity pill \u2014 voice-session surface; intensity/mute lifecycle",
+      "loc": 189,
+      "files": [
+        "index.ts",
+        "voice-pill.tsx"
+      ]
+    },
+    {
+      "package": "react-waveform",
+      "framework": "react",
+      "tier": "async-heavy",
+      "asyncKind": "media",
+      "rationale": "Live AudioContext + MediaStream analysis + rAF render loop",
+      "loc": 400,
+      "files": [
+        "waveform.tsx",
+        "index.ts"
+      ]
+    }
+  ]
+}

--- a/docs/instrumentation/eslint-rule-spec.md
+++ b/docs/instrumentation/eslint-rule-spec.md
@@ -1,0 +1,123 @@
+# ESLint Rule Spec — `no-blanket-logging` / `devwarn-policy`
+
+> Wave 0 deliverable for #255 (enforces the policy in
+> [`policy.md`](./policy.md)). **Spec only** — no rule code is shipped in
+> Wave 0. Implementation lands in **Wave 4** (epic #254) once the Wave 1
+> `devWarn` rollout has established the patterns.
+
+## 1. Goal
+
+Mechanically enforce the agreed stance so the codebase cannot drift back into
+blanket logging:
+
+1. Forbid `console.*` and any `logger.info/debug/warn/error` / telemetry
+   import inside **`skip`-tier** component packages.
+2. Forbid **unconditional** logging anywhere (must be `devWarn` /
+   env-guarded / behind a provided sink).
+3. Require footgun misuse seams to use `devWarn` from
+   `@refraction-ui/shared` — not `console.warn`, not `logger.warn`.
+4. Keep telemetry in `async-heavy` packages strictly provider-gated.
+
+## 2. Package / plugin shape
+
+- New workspace package: `packages/eslint-plugin-refraction-ui`
+  (dev-only, **not** published as a runtime dep — consistent with the
+  "minimize deps / no implicit phone-home" guardrails).
+- Exposes a flat-config + legacy-config preset:
+  `plugin:@refraction-ui/instrumentation/recommended`.
+- The plugin **reads `docs/instrumentation/component-tiers.json`** at lint
+  time (resolved relative to repo root) to know each package's tier. The
+  JSON is the single source of truth; the rule has no hardcoded list.
+
+## 3. Rules
+
+### 3.1 `@refraction-ui/instrumentation/no-blanket-logging`
+
+- **Type**: problem. **Default**: `error`.
+- **Applies to**: every file under `packages/*/src/**`.
+- **Reports** when:
+  - A `CallExpression` callee matches `console.(log|info|debug|warn|error|trace)`.
+  - A call to `.info(` / `.debug(` whose receiver is a logger/telemetry
+    identifier (heuristic: imported from `@refraction-ui/logger`,
+    `@refraction-ui/react-logger`, or a var named `/logger|telemetry/i`).
+  - **And** the call is not inside an env guard (see §4).
+- **Severity escalation**: if the enclosing package's tier in the tier map is
+  `skip`, *any* logging/telemetry import or call is reported (even guarded) —
+  `skip` means **zero** instrumentation.
+- **Autofix**: none (intentional — forces a human tier decision).
+- **Message**: `Blanket logging is forbidden by docs/instrumentation/policy.md. Use devWarn (footgun) or provider-gated telemetry (async-heavy); skip-tier packages get nothing.`
+
+### 3.2 `@refraction-ui/instrumentation/devwarn-at-seam`
+
+- **Type**: suggestion. **Default**: `warn` (→ `error` after Wave 1).
+- **Applies to**: packages whose tier is `footgun`.
+- **Reports** when a known misuse seam exists without an adjacent `devWarn`:
+  - A `throw new Error(/must be used within|requires|is required/)` inside a
+    context-guard function with **no** `devWarn(...)` call in the same block.
+  - A silent-default context read (`useContext(X)` where `X` was created
+    with a non-null default) in a `silent-default-context` package, with no
+    `devWarn` on the misuse branch.
+- **Autofix**: none (the warning message must be authored).
+- **Message**: `Footgun misuse seam should emit devWarn before the throw / silent fallback (see component-tiers.json footgunKind).`
+
+### 3.3 `@refraction-ui/instrumentation/devwarn-import-source`
+
+- **Type**: problem. **Default**: `error`.
+- `devWarn` / `devError` **must** be imported from `@refraction-ui/shared`.
+  Flags `console.warn` used where the tier map says `devWarn` is required,
+  and flags `devWarn` imported from anywhere else.
+- Ensures the capture primitive stays the zero-dep `@refraction-ui/shared`
+  one (#247 / #248 guardrail), never the telemetry lib.
+
+### 3.4 `@refraction-ui/instrumentation/telemetry-must-be-provider-gated`
+
+- **Type**: problem. **Default**: `error`.
+- **Applies to**: `async-heavy` packages.
+- Flags `useSpan()` / `telemetry.*` usage that is **not** reached through
+  the `<TelemetryProvider>` context (heuristic: direct `createTelemetry(...)`
+  construction inside a component package, or a span started at module scope).
+- Guarantees the "no-op without a consumer sink" invariant.
+
+## 4. "Env guard" definition (shared helper)
+
+A logging call is *guarded* if it is statically inside one of:
+
+- `if (process.env.NODE_ENV !== 'production') { … }`
+- `if (import.meta.env.DEV) { … }` / `if (__DEV__) { … }`
+- the body of `devWarn`/`devError` from `@refraction-ui/shared` (these are
+  guarded by construction — calling them is always allowed in footgun pkgs).
+
+## 5. Config wiring (Wave 4)
+
+Add to root `.eslintrc.cjs` `overrides`:
+
+```js
+{
+  files: ['packages/*/src/**/*.{ts,tsx}'],
+  plugins: ['@refraction-ui/instrumentation'],
+  extends: ['plugin:@refraction-ui/instrumentation/recommended'],
+}
+```
+
+`recommended` = `no-blanket-logging: error`,
+`devwarn-import-source: error`,
+`telemetry-must-be-provider-gated: error`,
+`devwarn-at-seam: warn` (promote to `error` after the Wave 1 footgun rollout
+is complete and green).
+
+## 6. Test fixtures (authored with the rule in Wave 4)
+
+- ✅ `devWarn` from `@refraction-ui/shared` in a footgun package → no report.
+- ❌ `console.warn` in a footgun package → `devwarn-import-source`.
+- ❌ any `logger.info` in a `skip` package → `no-blanket-logging` (escalated).
+- ❌ unguarded `console.log` anywhere → `no-blanket-logging`.
+- ❌ `createTelemetry()` constructed inside `react-waveform` → `telemetry-must-be-provider-gated`.
+- ❌ footgun context-guard throw with no adjacent `devWarn` → `devwarn-at-seam`.
+
+## 7. Non-goals
+
+- Not a type checker; tier source of truth is `component-tiers.json`, not
+  inference.
+- Does not rewrite code (no autofix) — every instrumentation decision is a
+  reviewed human choice per the policy.
+- Does not run in consumer apps — dev-only, this repo's lint pipeline.

--- a/docs/instrumentation/policy.md
+++ b/docs/instrumentation/policy.md
@@ -1,0 +1,148 @@
+# Instrumentation Policy — refraction-ui components
+
+> Wave 0 foundation artifact for epic **#254** (Instrument all existing
+> refraction-ui components with the logger), Wave 0 issue **#255**, building on
+> the error-feedback primitive epic **#247**.
+>
+> Status: **policy + tier map**. No code changes to any package. No changeset.
+
+## 1. The stance (non-negotiable)
+
+This is the agreed React/MUI stance. It is **NOT** blanket `logger.info()`
+across the ~281 packages in this monorepo. Three, and only three, things ship:
+
+1. **`devWarn` in the footgun minority.** Dev-only, env-guarded, warn-once.
+   Emits on the *misuse seam* (wrong provider, missing context, conflicting
+   props, deprecated API). Compiles out / is silent in production. Zero
+   runtime dependency on the telemetry library.
+2. **Error seams at refraction-origin errors.** A per-framework boundary
+   (`TelemetryErrorBoundary` for React, already in `@refraction-ui/react-logger`)
+   that routes errors **originating inside a `@refraction-ui/*` package** to
+   the optional sink — *only if the consumer wired one*. Off by default.
+3. **Telemetry only at async-heavy components.** Spans/timings on AI, media,
+   voice, video, realtime lifecycles — emitted **only** when a consumer
+   provides a sink via `<TelemetryProvider>`. No-op otherwise.
+
+Everything else (pure presentational components) gets **nothing**.
+
+### Explicitly forbidden
+
+- ❌ Blanket `logger.info()` / `console.*` across packages.
+- ❌ Any unconditional log on render, mount, prop change, or event in a
+  presentational component.
+- ❌ Telemetry that runs without a consumer-provided sink (no implicit
+  phone-home — consistent with #247 OSS guardrails).
+- ❌ Logging prop *values*, app state, user data, or PII. Error seams ship
+  redacted fingerprints only (package / componentName / version / normalized
+  stack hash / framework / count), per #247.
+- ❌ New telemetry contracts. The existing logger sink + wire contract
+  (`@refraction-ui/logger`, #214/#221) is reused, never redefined.
+
+## 2. Tiers
+
+The machine-readable map lives in
+[`component-tiers.json`](./component-tiers.json). Every React component package
+is classified into exactly one **primary** tier; `react-ai` additionally
+carries a **secondary** tier (see §2.4).
+
+### 2.1 `footgun` → `devWarn`
+
+A component is a footgun if **any** of:
+
+- It requires a provider/context and **throws** when used outside it
+  (`useX must be used within <XProvider>`, compound-part guards).
+- It has a **silent-default context** — sub-parts read a context default and
+  render visibly wrong (e.g. zero dimensions) instead of throwing. This is the
+  *worst* footgun: no error, no signal. `react-charts`, `react-select`.
+- It has a **required prop** whose absence throws (`AuthProvider` without
+  `adapter`).
+- It has **mutually-exclusive props** or a **deprecated** prop/API path.
+
+Treatment:
+
+- Add a `devWarn(...)` (from `@refraction-ui/shared`, primitive landed via
+  #248) **at the misuse seam**, *before* the existing throw or alongside the
+  silent fallback.
+- **Keep the existing `throw`.** `devWarn` augments, never replaces, the
+  thrown error. For silent-default contexts, `devWarn` is the *only* signal —
+  do not introduce a throw (would be a breaking change).
+- `devWarn` is warn-once per message, env-guarded (`process.env.NODE_ENV !==
+  'production'` / `import.meta.env.DEV`), and **must not import the telemetry
+  library**. If a consumer wired the diagnostics sink (#247 W1), the error
+  seam — not `devWarn` — forwards a redacted fingerprint.
+
+### 2.2 `async-heavy` → optional telemetry + error seam
+
+AI / meeting / media / voice / video / realtime components. Treatment:
+
+- Wrap the async lifecycle (LLM call, playback start→ready, recording
+  session, audio-analysis loop) in a span via `useSpan()` from
+  `@refraction-ui/react-logger`.
+- Failures route through the error seam (`TelemetryErrorBoundary` /
+  explicit `telemetry.error(...)` on the catch path).
+- **All of this is a no-op unless the consumer mounted `<TelemetryProvider>`
+  with a sink.** No provider → zero records, zero overhead.
+- Span attributes are operational only (model name, duration, status) —
+  **never** prompt content, audio bytes, user input.
+
+### 2.3 `skip` → nothing
+
+Pure presentational thin wrappers over a headless core (Badge, Card,
+Skeleton, …) and stub/re-export-only packages. **No instrumentation.** Adding
+`devWarn`/logging here is the exact anti-pattern this policy forbids.
+
+### 2.4 Dual-tier (`react-ai`)
+
+`react-ai` is **both** a footgun (`useAI`/`useTTS` throw outside their
+provider) **and** async-heavy (`generateText`/`generateJSON`/TTS are async
+network calls). Both treatments apply: `devWarn` on the provider-misuse seam
+**and** telemetry spans on the async generate/stream paths. Primary tier in
+the map is `footgun`; `secondaryTier: "async-heavy"` records the telemetry
+obligation.
+
+## 3. React-first prioritization
+
+Rollout is **React-first**: the `react-*` packages are instrumented in
+Waves 1–3 before any Angular / Astro / Flutter mirror. Rationale:
+
+- React is the reference framework (most consumers, the primitive landed in
+  `@refraction-ui/react-logger` first).
+- Angular/Astro/Flutter wrappers re-expose the same headless cores; once the
+  React policy is proven, the mirror is mechanical and lower-risk.
+- Per project guidance: headless core + React first; other frameworks when
+  idle.
+
+The non-React framework packages (`angular-*`, `astro-*`, Flutter) are **out
+of scope for the prioritized rollout** but inherit this identical policy and
+tier mapping by component name when their wave is scheduled.
+
+## 4. Mapping to epic waves
+
+| Wave | Scope | Tier | Dep |
+|------|-------|------|-----|
+| 0 | This doc + tier map + lint spec | — | logger core, #248, #255 |
+| 1 | Footgun `devWarn` rollout (React, batched) | `footgun` | W0 + #248 |
+| 2 | Error-seam wiring across React adapters | all w/ refraction-origin errors | W0 + #249 |
+| 3 | Async-heavy telemetry instrumentation (React) | `async-heavy` | W0 |
+| 4 | Enforcement lint rule + docs | — | W1, see [`eslint-rule-spec.md`](./eslint-rule-spec.md) |
+
+## 5. Acceptance per component (Waves 1–3)
+
+A component is "done" for its tier when:
+
+- **footgun**: `devWarn` at every misuse seam; existing throw retained; a
+  test asserts the warn fires once in dev and is silent in prod; no
+  `console.*`/`logger.info` added.
+- **async-heavy**: span emitted on the async lifecycle; verified no-op
+  without a provider; failure path routes to the seam; no payload leakage.
+- **skip**: explicitly left untouched; lint rule (Wave 4) flags any
+  `devWarn`/logger import added to a `skip` package as an error.
+
+## 6. Verification of this artifact
+
+- `component-tiers.json` parses as valid JSON (verified).
+- Markdown is **pure docs**: the `docs-site` app is a Next.js app with
+  hardcoded routes and does **not** ingest `docs/**`. No markdown build step
+  picks this up; nothing to "build".
+- **No changeset**: zero code changes to any `packages/*` — analysis +
+  committed docs/JSON only.


### PR DESCRIPTION
Epic #254 Wave 0. `docs/instrumentation/`: machine-readable component-tier map (84 react pkgs → footgun/async-heavy/skip), written policy (devWarn vs error-seam vs telemetry vs nothing; forbids blanket logging), and the ESLint enforcement spec. Drives the React-first devWarn rollout. Pure docs — no changeset. Closes #255.