### PR TITLE
feat: library-origin error-capture seams, all 3 frameworks (#249)

### DIFF
--- a/.changeset/error-capture-seams.md
+++ b/.changeset/error-capture-seams.md
@@ -1,0 +1,31 @@
+---
+"@refraction-ui/shared": minor
+"@refraction-ui/react-logger": minor
+"@refraction-ui/angular-logger": minor
+"@refraction-ui/astro-logger": minor
+---
+
+feat: per-framework library-origin error capture seams (epic #247 wave 1, #249)
+
+Error seams that tag ONLY errors whose stack originates in a `@refraction-ui/*`
+package and route them to an OPTIONAL, consumer-wired telemetry sink (no-op if
+none wired). App-origin errors pass through completely untouched — never
+captured, tagged, or forwarded to the diagnostics sink.
+
+- `@refraction-ui/shared`: `isLibraryOriginError(error)` predicate (the
+  capture gate, reuses the existing `@refraction-ui/*` stack-frame rule) and
+  `captureLibraryOriginError(error, identity, sink)` — the single filter →
+  tag → optional-forward primitive shared by every seam. Built on the existing
+  `libraryOriginError`/`stackFingerprint` envelope and the `DevFeedbackSink`
+  contract; no new definitions, zero dependency on `@refraction-ui/logger`.
+- `@refraction-ui/react-logger`: `LibraryErrorCaptureBoundary` (error boundary)
+  + `captureReactLibraryError` imperative seam.
+- `@refraction-ui/angular-logger`: `RefractionErrorHandler` (`ErrorHandler`)
+  + `provideLibraryErrorCapture`; always delegates to the base handler so the
+  app's default error behavior is preserved.
+- `@refraction-ui/astro-logger`: `createLibraryErrorCapture` middleware hook
+  + `captureAstroLibraryError`; always rethrows so Astro's error handling is
+  unchanged.
+
+The real `@refraction-ui/logger` `TelemetrySink` satisfies the structural
+`DevFeedbackSink` sink contract — nothing phones home unless explicitly wired.

--- a/packages/angular-logger/__tests__/library-error-handler.test.ts
+++ b/packages/angular-logger/__tests__/library-error-handler.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import { ErrorHandler } from '@angular/core'
+import { createMockSink } from '@refraction-ui/logger'
+import { stackFingerprint, type LibraryOriginIdentity } from '@refraction-ui/shared'
+import {
+  RefractionErrorHandler,
+  provideLibraryErrorCapture,
+  LIBRARY_ORIGIN_IDENTITY,
+  LIBRARY_ERROR_SINK,
+} from '../src/library-error-handler.js'
+
+/**
+ * Exercises the Angular capture seam against the REAL `@refraction-ui/shared`
+ * primitives and the REAL `@refraction-ui/logger` `createMockSink` (it
+ * structurally satisfies `DevFeedbackSink`) — no stubs. The DI provider
+ * factory wiring is verified directly without bootstrapping a browser
+ * platform, mirroring `telemetry.service.test.ts`.
+ */
+
+const IDENTITY: LibraryOriginIdentity = {
+  package: '@refraction-ui/angular',
+  componentName: 'Dialog',
+  version: '0.1.5',
+  framework: 'angular',
+}
+
+const REFRACTION_STACK = [
+  'Error: boom',
+  '    at Dialog (/abs/node_modules/@refraction-ui/angular/dist/index.js:120:15)',
+  '    at App (/Users/someuser/secret-project/src/app.component.ts:42:7)',
+].join('\n')
+const APP_STACK = [
+  'Error: app bug',
+  '    at App (/Users/someuser/secret-project/src/app.component.ts:42:7)',
+].join('\n')
+
+const refractionError = (): Error =>
+  Object.assign(new Error('boom'), { stack: REFRACTION_STACK })
+const appError = (): Error =>
+  Object.assign(new Error('app bug'), { stack: APP_STACK })
+
+/** A spy base handler so we can assert default behavior is preserved. */
+function spyDelegate(): ErrorHandler & { handled: unknown[] } {
+  const handled: unknown[] = []
+  return Object.assign(new ErrorHandler(), {
+    handled,
+    handleError(e: unknown) {
+      handled.push(e)
+    },
+  })
+}
+
+describe('RefractionErrorHandler — refraction-origin error', () => {
+  it('captures + tags with the stack fingerprint and forwards to the sink', () => {
+    const sink = createMockSink('ng-capture')
+    const handler = new RefractionErrorHandler(IDENTITY, sink, spyDelegate())
+
+    const err = refractionError()
+    handler.handleError(err)
+
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0].level).toBe('error')
+    expect(sink.logs[0].context).toMatchObject({
+      origin: 'refraction-ui',
+      package: '@refraction-ui/angular',
+      componentName: 'Dialog',
+      version: '0.1.5',
+      framework: 'angular',
+      fingerprint: stackFingerprint(err),
+    })
+  })
+
+  it('still delegates the error to the base handler (default behavior kept)', () => {
+    const sink = createMockSink('ng-capture-2')
+    const delegate = spyDelegate()
+    const handler = new RefractionErrorHandler(IDENTITY, sink, delegate)
+    const err = refractionError()
+    handler.handleError(err)
+    expect(delegate.handled).toEqual([err])
+  })
+
+  it('forwards no app data beyond the fingerprint hash', () => {
+    const sink = createMockSink('ng-capture-3')
+    new RefractionErrorHandler(IDENTITY, sink, spyDelegate()).handleError(
+      refractionError(),
+    )
+    const serialized = JSON.stringify(sink.logs[0])
+    expect(serialized).not.toContain('someuser')
+    expect(serialized).not.toContain('secret-project')
+    expect(serialized).not.toContain('app.component.ts')
+  })
+})
+
+describe('RefractionErrorHandler — app-origin error is untouched', () => {
+  it('does NOT capture or forward an app-origin error', () => {
+    const sink = createMockSink('ng-app')
+    const handler = new RefractionErrorHandler(IDENTITY, sink, spyDelegate())
+    expect(handler.tryCapture(appError())).toBeNull()
+    expect(sink.logs).toHaveLength(0)
+  })
+
+  it('still delegates an app-origin error to the base handler', () => {
+    const sink = createMockSink('ng-app-2')
+    const delegate = spyDelegate()
+    const handler = new RefractionErrorHandler(IDENTITY, sink, delegate)
+    const err = appError()
+    handler.handleError(err)
+    expect(sink.logs).toHaveLength(0)
+    expect(delegate.handled).toEqual([err])
+  })
+})
+
+describe('RefractionErrorHandler — no sink wired (no-op)', () => {
+  it('does not throw and forwards nothing with sink=null', () => {
+    const handler = new RefractionErrorHandler(IDENTITY, null, spyDelegate())
+    expect(() => handler.handleError(refractionError())).not.toThrow()
+    expect(handler.tryCapture(refractionError())?.context.origin).toBe(
+      'refraction-ui',
+    )
+  })
+
+  it('a throwing sink never breaks the handler', () => {
+    const handler = new RefractionErrorHandler(
+      IDENTITY,
+      {
+        log: () => {
+          throw new Error('sink down')
+        },
+      },
+      spyDelegate(),
+    )
+    expect(() => handler.handleError(refractionError())).not.toThrow()
+  })
+})
+
+describe('provideLibraryErrorCapture — DI wiring', () => {
+  it('returns the identity token, sink token, and ErrorHandler factory', () => {
+    const sink = createMockSink('ng-di')
+    const providers = provideLibraryErrorCapture(IDENTITY, sink)
+    expect(providers).toHaveLength(3)
+
+    const idP = providers.find(
+      (p): p is { provide: unknown; useValue: unknown } =>
+        typeof p === 'object' &&
+        p !== null &&
+        'provide' in p &&
+        p.provide === LIBRARY_ORIGIN_IDENTITY,
+    )
+    const sinkP = providers.find(
+      (p): p is { provide: unknown; useValue: unknown } =>
+        typeof p === 'object' &&
+        p !== null &&
+        'provide' in p &&
+        p.provide === LIBRARY_ERROR_SINK,
+    )
+    const handlerP = providers.find(
+      (p): p is {
+        provide: unknown
+        useFactory: (...a: unknown[]) => unknown
+        deps: unknown[]
+      } =>
+        typeof p === 'object' &&
+        p !== null &&
+        'provide' in p &&
+        p.provide === ErrorHandler,
+    )
+
+    expect(idP?.useValue).toBe(IDENTITY)
+    expect(sinkP?.useValue).toBe(sink)
+    expect(handlerP?.deps).toEqual([LIBRARY_ORIGIN_IDENTITY, LIBRARY_ERROR_SINK])
+
+    const handler = handlerP!.useFactory(IDENTITY, sink) as RefractionErrorHandler
+    handler.handleError(refractionError())
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0].context.origin).toBe('refraction-ui')
+  })
+
+  it('defaults the sink to null (nothing phones home unless wired)', () => {
+    const providers = provideLibraryErrorCapture(IDENTITY)
+    const sinkP = providers.find(
+      (p): p is { provide: unknown; useValue: unknown } =>
+        typeof p === 'object' &&
+        p !== null &&
+        'provide' in p &&
+        p.provide === LIBRARY_ERROR_SINK,
+    )
+    expect(sinkP?.useValue).toBeNull()
+  })
+})

--- a/packages/angular-logger/src/index.ts
+++ b/packages/angular-logger/src/index.ts
@@ -6,6 +6,14 @@ export {
   TELEMETRY_CONFIG,
 } from './telemetry.service.js'
 
+// Library-origin error capture seam (epic #247 / issue #249)
+export {
+  RefractionErrorHandler,
+  provideLibraryErrorCapture,
+  LIBRARY_ORIGIN_IDENTITY,
+  LIBRARY_ERROR_SINK,
+} from './library-error-handler.js'
+
 // Re-export core types for convenience (vendor-neutral — no Faro/Grafana
 // types are exposed)
 export type {
@@ -20,3 +28,10 @@ export type {
   Span,
   Telemetry,
 } from '@refraction-ui/logger'
+
+// Library-origin capture contract (reused from shared — not redefined)
+export type {
+  LibraryOriginIdentity,
+  DevFeedbackRecord,
+  DevFeedbackSink,
+} from '@refraction-ui/shared'

--- a/packages/angular-logger/src/library-error-handler.ts
+++ b/packages/angular-logger/src/library-error-handler.ts
@@ -1,0 +1,127 @@
+import {
+  ErrorHandler,
+  Injectable,
+  InjectionToken,
+  type Provider,
+} from '@angular/core'
+import {
+  captureLibraryOriginError,
+  type DevFeedbackRecord,
+  type DevFeedbackSink,
+  type LibraryOriginIdentity,
+} from '@refraction-ui/shared'
+
+/**
+ * library-error-handler — the Angular capture seam for epic #247 / issue #249.
+ *
+ * An `ErrorHandler` that tags ONLY errors whose stack originates in a
+ * `@refraction-ui/*` package and routes them to an optional, consumer-wired
+ * telemetry sink. The filter → tag → route flow lives entirely in
+ * `@refraction-ui/shared`'s `captureLibraryOriginError`; this class is the
+ * thin Angular DI wrapper around it.
+ *
+ * The consumer's normal error behavior is preserved: EVERY error is still
+ * delegated to Angular's default `ErrorHandler` (console + rethrow semantics).
+ * App-origin errors are never tagged or forwarded to the diagnostics sink.
+ *
+ * Zero hard dependency on the telemetry lib — the sink is the structural
+ * `DevFeedbackSink` from shared (the real `@refraction-ui/logger`
+ * `TelemetrySink` satisfies it). Nothing phones home unless a sink is wired.
+ */
+
+/**
+ * DI token for the fixed package/component identity tagged onto a captured
+ * library-origin error. Carries NO app data (the fingerprint is derived from
+ * the stack). Required by {@link provideLibraryErrorCapture}.
+ */
+export const LIBRARY_ORIGIN_IDENTITY = new InjectionToken<LibraryOriginIdentity>(
+  '@refraction-ui/angular-logger:LIBRARY_ORIGIN_IDENTITY',
+)
+
+/**
+ * DI token for the optional, consumer-wired telemetry sink. Unprovided /
+ * `null` ⇒ no-op (nothing phones home). The real `@refraction-ui/logger`
+ * `TelemetrySink` satisfies this structurally.
+ */
+export const LIBRARY_ERROR_SINK = new InjectionToken<DevFeedbackSink | null>(
+  '@refraction-ui/angular-logger:LIBRARY_ERROR_SINK',
+)
+
+/**
+ * RefractionErrorHandler — see module doc. Delegates all errors to a base
+ * `ErrorHandler` (default Angular behavior preserved) and additionally
+ * captures only refraction-ui-origin ones.
+ */
+@Injectable()
+export class RefractionErrorHandler implements ErrorHandler {
+  private readonly identity: LibraryOriginIdentity
+  private readonly sink: DevFeedbackSink | null
+  private readonly delegate: ErrorHandler
+
+  constructor(
+    identity: LibraryOriginIdentity,
+    sink: DevFeedbackSink | null,
+    /** Base handler to preserve default behavior. Defaults to Angular's. */
+    delegate: ErrorHandler = new ErrorHandler(),
+  ) {
+    this.identity = identity
+    this.sink = sink
+    this.delegate = delegate
+  }
+
+  /**
+   * Capture refraction-origin errors (filter + tag + optional forward), then
+   * ALWAYS delegate to the base handler so the app's normal error behavior is
+   * untouched. Returns nothing (Angular's `ErrorHandler` contract).
+   *
+   * Exposed return is `void`; the captured record (or `null` for app-origin)
+   * is available via {@link tryCapture} for tests / advanced consumers.
+   */
+  handleError(error: unknown): void {
+    this.tryCapture(error)
+    this.delegate.handleError(error)
+  }
+
+  /**
+   * The pure capture step (no delegation). Returns the tagged diagnostics
+   * record for a library-origin error, or `null` when the error is app-origin
+   * (untouched — never forwarded). Never throws.
+   */
+  tryCapture(error: unknown): DevFeedbackRecord | null {
+    return captureLibraryOriginError(error, this.identity, this.sink)
+  }
+}
+
+/**
+ * provideLibraryErrorCapture — registers {@link RefractionErrorHandler} as the
+ * app's `ErrorHandler`, wiring the supplied identity and an optional sink.
+ *
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [
+ *     provideLibraryErrorCapture(
+ *       { package: '@refraction-ui/angular', componentName: 'app',
+ *         version: '0.1.0', framework: 'angular' },
+ *       mySink, // omit / null ⇒ nothing phones home
+ *     ),
+ *   ],
+ * })
+ * ```
+ */
+export function provideLibraryErrorCapture(
+  identity: LibraryOriginIdentity,
+  sink: DevFeedbackSink | null = null,
+): Provider[] {
+  return [
+    { provide: LIBRARY_ORIGIN_IDENTITY, useValue: identity },
+    { provide: LIBRARY_ERROR_SINK, useValue: sink },
+    {
+      provide: ErrorHandler,
+      useFactory: (
+        id: LibraryOriginIdentity,
+        s: DevFeedbackSink | null,
+      ): ErrorHandler => new RefractionErrorHandler(id, s),
+      deps: [LIBRARY_ORIGIN_IDENTITY, LIBRARY_ERROR_SINK],
+    },
+  ]
+}

--- a/packages/astro-logger/__tests__/library-error-capture.test.ts
+++ b/packages/astro-logger/__tests__/library-error-capture.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import { createMockSink } from '@refraction-ui/logger'
+import { stackFingerprint, type LibraryOriginIdentity } from '@refraction-ui/shared'
+import {
+  createLibraryErrorCapture,
+  captureAstroLibraryError,
+  type LibraryErrorCaptureContext,
+} from '../src/library-error-capture.js'
+
+/**
+ * Exercises the Astro capture seam against the REAL `@refraction-ui/shared`
+ * primitives and the REAL `@refraction-ui/logger` `createMockSink` (it
+ * structurally satisfies `DevFeedbackSink`) — no stubs of the primitives,
+ * mirroring `telemetry-middleware.test.ts`.
+ */
+
+const IDENTITY: LibraryOriginIdentity = {
+  package: '@refraction-ui/astro',
+  componentName: 'Dialog',
+  version: '0.1.5',
+  framework: 'astro',
+}
+
+const REFRACTION_STACK = [
+  'Error: boom',
+  '    at Dialog (/abs/node_modules/@refraction-ui/astro/dist/index.js:120:15)',
+  '    at Page (/Users/someuser/secret-project/src/pages/index.astro:42:7)',
+].join('\n')
+const APP_STACK = [
+  'Error: app bug',
+  '    at Page (/Users/someuser/secret-project/src/pages/index.astro:42:7)',
+].join('\n')
+
+const refractionError = (): Error =>
+  Object.assign(new Error('boom'), { stack: REFRACTION_STACK })
+const appError = (): Error =>
+  Object.assign(new Error('app bug'), { stack: APP_STACK })
+
+function ctx(url = 'https://example.test/'): LibraryErrorCaptureContext {
+  return { request: new Request(url), locals: {} }
+}
+
+describe('createLibraryErrorCapture — happy path passthrough', () => {
+  it('returns an onRequest handler', () => {
+    expect(typeof createLibraryErrorCapture({ identity: IDENTITY })).toBe(
+      'function',
+    )
+  })
+
+  it('returns the downstream response unchanged when nothing throws', async () => {
+    const sink = createMockSink('astro-ok')
+    const onRequest = createLibraryErrorCapture({ identity: IDENTITY, sink })
+    const res = new Response('payload', { status: 201 })
+    const out = await onRequest(ctx(), () => res)
+    expect(out).toBe(res)
+    expect(sink.logs).toHaveLength(0)
+  })
+})
+
+describe('createLibraryErrorCapture — refraction-origin error', () => {
+  it('captures + tags with the fingerprint, forwards, and rethrows', async () => {
+    const sink = createMockSink('astro-capture')
+    let captured: unknown = null
+    const onRequest = createLibraryErrorCapture({
+      identity: IDENTITY,
+      sink,
+      onCapture: (r) => {
+        captured = r
+      },
+    })
+    const err = refractionError()
+
+    await expect(
+      onRequest(ctx(), () => {
+        throw err
+      }),
+    ).rejects.toBe(err)
+
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0].context).toMatchObject({
+      origin: 'refraction-ui',
+      package: '@refraction-ui/astro',
+      componentName: 'Dialog',
+      version: '0.1.5',
+      framework: 'astro',
+      fingerprint: stackFingerprint(err),
+    })
+    expect(captured).toBe(sink.logs[0])
+  })
+
+  it('forwards no app data beyond the fingerprint hash', async () => {
+    const sink = createMockSink('astro-capture-2')
+    const onRequest = createLibraryErrorCapture({ identity: IDENTITY, sink })
+    await onRequest(ctx(), () => {
+      throw refractionError()
+    }).catch(() => {})
+    const serialized = JSON.stringify(sink.logs[0])
+    expect(serialized).not.toContain('someuser')
+    expect(serialized).not.toContain('secret-project')
+    expect(serialized).not.toContain('index.astro')
+  })
+})
+
+describe('createLibraryErrorCapture — app-origin error is untouched', () => {
+  it('does NOT capture or forward, and still rethrows', async () => {
+    const sink = createMockSink('astro-app')
+    let onCaptureCalled = false
+    const onRequest = createLibraryErrorCapture({
+      identity: IDENTITY,
+      sink,
+      onCapture: () => {
+        onCaptureCalled = true
+      },
+    })
+    const err = appError()
+    await expect(
+      onRequest(ctx(), () => {
+        throw err
+      }),
+    ).rejects.toBe(err)
+    expect(sink.logs).toHaveLength(0)
+    expect(onCaptureCalled).toBe(false)
+  })
+})
+
+describe('createLibraryErrorCapture — no sink wired (no-op)', () => {
+  it('does not throw extra, forwards nothing, still rethrows', async () => {
+    const onRequest = createLibraryErrorCapture({ identity: IDENTITY })
+    const err = refractionError()
+    await expect(
+      onRequest(ctx(), () => {
+        throw err
+      }),
+    ).rejects.toBe(err)
+  })
+
+  it('a throwing sink never masks the original error', async () => {
+    const onRequest = createLibraryErrorCapture({
+      identity: IDENTITY,
+      sink: {
+        log: () => {
+          throw new Error('sink down')
+        },
+      },
+    })
+    const err = refractionError()
+    await expect(
+      onRequest(ctx(), () => {
+        throw err
+      }),
+    ).rejects.toBe(err)
+  })
+})
+
+describe('captureAstroLibraryError — imperative seam', () => {
+  it('tags + forwards a refraction-origin error', () => {
+    const sink = createMockSink('astro-imperative')
+    const rec = captureAstroLibraryError(refractionError(), IDENTITY, sink)
+    expect(rec).not.toBeNull()
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0].context.origin).toBe('refraction-ui')
+  })
+
+  it('returns null and forwards nothing for an app-origin error', () => {
+    const sink = createMockSink('astro-imperative-2')
+    expect(captureAstroLibraryError(appError(), IDENTITY, sink)).toBeNull()
+    expect(sink.logs).toHaveLength(0)
+  })
+
+  it('is a no-op forward with no sink', () => {
+    expect(
+      captureAstroLibraryError(refractionError(), IDENTITY)?.context.origin,
+    ).toBe('refraction-ui')
+  })
+})

--- a/packages/astro-logger/src/index.ts
+++ b/packages/astro-logger/src/index.ts
@@ -8,6 +8,20 @@ export {
   type TelemetryMiddlewareOptions,
 } from './telemetry-middleware.js'
 
+// Library-origin error capture seam (epic #247 / issue #249)
+export {
+  createLibraryErrorCapture,
+  captureAstroLibraryError,
+  type LibraryErrorCaptureContext,
+  type LibraryErrorCaptureNext,
+  type LibraryErrorCaptureOptions,
+} from './library-error-capture.js'
+export type {
+  LibraryOriginIdentity,
+  DevFeedbackRecord,
+  DevFeedbackSink,
+} from '@refraction-ui/shared'
+
 // Re-export core types and factories for convenience (Faro stays hidden)
 export {
   createTelemetry,

--- a/packages/astro-logger/src/library-error-capture.ts
+++ b/packages/astro-logger/src/library-error-capture.ts
@@ -1,0 +1,121 @@
+import {
+  captureLibraryOriginError,
+  type DevFeedbackRecord,
+  type DevFeedbackSink,
+  type LibraryOriginIdentity,
+} from '@refraction-ui/shared'
+
+/**
+ * library-error-capture — the Astro capture seam for epic #247 / issue #249.
+ *
+ * A `defineMiddleware`-compatible runtime hook that tags ONLY errors whose
+ * stack originates in a `@refraction-ui/*` package and routes them to an
+ * optional, consumer-wired telemetry sink. The filter → tag → route flow
+ * lives entirely in `@refraction-ui/shared`'s `captureLibraryOriginError`;
+ * this is the thin Astro middleware around it.
+ *
+ * The error is ALWAYS rethrown so Astro's normal error handling (and the
+ * app's own error pages) are untouched. App-origin errors are never tagged
+ * or forwarded to the diagnostics sink — they pass straight through.
+ *
+ * Zero hard dependency on the telemetry lib — the sink is the structural
+ * `DevFeedbackSink` from shared (the real `@refraction-ui/logger`
+ * `TelemetrySink` satisfies it). Nothing phones home unless a sink is wired.
+ */
+
+/**
+ * Subset of Astro's middleware context we depend on. Kept structural so the
+ * adapter never needs Astro's types at build time (Astro is a peer dep and
+ * its middleware types vary across versions).
+ */
+export interface LibraryErrorCaptureContext {
+  request: Request
+  locals: Record<string, unknown>
+}
+
+/** A `MiddlewareNext`-compatible continuation. */
+export type LibraryErrorCaptureNext = () => Promise<Response> | Response
+
+/** Options for {@link createLibraryErrorCapture}. */
+export interface LibraryErrorCaptureOptions {
+  /**
+   * Fixed package/component identity tagged onto a captured library-origin
+   * error. Carries NO app data — the fingerprint is derived from the stack.
+   */
+  identity: LibraryOriginIdentity
+  /**
+   * Optional, consumer-wired telemetry sink. Library-origin errors are
+   * forwarded here when present; absent / `null` ⇒ no-op (nothing phones
+   * home). The real `@refraction-ui/logger` `TelemetrySink` satisfies this.
+   */
+  sink?: DevFeedbackSink | null
+  /**
+   * Invoked when a library-origin error is captured, with the tagged
+   * diagnostics record (after it has been forwarded to the sink). Optional;
+   * never called for app-origin errors.
+   */
+  onCapture?: (record: DevFeedbackRecord) => void
+}
+
+/**
+ * createLibraryErrorCapture — the Astro-idiomatic server-side capture hook.
+ *
+ * Returns a `defineMiddleware`-compatible `onRequest` handler that runs the
+ * downstream chain and, if it throws, captures the error iff it is
+ * `@refraction-ui/*`-origin (filter + tag + optional forward) and then
+ * ALWAYS rethrows so Astro's error handling is unchanged.
+ *
+ * ```ts
+ * // src/middleware.ts
+ * import { defineMiddleware } from 'astro:middleware'
+ * import { createLibraryErrorCapture } from '@refraction-ui/astro-logger'
+ *
+ * export const onRequest = defineMiddleware(
+ *   createLibraryErrorCapture({
+ *     identity: { package: '@refraction-ui/astro', componentName: 'app',
+ *                 version: '0.1.0', framework: 'astro' },
+ *     sink: mySink, // omit ⇒ nothing phones home
+ *   }),
+ * )
+ * ```
+ */
+export function createLibraryErrorCapture(
+  options: LibraryErrorCaptureOptions,
+): (
+  context: LibraryErrorCaptureContext,
+  next: LibraryErrorCaptureNext,
+) => Promise<Response> {
+  const { identity, sink = null, onCapture } = options
+
+  return async function onRequest(
+    _context: LibraryErrorCaptureContext,
+    next: LibraryErrorCaptureNext,
+  ): Promise<Response> {
+    try {
+      return await next()
+    } catch (error) {
+      // Filter + tag + route happens entirely in shared. Returns the tagged
+      // record for a library-origin error, or null for an app-origin error
+      // (left completely untouched — not forwarded anywhere).
+      const record = captureLibraryOriginError(error, identity, sink)
+      if (record) onCapture?.(record)
+      // Always rethrow: Astro's normal error handling / error page is
+      // unchanged for both library- and app-origin errors.
+      throw error
+    }
+  }
+}
+
+/**
+ * captureAstroLibraryError — the non-middleware Astro seam. Use from an
+ * endpoint / server island `try/catch` where the middleware cannot reach.
+ * Same contract: library-origin only, optional sink, app-origin returns
+ * `null` untouched. Never throws.
+ */
+export function captureAstroLibraryError(
+  error: unknown,
+  identity: LibraryOriginIdentity,
+  sink?: DevFeedbackSink | null,
+): DevFeedbackRecord | null {
+  return captureLibraryOriginError(error, identity, sink)
+}

--- a/packages/react-logger/__tests__/library-error-capture.test.tsx
+++ b/packages/react-logger/__tests__/library-error-capture.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { createMockSink } from '@refraction-ui/logger'
+import { stackFingerprint, type LibraryOriginIdentity } from '@refraction-ui/shared'
+import {
+  LibraryErrorCaptureBoundary,
+  captureReactLibraryError,
+} from '../src/library-error-capture.js'
+
+/**
+ * The React capture seam is exercised against the REAL `@refraction-ui/shared`
+ * primitives and the REAL `@refraction-ui/logger` `createMockSink` (it
+ * structurally satisfies the `DevFeedbackSink` contract) — no stubs of the
+ * primitives, no mocked sink internals.
+ *
+ * `componentDidCatch` is not invoked during `renderToString` (React only
+ * calls `getDerivedStateFromError` on the server) and this monorepo has no
+ * DOM test infra, so the reporting path is driven directly against the real
+ * lifecycle method — same approach as `error-boundary.test.tsx`.
+ */
+
+const IDENTITY: LibraryOriginIdentity = {
+  package: '@refraction-ui/react',
+  componentName: 'Dialog',
+  version: '0.1.5',
+  framework: 'react',
+}
+
+const REFRACTION_STACK = [
+  'Error: render exploded',
+  '    at Dialog (/abs/path/node_modules/@refraction-ui/react/dist/index.js:120:15)',
+  '    at renderWithHooks (/abs/path/node_modules/react-dom/cjs/react-dom.development.js:14985:18)',
+  '    at App (/Users/someuser/secret-project/src/App.tsx:42:7)',
+].join('\n')
+
+const APP_STACK = [
+  'Error: app bug',
+  '    at App (/Users/someuser/secret-project/src/App.tsx:42:7)',
+  '    at main (/Users/someuser/secret-project/src/main.tsx:7:3)',
+].join('\n')
+
+function refractionError(): Error {
+  return Object.assign(new Error('render exploded'), {
+    stack: REFRACTION_STACK,
+  })
+}
+function appError(): Error {
+  return Object.assign(new Error('app bug'), { stack: APP_STACK })
+}
+
+const info = { componentStack: '\n    in Dialog' } as React.ErrorInfo
+
+describe('LibraryErrorCaptureBoundary — render passthrough', () => {
+  it('renders children when nothing throws', () => {
+    const html = renderToString(
+      React.createElement(
+        LibraryErrorCaptureBoundary,
+        { identity: IDENTITY },
+        React.createElement('div', null, 'safe content'),
+      ),
+    )
+    expect(html).toContain('safe content')
+  })
+
+  it('renders a node fallback after an error', () => {
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      fallback: React.createElement('p', null, 'fallback shown'),
+    })
+    boundary.state = { error: new Error('x') }
+    expect(boundary.render()).toEqual(
+      React.createElement('p', null, 'fallback shown'),
+    )
+  })
+
+  it('renders a render-prop fallback receiving the error', () => {
+    const err = new Error('x')
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      fallback: (e: Error) => React.createElement('p', null, e.message),
+    })
+    boundary.state = { error: err }
+    expect(boundary.render()).toEqual(React.createElement('p', null, 'x'))
+  })
+})
+
+describe('LibraryErrorCaptureBoundary — refraction-origin error', () => {
+  it('captures + tags the error with the stack fingerprint and forwards it', () => {
+    const sink = createMockSink('capture-sink')
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink,
+    })
+
+    const err = refractionError()
+    boundary.componentDidCatch(err, info)
+
+    expect(sink.logs).toHaveLength(1)
+    const record = sink.logs[0]
+    expect(record.level).toBe('error')
+    expect(record.context).toMatchObject({
+      origin: 'refraction-ui',
+      package: '@refraction-ui/react',
+      componentName: 'Dialog',
+      version: '0.1.5',
+      framework: 'react',
+      fingerprint: stackFingerprint(err),
+    })
+  })
+
+  it('passes the tagged record (not null) to onError', () => {
+    const sink = createMockSink('capture-sink-2')
+    let received: unknown = 'unset'
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink,
+      onError: (_e, _i, record) => {
+        received = record
+      },
+    })
+    boundary.componentDidCatch(refractionError(), info)
+    expect(received).not.toBeNull()
+    expect((received as { context: Record<string, unknown> }).context.origin).toBe(
+      'refraction-ui',
+    )
+  })
+
+  it('forwards no app data beyond the fingerprint hash', () => {
+    const sink = createMockSink('capture-sink-3')
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink,
+    })
+    boundary.componentDidCatch(refractionError(), info)
+    const serialized = JSON.stringify(sink.logs[0])
+    expect(serialized).not.toContain('someuser')
+    expect(serialized).not.toContain('secret-project')
+    expect(serialized).not.toContain('App.tsx')
+  })
+})
+
+describe('LibraryErrorCaptureBoundary — app-origin error is untouched', () => {
+  it('does NOT capture or forward an app-origin error', () => {
+    const sink = createMockSink('app-sink')
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink,
+    })
+    boundary.componentDidCatch(appError(), info)
+    expect(sink.logs).toHaveLength(0)
+  })
+
+  it('surfaces an app-origin error to onError with record === null', () => {
+    const sink = createMockSink('app-sink-2')
+    let record: unknown = 'unset'
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink,
+      onError: (_e, _i, r) => {
+        record = r
+      },
+    })
+    const err = appError()
+    boundary.componentDidCatch(err, info)
+    expect(record).toBeNull()
+    expect(sink.logs).toHaveLength(0)
+  })
+})
+
+describe('LibraryErrorCaptureBoundary — no sink wired (no-op)', () => {
+  it('does not throw and reports nothing when no sink is provided', () => {
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+    })
+    expect(() =>
+      boundary.componentDidCatch(refractionError(), info),
+    ).not.toThrow()
+  })
+
+  it('still surfaces the tagged record to onError without a sink', () => {
+    let record: unknown = 'unset'
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      onError: (_e, _i, r) => {
+        record = r
+      },
+    })
+    boundary.componentDidCatch(refractionError(), info)
+    expect((record as { context: Record<string, unknown> }).context.origin).toBe(
+      'refraction-ui',
+    )
+  })
+
+  it('a throwing sink never breaks the boundary', () => {
+    const boundary = new LibraryErrorCaptureBoundary({
+      identity: IDENTITY,
+      children: null,
+      sink: {
+        log: () => {
+          throw new Error('sink down')
+        },
+      },
+    })
+    expect(() =>
+      boundary.componentDidCatch(refractionError(), info),
+    ).not.toThrow()
+  })
+})
+
+describe('captureReactLibraryError — imperative seam', () => {
+  it('tags + forwards a refraction-origin error', () => {
+    const sink = createMockSink('imperative')
+    const rec = captureReactLibraryError(refractionError(), IDENTITY, sink)
+    expect(rec).not.toBeNull()
+    expect(sink.logs).toHaveLength(1)
+    expect(sink.logs[0].context.origin).toBe('refraction-ui')
+  })
+
+  it('returns null and forwards nothing for an app-origin error', () => {
+    const sink = createMockSink('imperative-2')
+    const rec = captureReactLibraryError(appError(), IDENTITY, sink)
+    expect(rec).toBeNull()
+    expect(sink.logs).toHaveLength(0)
+  })
+
+  it('is a no-op forward with no sink', () => {
+    const rec = captureReactLibraryError(refractionError(), IDENTITY)
+    expect(rec?.context.origin).toBe('refraction-ui')
+  })
+})

--- a/packages/react-logger/src/index.ts
+++ b/packages/react-logger/src/index.ts
@@ -13,6 +13,13 @@ export type { UseSpanAPI } from './use-span.js'
 export { TelemetryErrorBoundary } from './error-boundary.js'
 export type { TelemetryErrorBoundaryProps } from './error-boundary.js'
 
+// Library-origin error capture seam (epic #247 / issue #249)
+export {
+  LibraryErrorCaptureBoundary,
+  captureReactLibraryError,
+} from './library-error-capture.js'
+export type { LibraryErrorCaptureBoundaryProps } from './library-error-capture.js'
+
 // Re-export core types for convenience
 export type {
   Telemetry,

--- a/packages/react-logger/src/library-error-capture.tsx
+++ b/packages/react-logger/src/library-error-capture.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import {
+  captureLibraryOriginError,
+  type DevFeedbackRecord,
+  type DevFeedbackSink,
+  type LibraryOriginIdentity,
+} from '@refraction-ui/shared'
+
+/**
+ * library-error-capture — the React capture seam for epic #247 / issue #249.
+ *
+ * Tags ONLY errors whose stack originates in a `@refraction-ui/*` package and
+ * routes them to an optional, consumer-wired telemetry sink. The whole
+ * filter → tag → route flow lives in `@refraction-ui/shared`'s
+ * `captureLibraryOriginError`; this module is the thin React boundary around
+ * it. App-origin errors are never captured, tagged, or forwarded to the
+ * diagnostics sink — they pass straight through to the consumer's own error
+ * handling, exactly as if this seam were not present.
+ *
+ * Zero hard dependency on the telemetry lib: the sink is the structural
+ * `DevFeedbackSink` from shared (the real `@refraction-ui/logger`
+ * `TelemetrySink` satisfies it). Nothing phones home unless a sink is wired.
+ */
+
+export interface LibraryErrorCaptureBoundaryProps {
+  children: React.ReactNode
+  /**
+   * Fixed package/component identity tagged onto a captured library-origin
+   * error. Carries NO app data — the fingerprint is derived from the stack.
+   */
+  identity: LibraryOriginIdentity
+  /**
+   * Optional, consumer-wired telemetry sink. Library-origin errors are
+   * forwarded here when present; absent ⇒ no-op (nothing phones home).
+   */
+  sink?: DevFeedbackSink | null
+  /**
+   * Fallback UI rendered after ANY caught error (a boundary must render
+   * something). May be a node or a render function receiving the error and a
+   * reset callback. Defaults to re-rendering nothing (`null`).
+   */
+  fallback?:
+    | React.ReactNode
+    | ((error: Error, reset: () => void) => React.ReactNode)
+  /**
+   * Invoked for EVERY caught error (library- or app-origin), after capture is
+   * attempted. `record` is the tagged diagnostics record for a library-origin
+   * error, or `null` for an app-origin error (untouched — the app owns it).
+   */
+  onError?: (
+    error: Error,
+    info: React.ErrorInfo,
+    record: DevFeedbackRecord | null,
+  ) => void
+}
+
+interface LibraryErrorCaptureBoundaryState {
+  error: Error | null
+}
+
+/**
+ * LibraryErrorCaptureBoundary — a React error boundary whose ONLY telemetry
+ * side effect is capturing refraction-ui-origin errors.
+ *
+ * ```tsx
+ * <LibraryErrorCaptureBoundary
+ *   identity={{ package: '@refraction-ui/react', componentName: 'Dialog',
+ *               version: '0.1.5', framework: 'react' }}
+ *   sink={mySink}
+ * >
+ *   <Dialog />
+ * </LibraryErrorCaptureBoundary>
+ * ```
+ *
+ * - A `@refraction-ui/*`-origin render error → tagged via shared's
+ *   `libraryOriginError` and forwarded to `sink` (only if wired).
+ * - An app-origin render error → NOT tagged, NOT forwarded; surfaced to
+ *   `onError` with `record === null` and rendered via `fallback`, untouched.
+ */
+export class LibraryErrorCaptureBoundary extends React.Component<
+  LibraryErrorCaptureBoundaryProps,
+  LibraryErrorCaptureBoundaryState
+> {
+  state: LibraryErrorCaptureBoundaryState = { error: null }
+
+  static getDerivedStateFromError(
+    error: Error,
+  ): LibraryErrorCaptureBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // Filter + tag + route happens entirely in shared. Returns the tagged
+    // record for a library-origin error, or null for an app-origin error
+    // (which is left completely untouched — not forwarded anywhere).
+    const record = captureLibraryOriginError(
+      error,
+      this.props.identity,
+      this.props.sink,
+    )
+    this.props.onError?.(error, info, record)
+  }
+
+  reset = (): void => {
+    this.setState({ error: null })
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state
+    if (error) {
+      const { fallback } = this.props
+      if (typeof fallback === 'function') {
+        return fallback(error, this.reset)
+      }
+      return fallback ?? null
+    }
+    return this.props.children
+  }
+}
+
+/**
+ * captureReactLibraryError — the non-boundary React seam. Use from an
+ * imperative handler (event handlers, effects, `window.onerror` bridges)
+ * where an error boundary cannot reach. Same contract as the boundary:
+ * library-origin only, optional sink, app-origin returns `null` untouched.
+ */
+export function captureReactLibraryError(
+  error: unknown,
+  identity: LibraryOriginIdentity,
+  sink?: DevFeedbackSink | null,
+): DevFeedbackRecord | null {
+  return captureLibraryOriginError(error, identity, sink)
+}

--- a/packages/shared/__tests__/library-origin-error.test.ts
+++ b/packages/shared/__tests__/library-origin-error.test.ts
@@ -3,8 +3,12 @@ import {
   libraryOriginError,
   libraryOriginEnvelope,
   stackFingerprint,
+  isLibraryOriginError,
+  captureLibraryOriginError,
   type LibraryOriginErrorInput,
+  type LibraryOriginIdentity,
 } from '../src/library-origin-error.js'
+import type { DevFeedbackRecord } from '../src/dev-feedback.js'
 
 const REFRACTION_STACK = [
   'Error: boom',
@@ -147,6 +151,113 @@ describe('library-origin-error', () => {
     it('handles missing/undefined error without throwing', () => {
       expect(() => stackFingerprint(undefined)).not.toThrow()
       expect(stackFingerprint(undefined)).toEqual(expect.any(String))
+    })
+  })
+
+  describe('isLibraryOriginError (the capture-seam gate)', () => {
+    it('is true when the stack has a @refraction-ui/* frame', () => {
+      expect(
+        isLibraryOriginError(
+          Object.assign(new Error('boom'), { stack: REFRACTION_STACK }),
+        ),
+      ).toBe(true)
+      expect(isLibraryOriginError(REFRACTION_STACK)).toBe(true)
+    })
+
+    it('is false for an app-only error (no refraction-ui frame)', () => {
+      const appOnly = [
+        'Error: boom',
+        '    at App (/Users/someuser/app/src/App.tsx:1:1)',
+        '    at main (/Users/someuser/app/src/main.tsx:2:2)',
+      ].join('\n')
+      expect(
+        isLibraryOriginError(
+          Object.assign(new Error('boom'), { stack: appOnly }),
+        ),
+      ).toBe(false)
+    })
+
+    it('is false for a missing/odd error and never throws', () => {
+      expect(isLibraryOriginError(undefined)).toBe(false)
+      expect(isLibraryOriginError(null)).toBe(false)
+      expect(isLibraryOriginError(42)).toBe(false)
+      expect(isLibraryOriginError({})).toBe(false)
+    })
+  })
+
+  describe('captureLibraryOriginError (shared seam primitive)', () => {
+    const identity: LibraryOriginIdentity = {
+      package: '@refraction-ui/react',
+      componentName: 'Dialog',
+      version: '0.1.5',
+      framework: 'react',
+    }
+
+    const appError = Object.assign(new Error('app bug'), {
+      stack: [
+        'Error: app bug',
+        '    at App (/Users/someuser/app/src/App.tsx:1:1)',
+      ].join('\n'),
+    })
+    const libError = Object.assign(new Error('boom'), {
+      stack: REFRACTION_STACK,
+    })
+
+    it('tags a refraction-origin error and forwards it to the sink', () => {
+      const logs: DevFeedbackRecord[] = []
+      const sink = { log: (r: DevFeedbackRecord) => logs.push(r) }
+
+      const rec = captureLibraryOriginError(libError, identity, sink)
+
+      expect(rec).not.toBeNull()
+      expect(rec!.level).toBe('error')
+      expect(rec!.context).toMatchObject({
+        origin: 'refraction-ui',
+        package: '@refraction-ui/react',
+        componentName: 'Dialog',
+        version: '0.1.5',
+        framework: 'react',
+        fingerprint: stackFingerprint(libError),
+      })
+      expect(logs).toHaveLength(1)
+      expect(logs[0]).toBe(rec)
+    })
+
+    it('does NOT capture or forward an app-origin error (returns null)', () => {
+      const logs: DevFeedbackRecord[] = []
+      const sink = { log: (r: DevFeedbackRecord) => logs.push(r) }
+
+      const rec = captureLibraryOriginError(appError, identity, sink)
+
+      expect(rec).toBeNull()
+      expect(logs).toHaveLength(0)
+    })
+
+    it('is a no-op forward when no sink is wired (still tags the record)', () => {
+      const recNull = captureLibraryOriginError(libError, identity, null)
+      const recUndef = captureLibraryOriginError(libError, identity, undefined)
+      expect(recNull?.context.origin).toBe('refraction-ui')
+      expect(recUndef?.context.origin).toBe('refraction-ui')
+    })
+
+    it('a throwing sink never breaks the caller', () => {
+      const sink = {
+        log: () => {
+          throw new Error('sink is down')
+        },
+      }
+      expect(() =>
+        captureLibraryOriginError(libError, identity, sink),
+      ).not.toThrow()
+    })
+
+    it('carries no app data beyond the fingerprint hash', () => {
+      const rec = captureLibraryOriginError(libError, identity, null)!
+      const serialized = JSON.stringify(rec)
+      expect(serialized).not.toContain('someuser')
+      expect(serialized).not.toContain('secret-project')
+      expect(serialized).not.toContain('App.tsx')
+      expect(serialized).not.toContain('/Users/')
     })
   })
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,6 +57,7 @@ export type {
   LibraryFramework,
   LibraryOriginErrorInput,
   LibraryOriginEnvelope,
+  LibraryOriginIdentity,
 } from './library-origin-error.js'
 
 // Functions
@@ -79,4 +80,6 @@ export {
   libraryOriginError,
   libraryOriginEnvelope,
   stackFingerprint,
+  isLibraryOriginError,
+  captureLibraryOriginError,
 } from './library-origin-error.js'

--- a/packages/shared/src/library-origin-error.ts
+++ b/packages/shared/src/library-origin-error.ts
@@ -14,7 +14,10 @@
  * stack frames.
  */
 
-import type { DevFeedbackRecord } from './dev-feedback.js'
+import type { DevFeedbackRecord, DevFeedbackSink } from './dev-feedback.js'
+
+/** Matches any stack frame that references a `@refraction-ui/*` package. */
+const REFRACTION_FRAME = /@refraction-ui\//
 
 /** Frameworks a refraction-ui adapter can run under. */
 export type LibraryFramework =
@@ -71,7 +74,7 @@ function normalizeStack(stack: string): string {
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.startsWith('at ') || line.includes('@'))
-    .filter((line) => /@refraction-ui\//.test(line))
+    .filter((line) => REFRACTION_FRAME.test(line))
     .map((line) =>
       line
         // drop everything from the path/url onward, keep the symbol
@@ -170,4 +173,68 @@ export function libraryOriginError(
     timestamp: Date.now(),
     context: { ...envelope },
   }
+}
+
+/**
+ * Library-origin predicate — `true` iff the error's stack contains at least
+ * one frame that references a `@refraction-ui/*` package. This is the gate
+ * every per-framework capture seam uses: only library-origin errors are
+ * eligible; the app's own errors return `false` and pass through untouched.
+ *
+ * Mirrors exactly the frame-detection rule {@link stackFingerprint} normalizes
+ * by — no new contract, just the companion predicate the seams need. Never
+ * throws for a missing/odd error (returns `false`).
+ */
+export function isLibraryOriginError(error: unknown): boolean {
+  const stack = stackOf(error)
+  if (!stack) return false
+  return REFRACTION_FRAME.test(stack)
+}
+
+/**
+ * The fixed identity of the refraction-ui package/component a seam tags an
+ * error with. The seam supplies this; the stack itself supplies the
+ * fingerprint. Never carries app data.
+ */
+export type LibraryOriginIdentity = Pick<
+  LibraryOriginErrorInput,
+  'package' | 'componentName' | 'version' | 'framework'
+>
+
+/**
+ * The single capture primitive shared by every per-framework seam (React error
+ * boundary, Angular `ErrorHandler`, Astro middleware). It performs the entire
+ * guarded flow in one place so the seams stay thin and identical in behavior:
+ *
+ *  1. **Library-origin filter** — if the error's stack has no
+ *     `@refraction-ui/*` frame it is the app's own error: return `null` and do
+ *     NOT touch, capture, or forward it.
+ *  2. **Tag** — build the redacted {@link libraryOriginError} record
+ *     (package/componentName/version/framework + app-data-free fingerprint).
+ *  3. **Route to the optional sink** — forward the record to the
+ *     consumer-injected sink ONLY if one was wired; a broken sink can never
+ *     break the consumer app. With no sink this is a no-op beyond returning
+ *     the record (so a seam can still surface it locally).
+ *
+ * @returns the tagged record for a library-origin error, or `null` when the
+ *          error is app-origin (the "pass through untouched" signal).
+ */
+export function captureLibraryOriginError(
+  error: unknown,
+  identity: LibraryOriginIdentity,
+  sink: DevFeedbackSink | null | undefined,
+): DevFeedbackRecord | null {
+  if (!isLibraryOriginError(error)) return null
+
+  const record = libraryOriginError({ ...identity, error })
+
+  if (sink) {
+    try {
+      sink.log(record)
+    } catch {
+      // A broken sink must never break the consumer app.
+    }
+  }
+
+  return record
 }


### PR DESCRIPTION
Epic #247 Wave 1. Shared `isLibraryOriginError`/`captureLibraryOriginError` (reuses #248 envelope + DevFeedbackSink, no logger hard-dep) + thin React/Angular/Astro seams capturing ONLY `@refraction-ui/*`-origin errors → optional sink; app-origin errors untouched; throwing-sink safe. Changeset: shared+react/angular/astro-logger `minor`.

✅ turbo exit 0 (16 tasks) · shared 119 / react-logger 38 / angular-logger 19 / astro-logger 19 tests. Closes #249. Unblocks #254 Wave 2 (error-seam rollout).