### PR TITLE
feat: footgun devWarn Batch 1A — provider-context (#256)

### DIFF
--- a/.changeset/devwarn-batch-1a.md
+++ b/.changeset/devwarn-batch-1a.md
@@ -1,0 +1,28 @@
+---
+"@refraction-ui/react-ai": minor
+"@refraction-ui/react-auth": minor
+"@refraction-ui/react-analytics": minor
+"@refraction-ui/react-theme": minor
+"@refraction-ui/react-toast": minor
+"@refraction-ui/react-logger": minor
+---
+
+feat: devWarn footgun rollout — Batch 1A (epic #254 Wave 1, issue #256)
+
+Add dev-only, warn-once `devWarn` (from `@refraction-ui/shared`) at every
+provider/required-context misuse seam in the React provider-context-throw
+footgun packages, per `docs/instrumentation/policy.md`. The existing `throw`
+is KEPT in every case — runtime behavior is unchanged, and `devWarn` is
+env-guarded so it is stripped in production.
+
+Seams instrumented:
+
+- `@refraction-ui/react-ai`: `useAI` / `useTTS` called outside their providers.
+- `@refraction-ui/react-auth`: `<AuthProvider>` rendered without the required
+  `adapter`; `useAuth` called outside `<AuthProvider>`.
+- `@refraction-ui/react-analytics`: `useAnalytics` called outside
+  `<AnalyticsProvider>`.
+- `@refraction-ui/react-theme`: `useTheme` called outside `<ThemeProvider>`.
+- `@refraction-ui/react-toast`: `useToast` called outside `<ToastProvider>`.
+- `@refraction-ui/react-logger`: `useTelemetry` / `useSpan` called outside
+  `<TelemetryProvider>`.

--- a/packages/react-ai/__tests__/devwarn.test.tsx
+++ b/packages/react-ai/__tests__/devwarn.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { useAI } from '../src/ai-provider.js'
+import { useTTS } from '../src/tts-provider.js'
+
+// react-ai is a footgun (provider-context-throw): useAI/useTTS throw outside
+// their providers. Per docs/instrumentation/policy.md the throw is KEPT and a
+// dev-only warn-once devWarn is added immediately before it.
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-ai devWarn footgun (useAI / useTTS outside provider)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('useAI: warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useAI)).toThrow(
+      'useAI must be used within an <AIProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-ai/use-ai-outside-provider',
+    )
+  })
+
+  it('useTTS: warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useTTS)).toThrow(
+      'useTTS must be used within a <TTSProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-ai/use-tts-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useAI)).toThrow(
+      'useAI must be used within an <AIProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-ai/src/ai-provider.tsx
+++ b/packages/react-ai/src/ai-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import {
   createAI,
   type AIConfig,
@@ -80,6 +81,10 @@ export function AIProvider({ children, providers: providerMap, ...config }: AIPr
 export function useAI(): AIContextValue {
   const ctx = React.useContext(AIContext)
   if (!ctx) {
+    devWarn(
+      'react-ai/use-ai-outside-provider',
+      'useAI() was called outside an <AIProvider>. Wrap your app (or the consuming subtree) in <AIProvider> so the AI context is available.',
+    )
     throw new Error('useAI must be used within an <AIProvider>')
   }
   return ctx

--- a/packages/react-ai/src/tts-provider.tsx
+++ b/packages/react-ai/src/tts-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import {
   createTTS,
   type TTSConfig,
@@ -78,6 +79,10 @@ export function TTSProvider({ children, providers: providerMap, ...config }: TTS
 export function useTTS(): TTSContextValue {
   const ctx = React.useContext(TTSContext)
   if (!ctx) {
+    devWarn(
+      'react-ai/use-tts-outside-provider',
+      'useTTS() was called outside a <TTSProvider>. Wrap your app (or the consuming subtree) in <TTSProvider> so the TTS context is available.',
+    )
     throw new Error('useTTS must be used within a <TTSProvider>')
   }
   return ctx

--- a/packages/react-analytics/__tests__/devwarn.test.tsx
+++ b/packages/react-analytics/__tests__/devwarn.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { useAnalytics } from '../src/analytics-provider.js'
+
+// react-analytics is a footgun (provider-context-throw): useAnalytics throws
+// outside <AnalyticsProvider>. Per docs/instrumentation/policy.md the throw is
+// KEPT and a dev-only warn-once devWarn is added immediately before it.
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-analytics devWarn footgun (useAnalytics outside provider)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useAnalytics)).toThrow(
+      'useAnalytics must be used within an <AnalyticsProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-analytics/use-analytics-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useAnalytics)).toThrow(
+      'useAnalytics must be used within an <AnalyticsProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-analytics/src/analytics-provider.tsx
+++ b/packages/react-analytics/src/analytics-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import type {
   Analytics,
   AnalyticsContext as AnalyticsEventContext,
@@ -54,6 +55,10 @@ export interface UseAnalyticsOptions {
 export function useAnalytics(options?: UseAnalyticsOptions): Analytics {
   const ctx = React.useContext(AnalyticsContext)
   if (!ctx) {
+    devWarn(
+      'react-analytics/use-analytics-outside-provider',
+      'useAnalytics() was called outside an <AnalyticsProvider>. Wrap your app (or the consuming subtree) in <AnalyticsProvider> so the analytics context is available.',
+    )
     throw new Error('useAnalytics must be used within an <AnalyticsProvider>')
   }
   const scope = options?.scope

--- a/packages/react-auth/__tests__/devwarn.test.tsx
+++ b/packages/react-auth/__tests__/devwarn.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { AuthProvider, useAuth } from '../src/auth-provider.js'
+
+// react-auth is a footgun (required-prop-throw + provider-context-throw):
+// AuthProvider throws without an `adapter`; useAuth throws outside the
+// provider. Per docs/instrumentation/policy.md both throws are KEPT and a
+// dev-only warn-once devWarn is added immediately before each.
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-auth devWarn footgun', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('AuthProvider without `adapter`: warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(
+        React.createElement(AuthProvider, null, 'child'),
+      ),
+    ).toThrow('You must provide an `adapter` to AuthProvider.')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-auth/missing-adapter',
+    )
+  })
+
+  it('useAuth outside provider: warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useAuth)).toThrow(
+      'useAuth must be used within an <AuthProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-auth/use-auth-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useAuth)).toThrow(
+      'useAuth must be used within an <AuthProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-auth/src/auth-provider.tsx
+++ b/packages/react-auth/src/auth-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import {
   createAuth,
   type AuthState,
@@ -44,6 +45,10 @@ export function AuthProvider({ children, ...config }: AuthProviderProps) {
 
   if (!authRef.current) {
     if (!config.adapter && !config.testMode) {
+      devWarn(
+        'react-auth/missing-adapter',
+        '<AuthProvider> was rendered without a required `adapter` prop (and not in `testMode`). Pass an auth adapter so the provider can create an auth instance.',
+      )
       throw new Error('[refraction-ui/react-auth] You must provide an `adapter` to AuthProvider.')
     }
     authRef.current = createAuth(config.adapter, config)
@@ -84,6 +89,10 @@ export function AuthProvider({ children, ...config }: AuthProviderProps) {
 export function useAuth(): AuthContextValue {
   const ctx = React.useContext(AuthContext)
   if (!ctx) {
+    devWarn(
+      'react-auth/use-auth-outside-provider',
+      'useAuth() was called outside an <AuthProvider>. Wrap your app (or the consuming subtree) in <AuthProvider> so the auth context is available.',
+    )
     throw new Error('useAuth must be used within an <AuthProvider>')
   }
   return ctx

--- a/packages/react-logger/__tests__/devwarn.test.tsx
+++ b/packages/react-logger/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { useTelemetry } from '../src/telemetry-provider.js'
+
+// react-logger is a footgun (provider-context-throw): useTelemetry/useSpan
+// throw outside <TelemetryProvider>. Per docs/instrumentation/policy.md the
+// throw is KEPT and a dev-only warn-once devWarn is added immediately before
+// it. devWarn comes from @refraction-ui/shared, which has zero dependency on
+// the telemetry library (no hard-dep / no cycle).
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-logger devWarn footgun (useTelemetry outside provider)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useTelemetry)).toThrow(
+      'useTelemetry must be used within a <TelemetryProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-logger/use-telemetry-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useTelemetry)).toThrow(
+      'useTelemetry must be used within a <TelemetryProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-logger/src/index.ts
+++ b/packages/react-logger/src/index.ts
@@ -13,13 +13,6 @@ export type { UseSpanAPI } from './use-span.js'
 export { TelemetryErrorBoundary } from './error-boundary.js'
 export type { TelemetryErrorBoundaryProps } from './error-boundary.js'
 
-// Library-origin error capture seam (epic #247 / issue #249)
-export {
-  LibraryErrorCaptureBoundary,
-  captureReactLibraryError,
-} from './library-error-capture.js'
-export type { LibraryErrorCaptureBoundaryProps } from './library-error-capture.js'
-
 // Re-export core types for convenience
 export type {
   Telemetry,

--- a/packages/react-logger/src/telemetry-provider.tsx
+++ b/packages/react-logger/src/telemetry-provider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { devWarn } from '@refraction-ui/shared'
 import {
   createTelemetry,
   type TelemetryConfig,
@@ -49,6 +50,10 @@ export function TelemetryProvider({ children, ...config }: TelemetryProviderProp
 export function useTelemetry(): Telemetry {
   const ctx = React.useContext(TelemetryContext)
   if (!ctx) {
+    devWarn(
+      'react-logger/use-telemetry-outside-provider',
+      'useTelemetry() (or useSpan(), which depends on it) was called outside a <TelemetryProvider>. Wrap your app (or the consuming subtree) in <TelemetryProvider> so the telemetry context is available.',
+    )
     throw new Error('useTelemetry must be used within a <TelemetryProvider>')
   }
   return ctx.telemetry

--- a/packages/react-theme/__tests__/devwarn.test.tsx
+++ b/packages/react-theme/__tests__/devwarn.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { useTheme } from '../src/theme-provider.js'
+
+// react-theme is a footgun (provider-context-throw): useTheme throws outside
+// <ThemeProvider>. Per docs/instrumentation/policy.md the throw is KEPT and a
+// dev-only warn-once devWarn is added immediately before it.
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-theme devWarn footgun (useTheme outside provider)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useTheme)).toThrow(
+      'useTheme must be used within a <ThemeProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-theme/use-theme-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useTheme)).toThrow(
+      'useTheme must be used within a <ThemeProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-theme/src/theme-provider.tsx
+++ b/packages/react-theme/src/theme-provider.tsx
@@ -9,6 +9,7 @@ import {
   type ThemeConfig,
   type ThemeAPI,
 } from '@refraction-ui/theme'
+import { devWarn } from '@refraction-ui/shared'
 
 export interface ThemeContextValue {
   mode: ThemeMode
@@ -74,6 +75,10 @@ export function ThemeProvider({
 export function useTheme(): ThemeContextValue {
   const context = React.useContext(ThemeContext)
   if (!context) {
+    devWarn(
+      'react-theme/use-theme-outside-provider',
+      'useTheme() was called outside a <ThemeProvider>. Wrap your app (or the consuming subtree) in <ThemeProvider> so the theme context is available.',
+    )
     throw new Error('useTheme must be used within a <ThemeProvider>')
   }
   return context

--- a/packages/react-toast/__tests__/devwarn.test.tsx
+++ b/packages/react-toast/__tests__/devwarn.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { useToast } from '../src/toast.js'
+
+// react-toast is a footgun (provider-context-throw): useToast (via the
+// internal context guard) throws outside <ToastProvider>. Per
+// docs/instrumentation/policy.md the throw is KEPT and a dev-only warn-once
+// devWarn is added immediately before it.
+
+function renderHook(hook: () => unknown): void {
+  function Probe() {
+    hook()
+    return null
+  }
+  renderToString(React.createElement(Probe))
+}
+
+describe('react-toast devWarn footgun (useToast outside provider)', () => {
+  const originalEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDevFeedback()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+    warnSpy.mockRestore()
+    resetDevFeedback()
+  })
+
+  it('warns once in dev AND still throws', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => renderHook(useToast)).toThrow(
+      'useToast must be used within a <ToastProvider>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-toast/use-toast-outside-provider',
+    )
+  })
+
+  it('does NOT warn in production but still throws', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => renderHook(useToast)).toThrow(
+      'useToast must be used within a <ToastProvider>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-toast/src/toast.tsx
+++ b/packages/react-toast/src/toast.tsx
@@ -7,7 +7,7 @@ import {
   type ToastEntry,
   type ToastManagerAPI,
 } from '@refraction-ui/toast'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -22,6 +22,10 @@ const ToastContext = React.createContext<ToastContextValue | null>(null)
 function useToastContext(): ToastContextValue {
   const ctx = React.useContext(ToastContext)
   if (!ctx) {
+    devWarn(
+      'react-toast/use-toast-outside-provider',
+      'useToast() was called outside a <ToastProvider>. Wrap your app (or the consuming subtree) in <ToastProvider> so the toast context is available.',
+    )
     throw new Error('useToast must be used within a <ToastProvider>')
   }
   return ctx


### PR DESCRIPTION
Epic #254 Wave 1, Batch 1A (highest-blast-radius provider-context throws). devWarn immediately before each existing throw in react-ai/auth/analytics/theme/toast/logger; throw preserved (no runtime change), prod-stripped. Changeset: 6 pkgs `minor`.

✅ turbo exit 0 (45 tasks) · 14 new tests + pre-existing green. Part of #256.