### PR TITLE
feat: footgun devWarn Batch 1B — react-charts/react-select (#256)

### DIFF
--- a/.changeset/devwarn-batch-1b.md
+++ b/.changeset/devwarn-batch-1b.md
@@ -1,0 +1,10 @@
+---
+"@refraction-ui/react-charts": minor
+"@refraction-ui/react-select": minor
+---
+
+feat: dev-only `devWarn` on the silent-default-context footgun (epic #254 Wave 1, #256 Batch 1B)
+
+`react-charts` sub-charts (`Bars`/`Line`/`Circles`) and `react-select` compound parts (`SelectTrigger`/`SelectContent`/`SelectItem`) previously fell back to a context default with **no error and no signal** when used outside `<Chart>` / `<Select>` (the worst footgun tier per `docs/instrumentation/policy.md`). They now emit a warn-once `devWarn` from `@refraction-ui/shared` at the context-consumption seam.
+
+Non-breaking by design: no throw is introduced (would be a breaking change for a silent-default context), runtime behaviour is unchanged, and the `devWarn` is env-guarded so it is stripped/silent in production.

--- a/packages/react-charts/__tests__/footgun-devwarn.test.tsx
+++ b/packages/react-charts/__tests__/footgun-devwarn.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+// Real @refraction-ui/shared — no mock. devWarn/resetDevFeedback come from the
+// actual published primitive (epic #248), exercising the genuine env guard and
+// warn-once dedupe across the package boundary.
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { Chart, Bars, Line, Circles } from '../src/index.js'
+
+const barData = [
+  { label: 'A', value: 10 },
+  { label: 'B', value: 20 },
+]
+const xyData = [
+  { x: 0, y: 10 },
+  { x: 1, y: 20 },
+]
+
+function renderBarsAlone() {
+  return renderToString(
+    React.createElement(Bars, {
+      data: barData,
+      x: (d: (typeof barData)[0]) => d.label,
+      y: (d: (typeof barData)[0]) => d.value,
+    }),
+  )
+}
+
+describe('react-charts — silent-default-context footgun (devWarn)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  describe('in development', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('warns when a sub-chart renders without a <Chart> ancestor', () => {
+      renderBarsAlone()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const msg = String(warnSpy.mock.calls[0][0])
+      expect(msg).toContain('react-charts/no-chart-provider')
+      expect(msg).toContain('<Chart>')
+    })
+
+    it('warns for Line and Circles used outside <Chart> too', () => {
+      renderToString(
+        React.createElement(Line, {
+          data: xyData,
+          x: (d: (typeof xyData)[0]) => d.x,
+          y: (d: (typeof xyData)[0]) => d.y,
+        }),
+      )
+      // warn-once is keyed by code; one shared code across sub-charts.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      resetDevFeedback()
+      warnSpy.mockClear()
+      renderToString(
+        React.createElement(Circles, {
+          data: xyData,
+          cx: (d: (typeof xyData)[0]) => d.x,
+          cy: (d: (typeof xyData)[0]) => d.y,
+        }),
+      )
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT warn when wrapped in <Chart>', () => {
+      renderToString(
+        React.createElement(
+          Chart,
+          { width: 500, height: 300 },
+          React.createElement(Bars, {
+            data: barData,
+            x: (d: (typeof barData)[0]) => d.label,
+            y: (d: (typeof barData)[0]) => d.value,
+          }),
+        ),
+      )
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('warns at most once (warn-once dedupe) across many misuses', () => {
+      renderBarsAlone()
+      renderBarsAlone()
+      renderBarsAlone()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw — behaviour is unchanged, devWarn is the only signal', () => {
+      let html = ''
+      expect(() => {
+        html = renderBarsAlone()
+      }).not.toThrow()
+      // Still renders with the silent default dimensions (no breaking change).
+      expect(html).toContain('<rect')
+    })
+  })
+
+  describe('in production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    it('does NOT warn (devWarn is stripped/guarded in prod)', () => {
+      renderBarsAlone()
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('still renders identically (no behavioural change in prod)', () => {
+      const html = renderBarsAlone()
+      expect(html).toContain('<rect')
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/react-charts/src/bars.tsx
+++ b/packages/react-charts/src/bars.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { useContext } from 'react'
 import { createBandScale, createLinearScale, computeExtent } from '@refraction-ui/charts'
-import { ChartContext } from './chart-context.js'
+import { useChartContext } from './chart-context.js'
 
 export interface BarsProps<T = unknown> {
   data: T[]
@@ -11,7 +10,7 @@ export interface BarsProps<T = unknown> {
 }
 
 export function Bars<T>({ data, x, y, fill = 'currentColor' }: BarsProps<T>) {
-  const { dimensions } = useContext(ChartContext)
+  const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
 
   const labels = data.map(x)

--- a/packages/react-charts/src/chart-context.ts
+++ b/packages/react-charts/src/chart-context.ts
@@ -1,13 +1,24 @@
-import { createContext } from 'react'
+import { createContext, useContext } from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import type { Dimensions, Margin } from '@refraction-ui/charts'
 
 export interface ChartContextValue {
   dimensions: Dimensions
+  /**
+   * Internal marker: `true` only on the context *default* (i.e. no `<Chart>`
+   * provider above this consumer). `<Chart>` always supplies a value without
+   * this flag. Used purely to detect the silent-default footgun — never read
+   * for rendering, and stripped from the public type surface.
+   *
+   * @internal
+   */
+  __isDefault?: boolean
 }
 
 const DEFAULT_MARGIN: Margin = { top: 40, right: 30, bottom: 40, left: 75 }
 
 export const ChartContext = createContext<ChartContextValue>({
+  __isDefault: true,
   dimensions: {
     width: 600,
     height: 400,
@@ -16,3 +27,28 @@ export const ChartContext = createContext<ChartContextValue>({
     boundedHeight: 400 - DEFAULT_MARGIN.top - DEFAULT_MARGIN.bottom,
   },
 })
+
+/**
+ * Read the chart context for a sub-chart (`Bars`, `Line`, `Circles`, …).
+ *
+ * Footgun seam (epic #254 / #256, policy: `silent-default-context`): when a
+ * sub-chart is rendered without a `<Chart>` ancestor it silently falls back to
+ * a 600x400 default and renders visibly wrong (wrong scale, clipped, or
+ * zero-sized) with no error. There is no throw today and adding one would be a
+ * breaking change, so per `docs/instrumentation/policy.md` a dev-only
+ * `devWarn` is the *only* signal. Stripped in production, warn-once.
+ *
+ * Behaviour is unchanged: the default dimensions are still returned.
+ */
+export function useChartContext(): ChartContextValue {
+  const ctx = useContext(ChartContext)
+  if (ctx.__isDefault) {
+    devWarn(
+      'react-charts/no-chart-provider',
+      'A chart sub-component (Bars/Line/Circles/…) was rendered without a <Chart> ancestor. ' +
+        'It is silently falling back to default 600x400 dimensions and will render with the ' +
+        'wrong scale. Wrap it in <Chart>…</Chart>.',
+    )
+  }
+  return ctx
+}

--- a/packages/react-charts/src/circles.tsx
+++ b/packages/react-charts/src/circles.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { useContext } from 'react'
 import { createLinearScale, computeExtent } from '@refraction-ui/charts'
-import { ChartContext } from './chart-context.js'
+import { useChartContext } from './chart-context.js'
 
 export interface CirclesProps<T = unknown> {
   data: T[]
@@ -18,7 +17,7 @@ export function Circles<T>({
   r = 4,
   fill = 'currentColor',
 }: CirclesProps<T>) {
-  const { dimensions } = useContext(ChartContext)
+  const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
 
   const xValues = data.map(cx)

--- a/packages/react-charts/src/line.tsx
+++ b/packages/react-charts/src/line.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { useContext } from 'react'
 import { createLinearScale, computeExtent, linePath } from '@refraction-ui/charts'
-import { ChartContext } from './chart-context.js'
+import { useChartContext } from './chart-context.js'
 
 export interface LineProps<T = unknown> {
   data: T[]
@@ -20,7 +19,7 @@ export function Line<T>({
   strokeWidth = 2,
   fill = 'none',
 }: LineProps<T>) {
-  const { dimensions } = useContext(ChartContext)
+  const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
 
   const xValues = data.map(x)

--- a/packages/react-select/__tests__/footgun-devwarn.test.tsx
+++ b/packages/react-select/__tests__/footgun-devwarn.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+// Real @refraction-ui/shared — no mock. Exercises the genuine #248 primitive
+// (env guard + warn-once) across the package boundary.
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { Select, SelectTrigger, SelectContent, SelectItem } from '../src/select.js'
+
+describe('react-select — silent-default-context footgun (devWarn)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  describe('in development', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('warns when SelectTrigger renders without a <Select> ancestor', () => {
+      renderToString(React.createElement(SelectTrigger, null, 'Pick'))
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const msg = String(warnSpy.mock.calls[0][0])
+      expect(msg).toContain('react-select/no-select-provider')
+      expect(msg).toContain('<Select>')
+    })
+
+    it('warns when SelectItem renders without a <Select> ancestor', () => {
+      renderToString(
+        React.createElement(SelectItem, { value: 'a' }, 'Apple'),
+      )
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(String(warnSpy.mock.calls[0][0])).toContain(
+        'react-select/no-select-provider',
+      )
+    })
+
+    it('warns for SelectContent rendered out of context (seam is before the closed-null return)', () => {
+      renderToString(
+        React.createElement(SelectContent, null, 'hidden'),
+      )
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT warn when parts are inside <Select>', () => {
+      renderToString(
+        React.createElement(
+          Select,
+          null,
+          React.createElement(SelectTrigger, null, 'Pick'),
+          React.createElement(
+            'div',
+            null,
+            React.createElement(SelectItem, { value: 'a' }, 'Apple'),
+          ),
+        ),
+      )
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('warns at most once (warn-once dedupe) across many misuses', () => {
+      renderToString(React.createElement(SelectTrigger, null, 'one'))
+      renderToString(React.createElement(SelectTrigger, null, 'two'))
+      renderToString(React.createElement(SelectItem, { value: 'b' }, 'x'))
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw — behaviour unchanged, devWarn is the only signal', () => {
+      let html = ''
+      expect(() => {
+        html = renderToString(
+          React.createElement(SelectTrigger, null, 'Pick'),
+        )
+      }).not.toThrow()
+      // Still renders the (inert) button with the silent default context.
+      expect(html).toContain('<button')
+      expect(html).toContain('Pick')
+    })
+  })
+
+  describe('in production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    it('does NOT warn (devWarn is stripped/guarded in prod)', () => {
+      renderToString(React.createElement(SelectTrigger, null, 'Pick'))
+      renderToString(
+        React.createElement(SelectItem, { value: 'a' }, 'Apple'),
+      )
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('still renders identically (no behavioural change in prod)', () => {
+      const html = renderToString(
+        React.createElement(SelectTrigger, null, 'Pick'),
+      )
+      expect(html).toContain('<button')
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/react-select/src/select.tsx
+++ b/packages/react-select/src/select.tsx
@@ -6,7 +6,7 @@ import {
   selectItemVariants,
   type SelectOption,
 } from '@refraction-ui/select'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ─── Context ──────────────────────────────────────────────────── */
 interface SelectContextValue {
@@ -19,9 +19,19 @@ interface SelectContextValue {
   placeholder: string
   triggerId: string
   contentId: string
+  /**
+   * Internal marker: `true` only on the context *default* (i.e. no `<Select>`
+   * provider above this part). `<Select>` always supplies a value without
+   * this flag. Used purely to detect the silent-default footgun — never read
+   * for rendering.
+   *
+   * @internal
+   */
+  __isDefault?: boolean
 }
 
 const SelectContext = React.createContext<SelectContextValue>({
+  __isDefault: true,
   value: undefined,
   onValueChange: () => {},
   open: false,
@@ -32,6 +42,32 @@ const SelectContext = React.createContext<SelectContextValue>({
   triggerId: '',
   contentId: '',
 })
+
+/**
+ * Read the select context for a compound part (`SelectTrigger`,
+ * `SelectContent`, `SelectItem`).
+ *
+ * Footgun seam (epic #254 / #256, policy: `silent-default-context`): when a
+ * part is rendered without a `<Select>` ancestor it silently reads inert
+ * context defaults (no-op handlers, empty ids, never-open) and renders a dead
+ * control with no error. There is no throw today and adding one would be a
+ * breaking change, so per `docs/instrumentation/policy.md` a dev-only
+ * `devWarn` is the *only* signal. Stripped in production, warn-once.
+ *
+ * Behaviour is unchanged: the default context value is still returned.
+ */
+function useSelectContext(part: string): SelectContextValue {
+  const ctx = React.useContext(SelectContext)
+  if (ctx.__isDefault) {
+    devWarn(
+      'react-select/no-select-provider',
+      `<${part}> was rendered without a <Select> ancestor. It is silently ` +
+        'reading inert context defaults (clicks/keyboard do nothing, it never ' +
+        'opens). Wrap it in <Select>…</Select>.',
+    )
+  }
+  return ctx
+}
 
 /* ─── Select (root) ────────────────────────────────────────────── */
 export interface SelectProps {
@@ -85,7 +121,7 @@ export interface SelectTriggerProps extends React.ButtonHTMLAttributes<HTMLButto
 
 export const SelectTrigger = React.forwardRef<HTMLButtonElement, SelectTriggerProps>(
   ({ className, children, size = 'default', ...props }, ref) => {
-    const { open, setOpen, disabled, triggerId, contentId } = React.useContext(SelectContext)
+    const { open, setOpen, disabled, triggerId, contentId } = useSelectContext('SelectTrigger')
 
     const api = createSelect({ disabled, open })
 
@@ -148,7 +184,7 @@ export interface SelectContentProps extends React.HTMLAttributes<HTMLDivElement>
 
 export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
   ({ className, children, ...props }, forwardedRef) => {
-    const { open, contentId, triggerId, setOpen } = React.useContext(SelectContext)
+    const { open, contentId, triggerId, setOpen } = useSelectContext('SelectContent')
     const containerRef = React.useRef<HTMLDivElement>(null)
 
     // Merge refs
@@ -228,7 +264,7 @@ export interface SelectItemProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
   ({ className, children, value: itemValue, disabled: itemDisabled = false, ...props }, ref) => {
-    const { value, onValueChange, setOpen, triggerId } = React.useContext(SelectContext)
+    const { value, onValueChange, setOpen, triggerId } = useSelectContext('SelectItem')
     const isSelected = value === itemValue
 
     const handleClick = () => {


### PR DESCRIPTION
Epic #254 Wave 1, Batch 1B (silent-default contexts — the worst footgun: no signal today). Adds dev-only warn-once `devWarn` when used outside provider; **no throw** (non-breaking per `docs/instrumentation/policy.md`). Changeset: react-charts + react-select `minor`.

✅ turbo exit 0 · charts 23 / select 29 tests. Part of #256.