### PR TITLE
feat(flutter): Dart telemetry core (#226)

### DIFF
--- a/packages/flutter/lib/refraction_ui.dart
+++ b/packages/flutter/lib/refraction_ui.dart
@@ -66,3 +66,4 @@ export 'src/components/bottom_nav.dart';
 export 'src/components/breadcrumbs.dart';
 export 'src/components/footer.dart';
 export 'src/components/skeleton.dart';
+export 'src/telemetry/telemetry.dart';

--- a/packages/flutter/lib/src/telemetry/console_sink.dart
+++ b/packages/flutter/lib/src/telemetry/console_sink.dart
@@ -1,0 +1,193 @@
+/// Default zero-dependency console transport — a 1:1 port of
+/// `@refraction-ui/logger` `console-sink.ts`.
+library;
+
+import 'dart:convert';
+
+import 'types.dart';
+
+/// A console-ish writer with one method per level. Injectable for tests so a
+/// suite can capture output without touching the real console. Mirrors the
+/// `Pick<Console, 'debug' | 'info' | 'warn' | 'error'>` shape on the web.
+abstract class ConsoleLike {
+  /// Write a debug-level line.
+  void debug(String line, Object? payload);
+
+  /// Write an info-level line.
+  void info(String line, Object? payload);
+
+  /// Write a warn-level line.
+  void warn(String line, Object? payload);
+
+  /// Write an error-level line.
+  void error(String line, Object? payload);
+}
+
+/// Console method used for each level (`fatal` -> `error`, as on the web).
+const Map<LogLevel, String> _method = <LogLevel, String>{
+  LogLevel.debug: 'debug',
+  LogLevel.info: 'info',
+  LogLevel.warn: 'warn',
+  LogLevel.error: 'error',
+  LogLevel.fatal: 'error',
+};
+
+/// Default [ConsoleLike] — writes through `dart:developer`-free `print`
+/// equivalents. Platform-agnostic: identical on web/android/ios/desktop.
+class _DefaultConsole implements ConsoleLike {
+  const _DefaultConsole();
+
+  void _emit(String tag, String line, Object? payload) {
+    // ignore: avoid_print
+    print('$tag $line ${_stringifyPayload(payload)}');
+  }
+
+  static String _stringifyPayload(Object? payload) {
+    if (payload == null) return '';
+    try {
+      return jsonEncode(payload);
+    } catch (_) {
+      return payload.toString();
+    }
+  }
+
+  @override
+  void debug(String line, Object? payload) => _emit('DEBUG', line, payload);
+
+  @override
+  void info(String line, Object? payload) => _emit('INFO', line, payload);
+
+  @override
+  void warn(String line, Object? payload) => _emit('WARN', line, payload);
+
+  @override
+  void error(String line, Object? payload) => _emit('ERROR', line, payload);
+}
+
+/// Options for [createConsoleSink].
+class ConsoleSinkOptions {
+  /// Creates [ConsoleSinkOptions].
+  const ConsoleSinkOptions({this.pretty, this.console});
+
+  /// Single-line pretty output (vs. structured JSON). Defaults to `true`.
+  final bool? pretty;
+
+  /// Console to write to (injectable for tests). Defaults to a built-in.
+  final ConsoleLike? console;
+}
+
+class _ConsoleSink implements TelemetrySink {
+  _ConsoleSink(this._pretty, this._out);
+
+  final bool _pretty;
+  final ConsoleLike _out;
+
+  @override
+  String get name => 'console';
+
+  void _emit(LogLevel level, String line, Object? payload) {
+    switch (_method[level]) {
+      case 'debug':
+        _out.debug(line, payload);
+        break;
+      case 'info':
+        _out.info(line, payload);
+        break;
+      case 'warn':
+        _out.warn(line, payload);
+        break;
+      case 'error':
+      default:
+        _out.error(line, payload);
+        break;
+    }
+  }
+
+  @override
+  void log(LogRecord record) {
+    if (_pretty) {
+      final ts = DateTime.fromMillisecondsSinceEpoch(
+        record.timestamp,
+        isUtc: true,
+      ).toIso8601String();
+      _emit(
+        record.level,
+        '$ts ${record.level.wireName.toUpperCase()} '
+        '[${record.app}] ${record.message}',
+        record.context,
+      );
+    } else {
+      _emit(
+        record.level,
+        jsonEncode(<String, Object?>{
+          'type': 'log',
+          ...logRecordToJson(record),
+        }),
+        record.context,
+      );
+    }
+  }
+
+  @override
+  void span(SpanRecord record) {
+    final level = record.status == 'error' ? LogLevel.error : LogLevel.debug;
+    if (_pretty) {
+      _emit(
+        level,
+        '[span] ${record.name} '
+        '${record.durationMs.toDouble().toStringAsFixed(2)}ms '
+        '(${record.status})',
+        record.context,
+      );
+    } else {
+      _emit(
+        level,
+        jsonEncode(<String, Object?>{
+          'type': 'span',
+          ...spanRecordToJson(record),
+        }),
+        record.context,
+      );
+    }
+  }
+
+  @override
+  Future<void> flush() async {
+    // Console is synchronous — nothing buffered.
+  }
+}
+
+/// Default zero-dependency transport. Used whenever no `endpoint` is set.
+/// Synchronous; [TelemetrySink.flush] is a resolved no-op (nothing buffered).
+TelemetrySink createConsoleSink([ConsoleSinkOptions? opts]) {
+  final pretty = opts?.pretty ?? true;
+  final out = opts?.console ?? const _DefaultConsole();
+  return _ConsoleSink(pretty, out);
+}
+
+/// JSON projection of a [LogRecord], matching the web structured-JSON shape.
+Map<String, Object?> logRecordToJson(LogRecord r) => <String, Object?>{
+  'level': r.level.wireName,
+  'message': r.message,
+  'timestamp': r.timestamp,
+  'app': r.app,
+  'env': r.env.wireName,
+  'context': r.context,
+};
+
+/// JSON projection of a [SpanRecord], matching the web structured-JSON shape.
+Map<String, Object?> spanRecordToJson(SpanRecord r) => <String, Object?>{
+  'name': r.name,
+  'startTime': r.startTime,
+  'endTime': r.endTime,
+  'durationMs': r.durationMs,
+  'app': r.app,
+  'env': r.env.wireName,
+  'context': r.context,
+  'status': r.status,
+  if (r.error != null)
+    'error': <String, Object?>{
+      'name': r.error!.name,
+      'message': r.error!.message,
+    },
+};

--- a/packages/flutter/lib/src/telemetry/faro_engine.dart
+++ b/packages/flutter/lib/src/telemetry/faro_engine.dart
@@ -1,0 +1,133 @@
+/// Faro-backed engine — a 1:1 port of `@refraction-ui/logger`
+/// `faro-engine.ts`.
+///
+/// The vendor (Faro) is an **internal abstraction behind [TelemetrySink]** —
+/// no vendor type appears in this module's public surface. The real
+/// Faro-Flutter / OTel-Dart binding is a Wave 1 concern: when no override
+/// [FaroEngineOptions.transport] is supplied this factory resolves to `null`
+/// (peer absent), so the caller falls back to console — identical to the web
+/// semantics where the optional peer may be missing. The on-wire envelope
+/// (`{ kind, record }` pushed to a transport) is identical to web (OTLP).
+library;
+
+import 'types.dart';
+
+/// Minimal structural shape of a Faro-ish transport. Not part of the public
+/// vendor-neutral API beyond this engine's options. The payload envelope is
+/// identical to the web engine.
+abstract class FaroTransport {
+  /// Receive a `{ kind, record }` envelope. [kind] is `'log'` or `'span'`;
+  /// [record] is a [LogRecord] or [SpanRecord] respectively.
+  void push({required String kind, required Object record});
+}
+
+/// Options for [createFaroSink].
+class FaroEngineOptions {
+  /// Creates [FaroEngineOptions].
+  const FaroEngineOptions({
+    required this.app,
+    required this.endpoint,
+    this.transport,
+  });
+
+  /// Logical app/service name.
+  final String app;
+
+  /// Consumer-supplied collector endpoint. Data goes to the consumer's
+  /// endpoint, never refraction-ui's.
+  final String endpoint;
+
+  /// Test/override transport. When provided, the Faro vendor is NOT loaded
+  /// and records are forwarded straight to [FaroTransport.push].
+  final FaroTransport? transport;
+}
+
+/// Map our levels onto Faro's log-level strings (`fatal` -> `error`).
+const Map<LogLevel, String> _faroLevel = <LogLevel, String>{
+  LogLevel.debug: 'debug',
+  LogLevel.info: 'info',
+  LogLevel.warn: 'warn',
+  LogLevel.error: 'error',
+  LogLevel.fatal: 'error',
+};
+
+class _FaroSink implements TelemetrySink {
+  _FaroSink(this._transport);
+
+  final FaroTransport _transport;
+
+  @override
+  String get name => 'faro';
+
+  @override
+  void log(LogRecord record) {
+    _transport.push(kind: 'log', record: record);
+  }
+
+  @override
+  void span(SpanRecord record) {
+    _transport.push(kind: 'span', record: record);
+  }
+
+  @override
+  Future<void> flush() async {
+    // The vendor's own transport flushes on its schedule / on background;
+    // the manager drives app-exit flushing. Nothing buffered here.
+  }
+}
+
+/// Construct the Faro engine. Returns `null` when no vendor binding is
+/// available and no override [FaroEngineOptions.transport] was supplied —
+/// callers treat `null` as "fall back to console". The real Faro-Flutter /
+/// OTel-Dart binding lands in Wave 1 behind this same surface.
+Future<TelemetrySink?> createFaroSink(FaroEngineOptions opts) async {
+  final transport = opts.transport ?? await _loadFaroTransport(opts);
+  if (transport == null) return null;
+  return _FaroSink(transport);
+}
+
+/// Adapt the (Wave 1) Faro vendor to [FaroTransport]. Returns `null` while
+/// no vendor binding is wired (Wave 0) — exactly mirroring the web behavior
+/// where the optional peer is absent.
+Future<FaroTransport?> _loadFaroTransport(FaroEngineOptions opts) async {
+  // Wave 0: no vendor binding. Wave 1 plugs Faro-Flutter / OTel-Dart in here
+  // without any change to this engine's public surface or the OTLP envelope.
+  return null;
+}
+
+/// Faro context attributes are flat string maps; coerce ours to match.
+/// Exposed for parity tests against the web engine's `flatten`.
+Map<String, String> flattenContext(Map<String, Object?> ctx) {
+  final out = <String, String>{};
+  ctx.forEach((k, v) {
+    out[k] = v is String ? v : _jsonish(v);
+  });
+  return out;
+}
+
+String _jsonish(Object? v) {
+  if (v == null) return 'null';
+  if (v is num || v is bool) return v.toString();
+  if (v is String) return v;
+  // Match JSON.stringify for collections.
+  return _stringify(v);
+}
+
+String _stringify(Object? v) {
+  if (v == null) return 'null';
+  if (v is String) return '"$v"';
+  if (v is num || v is bool) return v.toString();
+  if (v is List) {
+    return '[${v.map(_stringify).join(',')}]';
+  }
+  if (v is Map) {
+    final entries = v.entries
+        .map((e) => '"${e.key}":${_stringify(e.value)}')
+        .join(',');
+    return '{$entries}';
+  }
+  return '"$v"';
+}
+
+/// Maps a [LogLevel] to the Faro log-level string. Exposed for parity tests.
+String faroLevelName(LogLevel level) => _faroLevel[level]!;

--- a/packages/flutter/lib/src/telemetry/lifecycle.dart
+++ b/packages/flutter/lib/src/telemetry/lifecycle.dart
@@ -1,0 +1,31 @@
+/// App-exit / background flush hook.
+///
+/// This is the ONE identical surface that the manager talks to. The actual
+/// platform wiring (web `pagehide`/`visibilitychange` vs. non-web app
+/// lifecycle) is an internal implementation detail selected via a conditional
+/// import — invisible to the consumer and uniform across web/android/ios/
+/// desktop. Mirrors the production-preset "beacon flush on page exit" branch
+/// in `@refraction-ui/logger`'s `telemetry-manager.ts`.
+library;
+
+import 'lifecycle_stub.dart'
+    if (dart.library.io) 'lifecycle_io.dart'
+    if (dart.library.js_interop) 'lifecycle_web.dart';
+
+/// A registered exit/background listener. Calling [cancel] detaches it.
+abstract class LifecycleSubscription {
+  /// Detach the listener.
+  void cancel();
+}
+
+/// Platform-neutral hook that invokes [onExit] when the host signals that the
+/// app/page is going away or to the background. Implemented per platform
+/// behind this single surface.
+abstract class LifecycleHook {
+  /// The platform default — resolved at compile time via conditional import.
+  factory LifecycleHook() => createLifecycleHook();
+
+  /// Register [onExit]; returns a handle that detaches it via
+  /// [LifecycleSubscription.cancel].
+  LifecycleSubscription onExit(void Function() onExit);
+}

--- a/packages/flutter/lib/src/telemetry/lifecycle_io.dart
+++ b/packages/flutter/lib/src/telemetry/lifecycle_io.dart
@@ -1,0 +1,58 @@
+/// Non-web lifecycle hook (android / ios / macos / windows / linux).
+///
+/// Internal implementation detail behind [LifecycleHook] — selected via the
+/// conditional import in `lifecycle.dart`. On desktop/server targets it
+/// listens for process termination signals (SIGTERM/SIGINT) so buffered
+/// records are flushed on exit. On mobile, foreground/background lifecycle
+/// transitions are driven by the Wave 1 engine layer through the same
+/// [LifecycleHook] surface; the core stays platform-agnostic and never
+/// imports Flutter widget bindings. Signal registration is guarded so it is
+/// a safe no-op where signals are unsupported.
+library;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'lifecycle.dart';
+
+class _IoSubscription implements LifecycleSubscription {
+  _IoSubscription(this._subs);
+
+  final List<StreamSubscription<ProcessSignal>> _subs;
+  bool _cancelled = false;
+
+  @override
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    for (final s in _subs) {
+      unawaited(s.cancel());
+    }
+    _subs.clear();
+  }
+}
+
+class _IoLifecycleHook implements LifecycleHook {
+  const _IoLifecycleHook();
+
+  @override
+  LifecycleSubscription onExit(void Function() onExit) {
+    final subs = <StreamSubscription<ProcessSignal>>[];
+    void watch(ProcessSignal signal) {
+      try {
+        subs.add(signal.watch().listen((_) => onExit()));
+      } catch (_) {
+        // Signal unsupported on this platform (e.g. mobile) — safe no-op.
+        // Mobile background flush is wired by the Wave 1 engine layer
+        // through this same surface.
+      }
+    }
+
+    watch(ProcessSignal.sigterm);
+    watch(ProcessSignal.sigint);
+    return _IoSubscription(subs);
+  }
+}
+
+/// Non-web factory.
+LifecycleHook createLifecycleHook() => const _IoLifecycleHook();

--- a/packages/flutter/lib/src/telemetry/lifecycle_stub.dart
+++ b/packages/flutter/lib/src/telemetry/lifecycle_stub.dart
@@ -1,0 +1,25 @@
+/// Fallback lifecycle hook used when neither `dart:io` nor web interop is
+/// available (e.g. pure unit-test VM with no platform signals). It registers
+/// nothing — the manager's explicit `flush()` still works everywhere. This
+/// keeps the core fully platform-agnostic.
+library;
+
+import 'lifecycle.dart';
+
+class _NoopSubscription implements LifecycleSubscription {
+  const _NoopSubscription();
+
+  @override
+  void cancel() {}
+}
+
+class _StubLifecycleHook implements LifecycleHook {
+  const _StubLifecycleHook();
+
+  @override
+  LifecycleSubscription onExit(void Function() onExit) =>
+      const _NoopSubscription();
+}
+
+/// Platform-default factory (no signals available).
+LifecycleHook createLifecycleHook() => const _StubLifecycleHook();

--- a/packages/flutter/lib/src/telemetry/lifecycle_web.dart
+++ b/packages/flutter/lib/src/telemetry/lifecycle_web.dart
@@ -1,0 +1,74 @@
+/// Web lifecycle hook (Flutter web).
+///
+/// Internal implementation detail behind [LifecycleHook] — selected via the
+/// conditional import in `lifecycle.dart`. Mirrors the web telemetry
+/// manager's "flush on `pagehide` + `visibilitychange` (hidden)" branch.
+/// Uses only `dart:js_interop` (SDK-provided, no extra pub dependency).
+library;
+
+import 'dart:js_interop';
+
+import 'lifecycle.dart';
+
+@JS('window')
+external _Window get _window;
+
+@JS('document')
+external _Document get _document;
+
+@JS()
+@staticInterop
+class _Window {}
+
+extension on _Window {
+  external void addEventListener(JSString type, JSFunction listener);
+  external void removeEventListener(JSString type, JSFunction listener);
+}
+
+@JS()
+@staticInterop
+class _Document {}
+
+extension on _Document {
+  external JSString? get visibilityState;
+}
+
+class _WebSubscription implements LifecycleSubscription {
+  _WebSubscription(this._detach);
+
+  final void Function() _detach;
+  bool _cancelled = false;
+
+  @override
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _detach();
+  }
+}
+
+class _WebLifecycleHook implements LifecycleHook {
+  const _WebLifecycleHook();
+
+  @override
+  LifecycleSubscription onExit(void Function() onExit) {
+    void pageHideListener(JSAny _) => onExit();
+    void visibilityListener(JSAny _) {
+      if (_document.visibilityState?.toDart == 'hidden') onExit();
+    }
+
+    final pageHide = pageHideListener.toJS;
+    final visibility = visibilityListener.toJS;
+
+    _window.addEventListener('pagehide'.toJS, pageHide);
+    _window.addEventListener('visibilitychange'.toJS, visibility);
+
+    return _WebSubscription(() {
+      _window.removeEventListener('pagehide'.toJS, pageHide);
+      _window.removeEventListener('visibilitychange'.toJS, visibility);
+    });
+  }
+}
+
+/// Web factory.
+LifecycleHook createLifecycleHook() => const _WebLifecycleHook();

--- a/packages/flutter/lib/src/telemetry/mock_sink.dart
+++ b/packages/flutter/lib/src/telemetry/mock_sink.dart
@@ -1,0 +1,42 @@
+/// Recording sink for tests — a 1:1 port of
+/// `@refraction-ui/logger` `mock-sink.ts`. Mirrors `createMockAIProvider`.
+library;
+
+import 'types.dart';
+
+/// A [TelemetrySink] that records everything for assertions instead of doing
+/// I/O. Used to test the manager and the Faro engine without any network.
+class MockSinkExtended implements TelemetrySink {
+  /// Creates a [MockSinkExtended] with the given engine [name].
+  MockSinkExtended([this._name = 'mock']);
+
+  final String _name;
+
+  /// Every log record received, in order.
+  final List<LogRecord> logs = <LogRecord>[];
+
+  /// Every span record received, in order.
+  final List<SpanRecord> spans = <SpanRecord>[];
+
+  /// Number of times [flush] was called.
+  int flushCalls = 0;
+
+  @override
+  String get name => _name;
+
+  @override
+  void log(LogRecord record) => logs.add(record);
+
+  @override
+  void span(SpanRecord record) => spans.add(record);
+
+  @override
+  Future<void> flush() async {
+    flushCalls++;
+  }
+}
+
+/// `createMockSink` — a [TelemetrySink] that records everything for
+/// assertions instead of doing I/O.
+MockSinkExtended createMockSink([String name = 'mock']) =>
+    MockSinkExtended(name);

--- a/packages/flutter/lib/src/telemetry/noop.dart
+++ b/packages/flutter/lib/src/telemetry/noop.dart
@@ -1,0 +1,58 @@
+/// Kill-switch logger — a 1:1 port of `@refraction-ui/logger` `noop.ts`.
+library;
+
+import 'types.dart';
+
+/// Shared no-op span — emits nothing, allocates nothing per call.
+class _NoopSpan implements Span {
+  const _NoopSpan();
+
+  @override
+  void end([SpanEndOptions? opts]) {
+    // no-op
+  }
+}
+
+const _NoopSpan _noopSpan = _NoopSpan();
+
+class _NoopTelemetry implements Telemetry {
+  const _NoopTelemetry();
+
+  @override
+  void debug(String message, [LogContext? context]) {}
+
+  @override
+  void info(String message, [LogContext? context]) {}
+
+  @override
+  void warn(String message, [LogContext? context]) {}
+
+  @override
+  void error(String message, [LogContext? context]) {}
+
+  @override
+  void fatal(String message, [LogContext? context]) {}
+
+  @override
+  Telemetry child(LogContext context) => this;
+
+  @override
+  Span startSpan(String name, [LogContext? attributes]) => _noopSpan;
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  List<String> get sinks => const <String>[];
+
+  @override
+  void addSink(TelemetrySink sink) {}
+
+  @override
+  void removeSink(String name) {}
+}
+
+/// Returned by `createTelemetry` when `enabled: false`. Every method is an
+/// empty stub, so the call sites can be dead-code-eliminated and the engines
+/// (console/Faro) are never constructed. Zero emissions.
+Telemetry createNoopTelemetry() => const _NoopTelemetry();

--- a/packages/flutter/lib/src/telemetry/presets.dart
+++ b/packages/flutter/lib/src/telemetry/presets.dart
@@ -1,0 +1,80 @@
+/// Behavior presets — a 1:1 port of `@refraction-ui/logger` `presets.ts`.
+library;
+
+import 'types.dart';
+
+/// Behavior derived from [TelemetryConfig.env]. The manager reads these
+/// fields to decide level filtering, batching, sampling, and flush triggers.
+class TelemetryPreset {
+  /// Creates a [TelemetryPreset].
+  const TelemetryPreset({
+    required this.minLevel,
+    required this.batch,
+    required this.batchSize,
+    required this.sampleRate,
+    required this.pretty,
+    required this.beaconFlush,
+  });
+
+  /// Records strictly below this level are dropped.
+  final LogLevel minLevel;
+
+  /// Buffer records and deliver in batches instead of synchronously.
+  final bool batch;
+
+  /// Batch size before an automatic flush (only when [batch]).
+  final int batchSize;
+
+  /// Default sample rate when config omits `sampleRate`.
+  final double sampleRate;
+
+  /// Pretty, single-line console output (vs. structured JSON).
+  final bool pretty;
+
+  /// Flush buffered records on app-exit / background signals, using a
+  /// beacon-style delivery when available.
+  ///
+  /// On the web this maps to `pagehide` + `visibilitychange` (hidden);
+  /// on mobile/desktop it maps to the equivalent app-lifecycle background
+  /// transition — handled internally behind one identical surface.
+  final bool beaconFlush;
+
+  /// Defensive copy so callers can't mutate a shared preset.
+  TelemetryPreset copy() => TelemetryPreset(
+    minLevel: minLevel,
+    batch: batch,
+    batchSize: batchSize,
+    sampleRate: sampleRate,
+    pretty: pretty,
+    beaconFlush: beaconFlush,
+  );
+}
+
+/// - development: sync, pretty, level=debug, no batching, sample everything.
+/// - production: batched + sampled, level>=warn, beacon flush on exit.
+///
+/// The screaming-case name is intentional — it mirrors `PRESETS` in
+/// `@refraction-ui/logger` for 1:1 API parity.
+// ignore: constant_identifier_names
+const Map<TelemetryEnv, TelemetryPreset> PRESETS =
+    <TelemetryEnv, TelemetryPreset>{
+      TelemetryEnv.development: TelemetryPreset(
+        minLevel: LogLevel.debug,
+        batch: false,
+        batchSize: 1,
+        sampleRate: 1,
+        pretty: true,
+        beaconFlush: false,
+      ),
+      TelemetryEnv.production: TelemetryPreset(
+        minLevel: LogLevel.warn,
+        batch: true,
+        batchSize: 20,
+        sampleRate: 0.25,
+        pretty: false,
+        beaconFlush: true,
+      ),
+    };
+
+/// Resolve the preset for an env (defensive copy so callers can't mutate it).
+TelemetryPreset resolvePreset(TelemetryEnv env) => PRESETS[env]!.copy();

--- a/packages/flutter/lib/src/telemetry/redact.dart
+++ b/packages/flutter/lib/src/telemetry/redact.dart
@@ -1,0 +1,42 @@
+/// Deep redaction — a 1:1 port of `@refraction-ui/logger` `redact.ts`.
+library;
+
+import 'types.dart';
+
+/// Deep-strip any object key whose name (case-insensitive) is in [keys].
+/// Lists are walked; cycles are guarded; non-matching values pass through
+/// unchanged. Returns a new structure — the input is never mutated.
+LogContext redact(LogContext value, List<String> keys) {
+  if (keys.isEmpty) return value;
+  final lookup = <String>{for (final k in keys) k.toLowerCase()};
+  return _walk(value, lookup, Set<Object>.identity()) as LogContext;
+}
+
+Object? _walk(Object? value, Set<String> keys, Set<Object> seen) {
+  if (value == null) return value;
+  if (value is String || value is num || value is bool) return value;
+
+  if (value is Map || value is List) {
+    if (seen.contains(value)) return '[Circular]';
+    seen.add(value);
+  } else {
+    // Opaque object — not a plain map/list; pass through unchanged.
+    return value;
+  }
+
+  if (value is List) {
+    return value.map((item) => _walk(item, keys, seen)).toList();
+  }
+
+  final map = value as Map;
+  final out = <String, Object?>{};
+  map.forEach((k, v) {
+    final key = k.toString();
+    if (keys.contains(key.toLowerCase())) {
+      out[key] = '[REDACTED]';
+    } else {
+      out[key] = _walk(v, keys, seen);
+    }
+  });
+  return out;
+}

--- a/packages/flutter/lib/src/telemetry/telemetry.dart
+++ b/packages/flutter/lib/src/telemetry/telemetry.dart
@@ -1,0 +1,95 @@
+/// Refraction UI telemetry — a 1:1 Dart port of the `@refraction-ui/logger`
+/// public surface. Same names and semantics: [createTelemetry], the
+/// vendor-neutral [TelemetrySink], dev/prod presets, a tree-shakeable noop
+/// kill switch, child loggers, spans, and redaction.
+///
+/// Uniform across every Flutter target (web / android / ios / desktop): the
+/// public API and package structure are identical; platform differences
+/// (app-exit flush wiring, vendor engine) are internal details behind one
+/// surface via conditional imports. The console engine is the default;
+/// the consumer supplies their own collector endpoint (data goes to *their*
+/// endpoint, never refraction-ui's). The OTLP/vendor wire envelope is
+/// identical to the web library.
+///
+/// ```dart
+/// import 'package:refraction_ui/refraction_ui.dart';
+///
+/// final telemetry = createTelemetry(const TelemetryConfig(
+///   app: 'interview-service',
+///   env: TelemetryEnv.production,
+///   endpoint: 'https://collector.example/ingest', // optional
+///   sampleRate: 0.25,                              // optional
+///   redactKeys: ['password', 'token'],             // optional
+/// ));
+///
+/// telemetry.warn('rate limited', {'route': '/v1/answer'});
+///
+/// final session = telemetry.child({'sessionId': 's-123'});
+/// final turn = session.child({'turnId': 't-7'});
+///
+/// final span = turn.startSpan('llm-call', {'model': 'gpt'});
+/// try {
+///   // ... async work ...
+///   span.end();
+/// } catch (err) {
+///   span.end(SpanEndOptions(error: err));
+/// }
+///
+/// await telemetry.flush();
+/// ```
+library;
+
+// Types (vendor-neutral — no Faro/Grafana/OTel type is exported).
+export 'types.dart'
+    show
+        LogLevel,
+        LogLevelName,
+        LEVEL_ORDER,
+        LogContext,
+        LogRecord,
+        SpanRecord,
+        SpanError,
+        TelemetrySink,
+        TelemetryEnv,
+        TelemetryEnvName,
+        TelemetryConfig,
+        SpanEndOptions,
+        Logger,
+        Span,
+        Telemetry;
+
+// Manager.
+export 'telemetry_manager.dart' show createTelemetry;
+
+// Presets.
+export 'presets.dart' show TelemetryPreset, PRESETS, resolvePreset;
+
+// Built-in transports.
+export 'console_sink.dart'
+    show
+        createConsoleSink,
+        ConsoleSinkOptions,
+        ConsoleLike,
+        logRecordToJson,
+        spanRecordToJson;
+
+// Vendor engine (internal abstraction behind TelemetrySink; Wave 1 binding).
+export 'faro_engine.dart'
+    show
+        createFaroSink,
+        FaroEngineOptions,
+        FaroTransport,
+        flattenContext,
+        faroLevelName;
+
+// Kill switch.
+export 'noop.dart' show createNoopTelemetry;
+
+// Utilities.
+export 'redact.dart' show redact;
+
+// Mock sink (for testing).
+export 'mock_sink.dart' show createMockSink, MockSinkExtended;
+
+// App-exit flush hook (uniform surface; platform wiring is internal).
+export 'lifecycle.dart' show LifecycleHook, LifecycleSubscription;

--- a/packages/flutter/lib/src/telemetry/telemetry_manager.dart
+++ b/packages/flutter/lib/src/telemetry/telemetry_manager.dart
@@ -1,0 +1,292 @@
+/// Telemetry manager — a 1:1 port of `@refraction-ui/logger`
+/// `telemetry-manager.ts`. Manager/provider pattern, mirroring `createAI`.
+library;
+
+import 'dart:math';
+
+import 'console_sink.dart';
+import 'faro_engine.dart';
+import 'lifecycle.dart';
+import 'noop.dart';
+import 'presets.dart';
+import 'redact.dart';
+import 'types.dart';
+
+class _Entry {
+  _Entry.log(this.logRecord) : kind = 'log', spanRecord = null;
+  _Entry.span(this.spanRecord) : kind = 'span', logRecord = null;
+
+  final String kind;
+  final LogRecord? logRecord;
+  final SpanRecord? spanRecord;
+}
+
+/// `createTelemetry` — creates a telemetry manager that fans records out to
+/// registered sinks. Manager/provider pattern, mirroring `createAI`.
+///
+/// - `enabled: false` -> tree-shakeable noop (zero emissions, no engines).
+/// - no `endpoint` -> console-only transport.
+/// - `endpoint` set -> the (Wave 1) vendor engine is registered when a
+///   binding/transport exists; console stays as a safe fallback until then.
+///
+/// The returned object IS a logger (root context = `{}`); `child()` derives
+/// loggers with bound context (sessionId / interviewId / turnId / ...).
+///
+/// Identical API and structure across web/android/ios/desktop — platform
+/// differences (app-exit flush wiring) are handled internally via a
+/// conditional-import [LifecycleHook] behind one surface.
+Telemetry createTelemetry(
+  TelemetryConfig config, {
+
+  /// Override the random source (for deterministic sampling in tests).
+  double Function()? randomSource,
+
+  /// Override the app-exit hook (for tests / custom hosts).
+  LifecycleHook? lifecycleHook,
+}) {
+  if (config.enabled == false) {
+    return createNoopTelemetry();
+  }
+
+  final preset = resolvePreset(config.env);
+  final sampleRate = config.sampleRate ?? preset.sampleRate;
+  final redactKeys = config.redactKeys ?? const <String>[];
+  final rng = randomSource ?? Random().nextDouble;
+
+  final sinks = <String, TelemetrySink>{};
+  final sinkOrder = <String>[];
+  final buffer = <_Entry>[];
+
+  void addSinkInternal(TelemetrySink sink) {
+    if (sinks.containsKey(sink.name)) {
+      sinks[sink.name] = sink;
+    } else {
+      sinks[sink.name] = sink;
+      sinkOrder.add(sink.name);
+    }
+  }
+
+  // Console transport is always present as the zero-dependency baseline.
+  addSinkInternal(createConsoleSink(ConsoleSinkOptions(pretty: preset.pretty)));
+
+  // When an endpoint is configured, attempt to attach the vendor engine. The
+  // construction is async + lazy so the optional vendor never becomes
+  // required and vendor names stay out of the public API.
+  if (config.endpoint != null) {
+    final endpoint = config.endpoint!;
+    // ignore: discarded_futures
+    createFaroSink(FaroEngineOptions(app: config.app, endpoint: endpoint))
+        .then((faro) {
+          if (faro != null) addSinkInternal(faro);
+        })
+        .catchError((_) {
+          // Vendor absent or init failed — console remains.
+        });
+  }
+
+  bool shouldSample() {
+    if (sampleRate >= 1) return true;
+    if (sampleRate <= 0) return false;
+    return rng() < sampleRate;
+  }
+
+  void deliver(_Entry entry) {
+    for (final name in sinkOrder) {
+      final sink = sinks[name];
+      if (sink == null) continue;
+      if (entry.kind == 'log') {
+        sink.log(entry.logRecord!);
+      } else {
+        sink.span(entry.spanRecord!);
+      }
+    }
+  }
+
+  Future<void> flushBuffer() async {
+    if (buffer.isNotEmpty) {
+      final pending = List<_Entry>.from(buffer);
+      buffer.clear();
+      for (final entry in pending) {
+        deliver(entry);
+      }
+    }
+    await Future.wait(
+      sinkOrder.map((name) => sinks[name]?.flush() ?? Future<void>.value()),
+    );
+  }
+
+  void dispatch(_Entry entry) {
+    if (preset.batch) {
+      buffer.add(entry);
+      if (buffer.length >= preset.batchSize) {
+        // ignore: discarded_futures
+        flushBuffer();
+      }
+      return;
+    }
+    deliver(entry);
+  }
+
+  // ---- app-exit beacon flush (production preset) --------------------------
+  // Uniform across all targets: web maps to pagehide/visibilitychange,
+  // non-web maps to process/lifecycle signals — handled internally behind
+  // the single [LifecycleHook] surface.
+  if (preset.beaconFlush) {
+    final hook = lifecycleHook ?? LifecycleHook();
+    hook.onExit(() {
+      // ignore: discarded_futures
+      flushBuffer();
+    });
+  }
+
+  late final Telemetry Function(LogContext) makeLogger;
+
+  makeLogger = (LogContext boundContext) {
+    void emit(LogLevel level, String message, [LogContext? context]) {
+      if (LEVEL_ORDER[level]! < LEVEL_ORDER[preset.minLevel]!) return;
+      if (!shouldSample()) return;
+      final merged = redact(<String, Object?>{
+        ...boundContext,
+        ...?context,
+      }, redactKeys);
+      final record = LogRecord(
+        level: level,
+        message: message,
+        timestamp: DateTime.now().millisecondsSinceEpoch,
+        app: config.app,
+        env: config.env,
+        context: merged,
+      );
+      dispatch(_Entry.log(record));
+    }
+
+    return _TelemetryImpl(
+      emit: emit,
+      makeChild: (ctx) =>
+          makeLogger(<String, Object?>{...boundContext, ...ctx}),
+      startSpanImpl: (name, attributes) {
+        final startTime = DateTime.now().millisecondsSinceEpoch;
+        var ended = false;
+        return _SpanImpl(() => ended, (value) => ended = value, (opts) {
+          final endTime = DateTime.now().millisecondsSinceEpoch;
+          final merged = redact(<String, Object?>{
+            ...boundContext,
+            ...?attributes,
+            ...?opts?.attributes,
+          }, redactKeys);
+          final err = opts?.error;
+          final record = SpanRecord(
+            name: name,
+            startTime: startTime,
+            endTime: endTime,
+            durationMs: endTime - startTime,
+            app: config.app,
+            env: config.env,
+            context: merged,
+            status: err != null ? 'error' : 'ok',
+            error: err != null
+                ? SpanError(
+                    name: (err is Error || err is Exception)
+                        ? err.runtimeType.toString()
+                        : 'Error',
+                    message: err.toString(),
+                  )
+                : null,
+          );
+          dispatch(_Entry.span(record));
+        });
+      },
+      flushImpl: flushBuffer,
+      sinksImpl: () => List<String>.from(sinkOrder),
+      addSinkImpl: addSinkInternal,
+      removeSinkImpl: (name) {
+        if (sinks.containsKey(name)) {
+          sinks.remove(name);
+          sinkOrder.remove(name);
+        }
+      },
+    );
+  };
+
+  return makeLogger(<String, Object?>{});
+}
+
+class _SpanImpl implements Span {
+  _SpanImpl(this._isEnded, this._setEnded, this._onEnd);
+
+  final bool Function() _isEnded;
+  final void Function(bool) _setEnded;
+  final void Function(SpanEndOptions?) _onEnd;
+
+  @override
+  void end([SpanEndOptions? opts]) {
+    if (_isEnded()) return;
+    _setEnded(true);
+    _onEnd(opts);
+  }
+}
+
+class _TelemetryImpl implements Telemetry {
+  _TelemetryImpl({
+    required void Function(LogLevel, String, [LogContext?]) emit,
+    required Telemetry Function(LogContext) makeChild,
+    required Span Function(String, LogContext?) startSpanImpl,
+    required Future<void> Function() flushImpl,
+    required List<String> Function() sinksImpl,
+    required void Function(TelemetrySink) addSinkImpl,
+    required void Function(String) removeSinkImpl,
+  }) : _emit = emit,
+       _makeChild = makeChild,
+       _startSpan = startSpanImpl,
+       _flush = flushImpl,
+       _sinks = sinksImpl,
+       _addSink = addSinkImpl,
+       _removeSink = removeSinkImpl;
+
+  final void Function(LogLevel, String, [LogContext?]) _emit;
+  final Telemetry Function(LogContext) _makeChild;
+  final Span Function(String, LogContext?) _startSpan;
+  final Future<void> Function() _flush;
+  final List<String> Function() _sinks;
+  final void Function(TelemetrySink) _addSink;
+  final void Function(String) _removeSink;
+
+  @override
+  void debug(String message, [LogContext? context]) =>
+      _emit(LogLevel.debug, message, context);
+
+  @override
+  void info(String message, [LogContext? context]) =>
+      _emit(LogLevel.info, message, context);
+
+  @override
+  void warn(String message, [LogContext? context]) =>
+      _emit(LogLevel.warn, message, context);
+
+  @override
+  void error(String message, [LogContext? context]) =>
+      _emit(LogLevel.error, message, context);
+
+  @override
+  void fatal(String message, [LogContext? context]) =>
+      _emit(LogLevel.fatal, message, context);
+
+  @override
+  Telemetry child(LogContext context) => _makeChild(context);
+
+  @override
+  Span startSpan(String name, [LogContext? attributes]) =>
+      _startSpan(name, attributes);
+
+  @override
+  Future<void> flush() => _flush();
+
+  @override
+  List<String> get sinks => _sinks();
+
+  @override
+  void addSink(TelemetrySink sink) => _addSink(sink);
+
+  @override
+  void removeSink(String name) => _removeSink(name);
+}

--- a/packages/flutter/lib/src/telemetry/types.dart
+++ b/packages/flutter/lib/src/telemetry/types.dart
@@ -1,0 +1,253 @@
+/// Vendor-neutral telemetry contracts — a 1:1 Dart port of the
+/// `@refraction-ui/logger` public surface. No vendor (Faro/Grafana/OTel)
+/// type ever appears here or anywhere in the public API.
+library;
+
+/// Severity levels, ordered low -> high.
+enum LogLevel { debug, info, warn, error, fatal }
+
+/// Numeric ordering used for level threshold comparisons.
+///
+/// Mirrors `LEVEL_ORDER` in `@refraction-ui/logger`. The screaming-case name
+/// is intentional — it is part of the ported public API surface.
+// ignore: constant_identifier_names
+const Map<LogLevel, int> LEVEL_ORDER = <LogLevel, int>{
+  LogLevel.debug: 10,
+  LogLevel.info: 20,
+  LogLevel.warn: 30,
+  LogLevel.error: 40,
+  LogLevel.fatal: 50,
+};
+
+/// Wire/string name for a [LogLevel] (matches the TS string union values).
+extension LogLevelName on LogLevel {
+  /// The lowercase string identifier (`'debug'`, `'info'`, ...).
+  String get wireName {
+    switch (this) {
+      case LogLevel.debug:
+        return 'debug';
+      case LogLevel.info:
+        return 'info';
+      case LogLevel.warn:
+        return 'warn';
+      case LogLevel.error:
+        return 'error';
+      case LogLevel.fatal:
+        return 'fatal';
+    }
+  }
+}
+
+/// Bound key/value pairs attached to every record emitted by a logger.
+typedef LogContext = Map<String, Object?>;
+
+/// Telemetry environment — selects a behavior preset.
+enum TelemetryEnv { development, production }
+
+/// Wire/string name for a [TelemetryEnv] (matches the TS string union).
+extension TelemetryEnvName on TelemetryEnv {
+  /// The lowercase string identifier (`'development'` / `'production'`).
+  String get wireName =>
+      this == TelemetryEnv.development ? 'development' : 'production';
+}
+
+/// A single structured log record handed to a sink.
+class LogRecord {
+  /// Creates a [LogRecord].
+  const LogRecord({
+    required this.level,
+    required this.message,
+    required this.timestamp,
+    required this.app,
+    required this.env,
+    required this.context,
+  });
+
+  /// Severity of the record.
+  final LogLevel level;
+
+  /// Human-readable message.
+  final String message;
+
+  /// Epoch milliseconds when the record was created.
+  final int timestamp;
+
+  /// Logical app/service name.
+  final String app;
+
+  /// Environment preset selector this record was emitted under.
+  final TelemetryEnv env;
+
+  /// Merged bound context (child loggers) + per-call context, post-redaction.
+  final LogContext context;
+}
+
+/// A span record handed to a sink when a span ends.
+class SpanRecord {
+  /// Creates a [SpanRecord].
+  const SpanRecord({
+    required this.name,
+    required this.startTime,
+    required this.endTime,
+    required this.durationMs,
+    required this.app,
+    required this.env,
+    required this.context,
+    required this.status,
+    this.error,
+  });
+
+  /// Span name.
+  final String name;
+
+  /// Epoch milliseconds when the span started.
+  final int startTime;
+
+  /// Epoch milliseconds when the span ended.
+  final int endTime;
+
+  /// Wall-clock duration in milliseconds.
+  final int durationMs;
+
+  /// Logical app/service name.
+  final String app;
+
+  /// Environment preset selector this span was emitted under.
+  final TelemetryEnv env;
+
+  /// Merged bound context + span attributes, post-redaction.
+  final LogContext context;
+
+  /// `'ok'` unless ended with an error.
+  final String status;
+
+  /// Set when the span ended with an error.
+  final SpanError? error;
+}
+
+/// Error detail attached to a [SpanRecord] when a span ends with an error.
+class SpanError {
+  /// Creates a [SpanError].
+  const SpanError({required this.name, required this.message});
+
+  /// Error class/type name (`'Error'` for non-[Error] throwables).
+  final String name;
+
+  /// Error message (stringified for non-[Error] throwables).
+  final String message;
+}
+
+/// Vendor-neutral telemetry sink. Engines (console, Faro, custom) implement
+/// this — no vendor type ever leaks across this boundary.
+abstract class TelemetrySink {
+  /// Engine name, for diagnostics.
+  String get name;
+
+  /// Receive a log record. May buffer; honor [flush].
+  void log(LogRecord record);
+
+  /// Receive a finished span. May buffer; honor [flush].
+  void span(SpanRecord record);
+
+  /// Force-deliver any buffered records. Resolves once delivery is attempted.
+  Future<void> flush();
+}
+
+/// Config for `createTelemetry` — mirrors `createAI`'s config shape.
+class TelemetryConfig {
+  /// Creates a [TelemetryConfig].
+  const TelemetryConfig({
+    required this.app,
+    required this.env,
+    this.endpoint,
+    this.enabled,
+    this.sampleRate,
+    this.redactKeys,
+  });
+
+  /// Logical app/service name attached to every record.
+  final String app;
+
+  /// Environment preset selector.
+  final TelemetryEnv env;
+
+  /// Remote collector endpoint. When omitted, telemetry stays console-only
+  /// (no network engine is constructed).
+  final String? endpoint;
+
+  /// Master kill switch. When `false`, a tree-shakeable noop logger is
+  /// returned and zero records are ever produced. Defaults to `true`.
+  final bool? enabled;
+
+  /// Fraction of records kept, 0..1. Defaults to the preset value
+  /// (1 in development, 0.25 in production). Records below the sample
+  /// are dropped before reaching any sink.
+  final double? sampleRate;
+
+  /// Context keys to strip (deep) before a record is emitted. Use for
+  /// PII / secrets, e.g. `['password', 'token', 'authorization']`.
+  final List<String>? redactKeys;
+}
+
+/// Options passed to [Span.end].
+class SpanEndOptions {
+  /// Creates [SpanEndOptions].
+  const SpanEndOptions({this.error, this.attributes});
+
+  /// When set, the span is recorded with `status: 'error'`.
+  final Object? error;
+
+  /// Additional attributes merged into the span context.
+  final LogContext? attributes;
+}
+
+/// An in-flight span returned by [Logger.startSpan].
+abstract class Span {
+  /// End the span and emit a [SpanRecord]. Optionally attach error/attrs.
+  /// Idempotent — a second call is a no-op.
+  void end([SpanEndOptions? opts]);
+}
+
+/// A logger bound to a context. Child loggers inherit + extend that context.
+abstract class Logger {
+  /// Emit a record at [LogLevel.debug].
+  void debug(String message, [LogContext? context]);
+
+  /// Emit a record at [LogLevel.info].
+  void info(String message, [LogContext? context]);
+
+  /// Emit a record at [LogLevel.warn].
+  void warn(String message, [LogContext? context]);
+
+  /// Emit a record at [LogLevel.error].
+  void error(String message, [LogContext? context]);
+
+  /// Emit a record at [LogLevel.fatal].
+  void fatal(String message, [LogContext? context]);
+
+  /// Derive a logger with additional bound context (e.g.
+  /// `{ sessionId, interviewId, turnId }`). Merges over the parent's context.
+  /// The parent is unaffected.
+  Logger child(LogContext context);
+
+  /// Begin a span. Call [Span.end] to record its duration.
+  Span startSpan(String name, [LogContext? attributes]);
+
+  /// Force-deliver buffered records on every sink.
+  Future<void> flush();
+}
+
+/// Return type of `createTelemetry`. Extends [Logger] with sink management.
+abstract class Telemetry implements Logger {
+  /// Registered sink names, in insertion order.
+  List<String> get sinks;
+
+  /// Register an additional sink (e.g. a custom collector).
+  void addSink(TelemetrySink sink);
+
+  /// Remove a sink by name.
+  void removeSink(String name);
+
+  @override
+  Telemetry child(LogContext context);
+}

--- a/packages/flutter/test/telemetry_console_noop_test.dart
+++ b/packages/flutter/test/telemetry_console_noop_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+class _CapturingConsole implements ConsoleLike {
+  final List<(String, String, Object?)> calls = <(String, String, Object?)>[];
+
+  @override
+  void debug(String line, Object? payload) =>
+      calls.add(('debug', line, payload));
+
+  @override
+  void info(String line, Object? payload) => calls.add(('info', line, payload));
+
+  @override
+  void warn(String line, Object? payload) => calls.add(('warn', line, payload));
+
+  @override
+  void error(String line, Object? payload) =>
+      calls.add(('error', line, payload));
+}
+
+void main() {
+  group('createConsoleSink (parity with console-sink.ts)', () {
+    test('pretty log routes to the level method with formatted line', () {
+      final c = _CapturingConsole();
+      final sink = createConsoleSink(ConsoleSinkOptions(console: c));
+      sink.log(
+        LogRecord(
+          level: LogLevel.warn,
+          message: 'hi',
+          timestamp: 0,
+          app: 'svc',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{'k': 'v'},
+        ),
+      );
+      expect(c.calls.single.$1, 'warn');
+      expect(c.calls.single.$2, contains('WARN'));
+      expect(c.calls.single.$2, contains('[svc]'));
+      expect(c.calls.single.$2, contains('hi'));
+      expect(c.calls.single.$3, <String, Object?>{'k': 'v'});
+    });
+
+    test('fatal maps to console.error', () {
+      final c = _CapturingConsole();
+      final sink = createConsoleSink(ConsoleSinkOptions(console: c));
+      sink.log(
+        LogRecord(
+          level: LogLevel.fatal,
+          message: 'boom',
+          timestamp: 0,
+          app: 'svc',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{},
+        ),
+      );
+      expect(c.calls.single.$1, 'error');
+    });
+
+    test('non-pretty emits structured JSON with type:log', () {
+      final c = _CapturingConsole();
+      final sink = createConsoleSink(
+        ConsoleSinkOptions(pretty: false, console: c),
+      );
+      sink.log(
+        LogRecord(
+          level: LogLevel.info,
+          message: 'm',
+          timestamp: 123,
+          app: 'svc',
+          env: TelemetryEnv.production,
+          context: const <String, Object?>{},
+        ),
+      );
+      expect(c.calls.single.$2, contains('"type":"log"'));
+      expect(c.calls.single.$2, contains('"message":"m"'));
+      expect(c.calls.single.$2, contains('"env":"production"'));
+    });
+
+    test('span: ok -> debug, error -> error; pretty line shape', () {
+      final c = _CapturingConsole();
+      final sink = createConsoleSink(ConsoleSinkOptions(console: c));
+      sink.span(
+        SpanRecord(
+          name: 'work',
+          startTime: 0,
+          endTime: 5,
+          durationMs: 5,
+          app: 'svc',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{},
+          status: 'ok',
+        ),
+      );
+      sink.span(
+        SpanRecord(
+          name: 'work',
+          startTime: 0,
+          endTime: 5,
+          durationMs: 5,
+          app: 'svc',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{},
+          status: 'error',
+        ),
+      );
+      expect(c.calls[0].$1, 'debug');
+      expect(c.calls[0].$2, contains('[span] work'));
+      expect(c.calls[0].$2, contains('(ok)'));
+      expect(c.calls[1].$1, 'error');
+      expect(c.calls[1].$2, contains('(error)'));
+    });
+
+    test('flush resolves (nothing buffered)', () async {
+      final sink = createConsoleSink(
+        ConsoleSinkOptions(console: _CapturingConsole()),
+      );
+      await expectLater(sink.flush(), completes);
+    });
+  });
+
+  group('createNoopTelemetry (kill switch, parity with noop.ts)', () {
+    test('zero emissions, empty sinks, idempotent child/span', () async {
+      final t = createNoopTelemetry();
+      t.debug('x');
+      t.info('x');
+      t.warn('x');
+      t.error('x');
+      t.fatal('x');
+      expect(t.sinks, isEmpty);
+      expect(identical(t.child(const <String, Object?>{}), t), isTrue);
+      final span = t.startSpan('s');
+      span.end();
+      span.end(); // idempotent / no throw
+      t.addSink(createMockSink());
+      t.removeSink('mock');
+      expect(t.sinks, isEmpty);
+      await expectLater(t.flush(), completes);
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_faro_engine_test.dart
+++ b/packages/flutter/test/telemetry_faro_engine_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+class _RecordingTransport implements FaroTransport {
+  final List<({String kind, Object record})> pushes =
+      <({String kind, Object record})>[];
+
+  @override
+  void push({required String kind, required Object record}) =>
+      pushes.add((kind: kind, record: record));
+}
+
+void main() {
+  group('createFaroSink (parity with faro-engine.ts)', () {
+    test(
+      'no transport + no vendor binding -> null (caller falls back)',
+      () async {
+        final sink = await createFaroSink(
+          const FaroEngineOptions(app: 'svc', endpoint: 'https://x.example'),
+        );
+        expect(sink, isNull);
+      },
+    );
+
+    test(
+      'injected transport bypasses vendor; OTLP envelope identical to web',
+      () async {
+        final transport = _RecordingTransport();
+        final sink = await createFaroSink(
+          FaroEngineOptions(
+            app: 'svc',
+            endpoint: 'https://collector.example',
+            transport: transport,
+          ),
+        );
+        expect(sink, isNotNull);
+        expect(sink!.name, 'faro');
+
+        final log = LogRecord(
+          level: LogLevel.warn,
+          message: 'm',
+          timestamp: 1,
+          app: 'svc',
+          env: TelemetryEnv.production,
+          context: const <String, Object?>{'k': 'v'},
+        );
+        final span = SpanRecord(
+          name: 's',
+          startTime: 0,
+          endTime: 2,
+          durationMs: 2,
+          app: 'svc',
+          env: TelemetryEnv.production,
+          context: const <String, Object?>{},
+          status: 'ok',
+        );
+
+        sink.log(log);
+        sink.span(span);
+
+        // Envelope shape: { kind, record } — identical to the web engine.
+        expect(transport.pushes[0].kind, 'log');
+        expect(identical(transport.pushes[0].record, log), isTrue);
+        expect(transport.pushes[1].kind, 'span');
+        expect(identical(transport.pushes[1].record, span), isTrue);
+
+        await expectLater(sink.flush(), completes);
+      },
+    );
+
+    test('manager wires an endpoint sink when transport injected', () async {
+      final transport = _RecordingTransport();
+      final faro = await createFaroSink(
+        FaroEngineOptions(
+          app: 'svc',
+          endpoint: 'https://collector.example',
+          transport: transport,
+        ),
+      );
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      t.addSink(faro!);
+      t.error('boom');
+      expect(transport.pushes.single.kind, 'log');
+    });
+
+    test('faroLevelName maps fatal -> error (parity with FARO_LEVEL)', () {
+      expect(faroLevelName(LogLevel.debug), 'debug');
+      expect(faroLevelName(LogLevel.info), 'info');
+      expect(faroLevelName(LogLevel.warn), 'warn');
+      expect(faroLevelName(LogLevel.error), 'error');
+      expect(faroLevelName(LogLevel.fatal), 'error');
+    });
+
+    test('flattenContext coerces non-strings (parity with flatten)', () {
+      final flat = flattenContext(<String, Object?>{
+        's': 'str',
+        'n': 5,
+        'b': true,
+        'list': <Object?>[1, 2],
+        'map': <String, Object?>{'a': 1},
+      });
+      expect(flat['s'], 'str');
+      expect(flat['n'], '5');
+      expect(flat['b'], 'true');
+      expect(flat['list'], '[1,2]');
+      expect(flat['map'], '{"a":1}');
+    });
+  });
+
+  group('createMockSink (parity with mock-sink.ts)', () {
+    test('records logs, spans, and flush calls', () async {
+      final m = createMockSink('m');
+      expect(m.name, 'm');
+      m.log(
+        LogRecord(
+          level: LogLevel.info,
+          message: 'x',
+          timestamp: 0,
+          app: 'a',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{},
+        ),
+      );
+      m.span(
+        SpanRecord(
+          name: 's',
+          startTime: 0,
+          endTime: 0,
+          durationMs: 0,
+          app: 'a',
+          env: TelemetryEnv.development,
+          context: const <String, Object?>{},
+          status: 'ok',
+        ),
+      );
+      await m.flush();
+      expect(m.logs, hasLength(1));
+      expect(m.spans, hasLength(1));
+      expect(m.flushCalls, 1);
+    });
+
+    test('default name is "mock"', () {
+      expect(createMockSink().name, 'mock');
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_manager_test.dart
+++ b/packages/flutter/test/telemetry_manager_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+/// Test [LifecycleHook] whose registered exit listener can be fired manually.
+class _FakeLifecycleHook implements LifecycleHook {
+  void Function()? _listener;
+
+  void fireExit() => _listener?.call();
+
+  @override
+  LifecycleSubscription onExit(void Function() onExit) {
+    _listener = onExit;
+    return _FakeSub();
+  }
+}
+
+class _FakeSub implements LifecycleSubscription {
+  @override
+  void cancel() {}
+}
+
+void main() {
+  group('createTelemetry — parity with telemetry-manager.ts', () {
+    test('disabled -> noop, zero emissions', () {
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'a',
+          env: TelemetryEnv.development,
+          enabled: false,
+        ),
+      );
+      final mock = createMockSink();
+      t.addSink(mock); // noop ignores
+      t.error('should not emit');
+      expect(t.sinks, isEmpty);
+      expect(mock.logs, isEmpty);
+    });
+
+    test('no endpoint -> console-only (single console sink)', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'a', env: TelemetryEnv.development),
+      );
+      expect(t.sinks, <String>['console']);
+    });
+
+    test('dev preset: debug passes, sync delivery to a custom sink', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+      t.debug('d', <String, Object?>{'x': 1});
+      expect(mock.logs, hasLength(1));
+      final r = mock.logs.single;
+      expect(r.level, LogLevel.debug);
+      expect(r.app, 'svc');
+      expect(r.env, TelemetryEnv.development);
+      expect(r.context, <String, Object?>{'x': 1});
+    });
+
+    test(
+      'prod preset: below warn dropped, warn+ batched then flushed',
+      () async {
+        final t = createTelemetry(
+          const TelemetryConfig(
+            app: 'svc',
+            env: TelemetryEnv.production,
+            sampleRate: 1,
+          ),
+        );
+        final mock = createMockSink();
+        t.addSink(mock);
+
+        t.debug('drop');
+        t.info('drop');
+        expect(mock.logs, isEmpty); // below minLevel (warn)
+
+        t.warn('buffered');
+        expect(mock.logs, isEmpty); // batched, not yet delivered
+
+        await t.flush();
+        expect(mock.logs, hasLength(1));
+        expect(mock.logs.single.message, 'buffered');
+        expect(mock.flushCalls, greaterThanOrEqualTo(1));
+      },
+    );
+
+    test('prod preset: auto-flush when batchSize (20) reached', () {
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.production,
+          sampleRate: 1,
+        ),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+      for (var i = 0; i < 20; i++) {
+        t.error('e$i');
+      }
+      expect(mock.logs, hasLength(20));
+    });
+
+    test('sampleRate 0 drops everything; explicit rate overrides preset', () {
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.development,
+          sampleRate: 0,
+        ),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+      t.error('nope');
+      expect(mock.logs, isEmpty);
+    });
+
+    test('deterministic sampling via injected randomSource', () {
+      var t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.development,
+          sampleRate: 0.5,
+        ),
+        randomSource: () => 0.9, // >= 0.5 -> dropped
+      );
+      var mock = createMockSink();
+      t.addSink(mock);
+      t.error('drop');
+      expect(mock.logs, isEmpty);
+
+      t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.development,
+          sampleRate: 0.5,
+        ),
+        randomSource: () => 0.1, // < 0.5 -> kept
+      );
+      mock = createMockSink();
+      t.addSink(mock);
+      t.error('keep');
+      expect(mock.logs, hasLength(1));
+    });
+
+    test(
+      'redaction applies to log + span context (deep, case-insensitive)',
+      () {
+        final t = createTelemetry(
+          const TelemetryConfig(
+            app: 'svc',
+            env: TelemetryEnv.development,
+            redactKeys: <String>['password'],
+          ),
+        );
+        final mock = createMockSink();
+        t.addSink(mock);
+        t.warn('w', <String, Object?>{'Password': 'secret', 'ok': 1});
+        expect(mock.logs.single.context['Password'], '[REDACTED]');
+        expect(mock.logs.single.context['ok'], 1);
+
+        t.startSpan('s', <String, Object?>{'password': 'x'}).end();
+        expect(mock.spans.single.context['password'], '[REDACTED]');
+      },
+    );
+
+    test('child loggers merge bound context; parent unaffected', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      final session = t.child(<String, Object?>{'sessionId': 's-1'});
+      final turn = session.child(<String, Object?>{'turnId': 't-7'});
+      turn.info('hello', <String, Object?>{'extra': true});
+
+      final ctx = mock.logs.single.context;
+      expect(ctx['sessionId'], 's-1');
+      expect(ctx['turnId'], 't-7');
+      expect(ctx['extra'], true);
+
+      // Parent has no bound child context.
+      t.info('root');
+      expect(mock.logs.last.context.containsKey('sessionId'), isFalse);
+    });
+
+    test('span lifecycle: duration, ok status, idempotent end, error', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      final span = t.startSpan('llm-call', <String, Object?>{'model': 'gpt'});
+      span.end();
+      span.end(); // idempotent — second emission suppressed
+      expect(mock.spans, hasLength(1));
+      final ok = mock.spans.single;
+      expect(ok.name, 'llm-call');
+      expect(ok.status, 'ok');
+      expect(ok.error, isNull);
+      expect(ok.durationMs, greaterThanOrEqualTo(0));
+      expect(ok.endTime, greaterThanOrEqualTo(ok.startTime));
+      expect(ok.context['model'], 'gpt');
+
+      t
+          .startSpan('boom')
+          .end(
+            SpanEndOptions(
+              error: StateError('bad'),
+              attributes: <String, Object?>{'phase': 2},
+            ),
+          );
+      final errSpan = mock.spans.last;
+      expect(errSpan.status, 'error');
+      expect(errSpan.error, isNotNull);
+      expect(errSpan.error!.message, contains('bad'));
+      expect(errSpan.context['phase'], 2);
+    });
+
+    test('addSink/removeSink + insertion-ordered sink names', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      t.addSink(createMockSink('a'));
+      t.addSink(createMockSink('b'));
+      expect(t.sinks, <String>['console', 'a', 'b']);
+      t.removeSink('a');
+      expect(t.sinks, <String>['console', 'b']);
+    });
+
+    test('production beaconFlush: lifecycle exit triggers a flush', () async {
+      final hook = _FakeLifecycleHook();
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.production,
+          sampleRate: 1,
+        ),
+        lifecycleHook: hook,
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+      t.error('pending');
+      expect(mock.logs, isEmpty); // buffered
+      hook.fireExit();
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.logs, hasLength(1));
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_redact_test.dart
+++ b/packages/flutter/test/telemetry_redact_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('redact (parity with redact.ts)', () {
+    test('empty keys returns the value unchanged (same identity)', () {
+      final input = <String, Object?>{'a': 1};
+      expect(identical(redact(input, const <String>[]), input), isTrue);
+    });
+
+    test('case-insensitive key matching', () {
+      final out = redact(
+        <String, Object?>{'Password': 'p', 'TOKEN': 't', 'keep': 'v'},
+        <String>['password', 'token'],
+      );
+      expect(out['Password'], '[REDACTED]');
+      expect(out['TOKEN'], '[REDACTED]');
+      expect(out['keep'], 'v');
+    });
+
+    test('deep redaction through nested maps and lists', () {
+      final out = redact(
+        <String, Object?>{
+          'outer': <String, Object?>{
+            'secret': 'x',
+            'list': <Object?>[
+              <String, Object?>{'secret': 'y', 'ok': 1},
+            ],
+          },
+        },
+        <String>['secret'],
+      );
+      final outer = out['outer']! as Map;
+      expect(outer['secret'], '[REDACTED]');
+      final list = outer['list']! as List;
+      final item = list.first as Map;
+      expect(item['secret'], '[REDACTED]');
+      expect(item['ok'], 1);
+    });
+
+    test('does not mutate the input', () {
+      final input = <String, Object?>{'password': 'p'};
+      redact(input, <String>['password']);
+      expect(input['password'], 'p');
+    });
+
+    test('cycle-safe', () {
+      final cyclic = <String, Object?>{'a': 1};
+      cyclic['self'] = cyclic;
+      final out = redact(cyclic, <String>['nope']);
+      expect(out['a'], 1);
+      expect(out['self'], '[Circular]');
+    });
+
+    test('non-object scalars pass through', () {
+      final out = redact(
+        <String, Object?>{'n': 5, 'b': true, 's': 'str', 'nil': null},
+        <String>['x'],
+      );
+      expect(out['n'], 5);
+      expect(out['b'], true);
+      expect(out['s'], 'str');
+      expect(out['nil'], isNull);
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_types_presets_test.dart
+++ b/packages/flutter/test/telemetry_types_presets_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('LEVEL_ORDER (parity with @refraction-ui/logger)', () {
+    test('numeric ordering matches the web contract', () {
+      expect(LEVEL_ORDER[LogLevel.debug], 10);
+      expect(LEVEL_ORDER[LogLevel.info], 20);
+      expect(LEVEL_ORDER[LogLevel.warn], 30);
+      expect(LEVEL_ORDER[LogLevel.error], 40);
+      expect(LEVEL_ORDER[LogLevel.fatal], 50);
+    });
+
+    test('wire names match the TS string union', () {
+      expect(LogLevel.debug.wireName, 'debug');
+      expect(LogLevel.fatal.wireName, 'fatal');
+      expect(TelemetryEnv.development.wireName, 'development');
+      expect(TelemetryEnv.production.wireName, 'production');
+    });
+  });
+
+  group('Presets (parity with presets.ts)', () {
+    test('development preset', () {
+      final p = resolvePreset(TelemetryEnv.development);
+      expect(p.minLevel, LogLevel.debug);
+      expect(p.batch, isFalse);
+      expect(p.batchSize, 1);
+      expect(p.sampleRate, 1);
+      expect(p.pretty, isTrue);
+      expect(p.beaconFlush, isFalse);
+    });
+
+    test('production preset', () {
+      final p = resolvePreset(TelemetryEnv.production);
+      expect(p.minLevel, LogLevel.warn);
+      expect(p.batch, isTrue);
+      expect(p.batchSize, 20);
+      expect(p.sampleRate, 0.25);
+      expect(p.pretty, isFalse);
+      expect(p.beaconFlush, isTrue);
+    });
+
+    test(
+      'resolvePreset returns a defensive copy (not the shared instance)',
+      () {
+        final a = resolvePreset(TelemetryEnv.production);
+        final b = resolvePreset(TelemetryEnv.production);
+        expect(identical(a, b), isFalse);
+        expect(identical(a, PRESETS[TelemetryEnv.production]), isFalse);
+      },
+    );
+
+    test('PRESETS map exposes both environments', () {
+      expect(PRESETS.keys, containsAll(TelemetryEnv.values));
+    });
+  });
+}


### PR DESCRIPTION
Epic #225 Wave 0. 1:1 Dart port of `@refraction-ui/logger` into `packages/flutter/lib/src/telemetry` — createTelemetry/TelemetrySink/presets/noop/child/spans/redaction, identical OTLP wire, consumer-supplied backend. **Uniform structure across web/android/ios/desktop**: platform differences handled internally via conditional imports behind one identical surface (no per-platform packages, no flutter-web special-casing). Faro is an internal abstraction behind TelemetrySink (Wave 1).

✅ flutter pub get / analyze clean · flutter test **63 pass** (37 new + 26 existing). No changeset (Dart pub pkg, not npm). Closes #226.

Note: pre-existing repo-wide `dart format` drift (29 unrelated files) makes `make check` red independent of this change — recommend a separate formatting-cleanup chore.