### PR TITLE
feat: footgun devWarn Batch 1C — compound-context primitives (#256)

### DIFF
--- a/.changeset/devwarn-batch-1c.md
+++ b/.changeset/devwarn-batch-1c.md
@@ -1,0 +1,22 @@
+---
+"@refraction-ui/react-dialog": minor
+"@refraction-ui/react-tabs": minor
+"@refraction-ui/react-popover": minor
+"@refraction-ui/react-tooltip": minor
+"@refraction-ui/react-dropdown-menu": minor
+"@refraction-ui/react-command": minor
+"@refraction-ui/react-combobox": minor
+"@refraction-ui/react-form": minor
+"@refraction-ui/react-accordion": minor
+"@refraction-ui/react-collapsible": minor
+---
+
+feat: add dev-only `devWarn` at compound-context misuse seams (epic #254 Wave 1, issue #256, batch 1C)
+
+Adds a warn-once, env-guarded `devWarn` from `@refraction-ui/shared` immediately
+before each existing compound-component context guard `throw` in the high-traffic
+compound-context-throw footgun primitives (Dialog, Tabs, Popover, Tooltip,
+DropdownMenu, Command, Combobox, Form, Accordion, Collapsible). The existing
+`throw` is preserved unchanged — `devWarn` augments it with an actionable,
+greppable message and is fully stripped in production. Per the instrumentation
+policy this is the footgun minority only; no blanket logging, no new deps.

--- a/packages/react-accordion/__tests__/devwarn.test.tsx
+++ b/packages/react-accordion/__tests__/devwarn.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import {
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '../src/accordion.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throws, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-accordion devWarn (footgun: compound parts outside their root)', () => {
+  it('warns once + throws for <AccordionItem> outside <Accordion>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(
+        React.createElement(AccordionItem, { value: 'a' }, 'x'),
+      ),
+    ).toThrow('AccordionItem must be within Accordion')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-accordion/item-outside-accordion',
+    )
+  })
+
+  it('warns once + throws for <AccordionTrigger> missing context', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(AccordionTrigger, null, 'x')),
+    ).toThrow('AccordionTrigger missing context')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-accordion/trigger-missing-context',
+    )
+  })
+
+  it('warns once + throws for <AccordionContent> missing context', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(AccordionContent, null, 'x')),
+    ).toThrow('AccordionContent missing context')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-accordion/content-missing-context',
+    )
+  })
+
+  it('is silent in production but each throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(
+        React.createElement(AccordionItem, { value: 'a' }, 'x'),
+      ),
+    ).toThrow('AccordionItem must be within Accordion')
+    expect(() =>
+      renderToString(React.createElement(AccordionTrigger, null, 'x')),
+    ).toThrow('AccordionTrigger missing context')
+    expect(() =>
+      renderToString(React.createElement(AccordionContent, null, 'x')),
+    ).toThrow('AccordionContent missing context')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('each guard warns only once across repeated misuse', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(
+          React.createElement(AccordionItem, { value: 'a' }, 'x'),
+        ),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-accordion/src/accordion.tsx
+++ b/packages/react-accordion/src/accordion.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 const AccordionContext = React.createContext<{
   type: 'single' | 'multiple'
@@ -59,7 +59,13 @@ export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement>
 export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
   ({ className, value, ...props }, ref) => {
     const context = React.useContext(AccordionContext)
-    if (!context) throw new Error('AccordionItem must be within Accordion')
+    if (!context) {
+      devWarn(
+        'react-accordion/item-outside-accordion',
+        '<AccordionItem> must be rendered inside an <Accordion>. The missing AccordionContext makes this throw.',
+      )
+      throw new Error('AccordionItem must be within Accordion')
+    }
 
     const isOpen = context.type === 'single'
       ? context.value === value
@@ -81,7 +87,13 @@ export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTri
     const accordionContext = React.useContext(AccordionContext)
     const itemContext = React.useContext(AccordionItemContext)
     
-    if (!accordionContext || !itemContext) throw new Error('AccordionTrigger missing context')
+    if (!accordionContext || !itemContext) {
+      devWarn(
+        'react-accordion/trigger-missing-context',
+        '<AccordionTrigger> must be rendered inside an <AccordionItem> within an <Accordion>. The missing AccordionContext/AccordionItemContext makes this throw.',
+      )
+      throw new Error('AccordionTrigger missing context')
+    }
 
     return (
       <h3 className="flex m-0 p-0">
@@ -124,7 +136,13 @@ export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivEleme
 export const AccordionContent = React.forwardRef<HTMLDivElement, AccordionContentProps>(
   ({ className, children, ...props }, ref) => {
     const itemContext = React.useContext(AccordionItemContext)
-    if (!itemContext) throw new Error('AccordionContent missing context')
+    if (!itemContext) {
+      devWarn(
+        'react-accordion/content-missing-context',
+        '<AccordionContent> must be rendered inside an <AccordionItem>. The missing AccordionItemContext makes this throw.',
+      )
+      throw new Error('AccordionContent missing context')
+    }
 
     return (
       <div

--- a/packages/react-collapsible/__tests__/devwarn.test.tsx
+++ b/packages/react-collapsible/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { CollapsibleTrigger } from '../src/collapsible.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-collapsible devWarn (footgun: compound part outside <Collapsible>)', () => {
+  it('warns once in dev AND still throws when used outside <Collapsible>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(CollapsibleTrigger, null, 'Toggle')),
+    ).toThrow('Collapsible compound components must be used within <Collapsible>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-collapsible/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(CollapsibleTrigger, null, 'Toggle')),
+    ).toThrow('Collapsible compound components must be used within <Collapsible>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(CollapsibleTrigger, null, 'Toggle')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-collapsible/src/collapsible.tsx
+++ b/packages/react-collapsible/src/collapsible.tsx
@@ -4,7 +4,7 @@ import {
   collapsibleContentVariants,
   type CollapsibleProps as CoreCollapsibleProps,
 } from '@refraction-ui/collapsible'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -22,6 +22,10 @@ const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(n
 function useCollapsibleContext(): CollapsibleContextValue {
   const ctx = React.useContext(CollapsibleContext)
   if (!ctx) {
+    devWarn(
+      'react-collapsible/context-outside-provider',
+      'Collapsible compound components (CollapsibleTrigger/CollapsibleContent) must be rendered inside a <Collapsible>. The missing CollapsibleContext makes this throw.',
+    )
     throw new Error(
       'Collapsible compound components must be used within <Collapsible>',
     )

--- a/packages/react-combobox/__tests__/devwarn.test.tsx
+++ b/packages/react-combobox/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { ComboboxInput } from '../src/combobox.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-combobox devWarn (footgun: compound part outside <Combobox>)', () => {
+  it('warns once in dev AND still throws when used outside <Combobox>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(ComboboxInput, null)),
+    ).toThrow('Combobox compound components must be used within <Combobox>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-combobox/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(ComboboxInput, null)),
+    ).toThrow('Combobox compound components must be used within <Combobox>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(ComboboxInput, null)),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-combobox/src/combobox.tsx
+++ b/packages/react-combobox/src/combobox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
-import { cn, cva, generateId } from '@refraction-ui/shared'
+import { cn, cva, generateId, devWarn } from '@refraction-ui/shared'
 
 /* ─── Types ────────────────────────────────────────────────────── */
 
@@ -108,6 +108,10 @@ const ComboboxContext = React.createContext<ComboboxContextValue | null>(null)
 function useComboboxContext(): ComboboxContextValue {
   const ctx = React.useContext(ComboboxContext)
   if (!ctx) {
+    devWarn(
+      'react-combobox/context-outside-provider',
+      'Combobox compound components (ComboboxInput/ComboboxContent/ComboboxItem/etc.) must be rendered inside a <Combobox>. The missing ComboboxContext makes this throw.',
+    )
     throw new Error('Combobox compound components must be used within <Combobox>')
   }
   return ctx

--- a/packages/react-command/__tests__/devwarn.test.tsx
+++ b/packages/react-command/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { CommandInput } from '../src/command.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-command devWarn (footgun: compound part outside <Command>)', () => {
+  it('warns once in dev AND still throws when used outside <Command>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(CommandInput, null)),
+    ).toThrow('Command compound components must be used within <Command>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-command/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(CommandInput, null)),
+    ).toThrow('Command compound components must be used within <Command>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(CommandInput, null)),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-command/src/command.tsx
+++ b/packages/react-command/src/command.tsx
@@ -8,7 +8,7 @@ import {
   type CommandProps as CoreCommandProps,
   type CommandItemData,
 } from '@refraction-ui/command'
-import { cn, createKeyboardHandler, Keys } from '@refraction-ui/shared'
+import { cn, createKeyboardHandler, Keys, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -32,6 +32,10 @@ const CommandContext = React.createContext<CommandContextValue | null>(null)
 function useCommandContext(): CommandContextValue {
   const ctx = React.useContext(CommandContext)
   if (!ctx) {
+    devWarn(
+      'react-command/context-outside-provider',
+      'Command compound components (CommandInput/CommandList/CommandItem/CommandGroup/etc.) must be rendered inside a <Command>. The missing CommandContext makes this throw.',
+    )
     throw new Error('Command compound components must be used within <Command>')
   }
   return ctx

--- a/packages/react-dialog/__tests__/devwarn.test.tsx
+++ b/packages/react-dialog/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { DialogTitle } from '../src/dialog.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-dialog devWarn (footgun: compound part outside <Dialog>)', () => {
+  it('warns once in dev AND still throws when used outside <Dialog>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(DialogTitle, null, 'Title')),
+    ).toThrow('Dialog compound components must be used within <Dialog>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-dialog/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(DialogTitle, null, 'Title')),
+    ).toThrow('Dialog compound components must be used within <Dialog>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(DialogTitle, null, 'Title')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-dialog/src/dialog.tsx
+++ b/packages/react-dialog/src/dialog.tsx
@@ -6,7 +6,7 @@ import {
   dialogContentVariants,
   type DialogProps as CoreDialogProps,
 } from '@refraction-ui/dialog'
-import { cn, createKeyboardHandler } from '@refraction-ui/shared'
+import { cn, createKeyboardHandler, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -26,6 +26,10 @@ const DialogContext = React.createContext<DialogContextValue | null>(null)
 function useDialogContext(): DialogContextValue {
   const ctx = React.useContext(DialogContext)
   if (!ctx) {
+    devWarn(
+      'react-dialog/context-outside-provider',
+      'Dialog compound components (DialogTrigger/DialogContent/DialogTitle/etc.) must be rendered inside a <Dialog>. The missing DialogContext makes this throw.',
+    )
     throw new Error('Dialog compound components must be used within <Dialog>')
   }
   return ctx

--- a/packages/react-dropdown-menu/__tests__/devwarn.test.tsx
+++ b/packages/react-dropdown-menu/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { DropdownMenuTrigger } from '../src/dropdown-menu.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-dropdown-menu devWarn (footgun: compound part outside <DropdownMenu>)', () => {
+  it('warns once in dev AND still throws when used outside <DropdownMenu>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(DropdownMenuTrigger, null, 'Menu')),
+    ).toThrow('DropdownMenu compound components must be used within <DropdownMenu>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-dropdown-menu/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(DropdownMenuTrigger, null, 'Menu')),
+    ).toThrow('DropdownMenu compound components must be used within <DropdownMenu>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(DropdownMenuTrigger, null, 'Menu')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react-dropdown-menu/src/dropdown-menu.tsx
@@ -7,7 +7,7 @@ import {
   type DropdownMenuProps as CoreDropdownMenuProps,
   type MenuItemProps as CoreMenuItemProps,
 } from '@refraction-ui/dropdown-menu'
-import { cn, createKeyboardHandler } from '@refraction-ui/shared'
+import { cn, createKeyboardHandler, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -24,6 +24,10 @@ const DropdownMenuContext = React.createContext<DropdownMenuContextValue | null>
 function useDropdownMenuContext(): DropdownMenuContextValue {
   const ctx = React.useContext(DropdownMenuContext)
   if (!ctx) {
+    devWarn(
+      'react-dropdown-menu/context-outside-provider',
+      'DropdownMenu compound components (DropdownMenuTrigger/DropdownMenuContent/DropdownMenuItem/etc.) must be rendered inside a <DropdownMenu>. The missing DropdownMenuContext makes this throw.',
+    )
     throw new Error('DropdownMenu compound components must be used within <DropdownMenu>')
   }
   return ctx

--- a/packages/react-form/__tests__/devwarn.test.tsx
+++ b/packages/react-form/__tests__/devwarn.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { Form, FormField, FormItem, FormLabel, useForm } from '../src/index.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing useFormField context throws, fires once in dev, and
+// is fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+// React 19 expects this flag to be set when running tests outside a browser bundler.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const originalEnv = process.env.NODE_ENV
+let container: HTMLDivElement
+let root: Root
+let warnSpy: ReturnType<typeof vi.spyOn>
+let errorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  // React logs the thrown render error to console.error; silence the noise.
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  warnSpy.mockRestore()
+  errorSpy.mockRestore()
+  resetDevFeedback()
+})
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui)
+  })
+}
+
+// FormLabel calls useFormField(). Rendered inside a <Form> (so the RHF
+// useFormState/useFormContext wiring resolves) but OUTSIDE any <FormField>,
+// so the missing FormFieldContext is what trips the guard.
+function OutsideFormField() {
+  const form = useForm<{ email: string }>({ defaultValues: { email: '' } })
+  return (
+    <Form {...form}>
+      <FormLabel>Email</FormLabel>
+    </Form>
+  )
+}
+
+// Inside a FormField (provides FormFieldContext) but with no FormItem, so the
+// "outside <FormItem>" guard fires.
+function OutsideFormItem() {
+  const form = useForm<{ email: string }>({ defaultValues: { email: '' } })
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="email"
+        render={() => <FormLabel>Email</FormLabel>}
+      />
+    </Form>
+  )
+}
+
+describe('react-form devWarn (footgun: useFormField outside its context)', () => {
+  it('warns once + throws when used outside <FormField>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => render(<OutsideFormField />)).toThrow(
+      'useFormField must be used within a <FormField>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-form/use-form-field-outside-form-field',
+    )
+  })
+
+  it('warns once + throws when used outside <FormItem>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() => render(<OutsideFormItem />)).toThrow(
+      'useFormField must be used within a <FormItem>',
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-form/use-form-field-outside-form-item',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() => render(<OutsideFormField />)).toThrow(
+      'useFormField must be used within a <FormField>',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() => render(<OutsideFormField />)).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-form/src/form.tsx
+++ b/packages/react-form/src/form.tsx
@@ -8,7 +8,7 @@ import {
   type FieldPath,
   type FieldValues,
 } from 'react-hook-form'
-import { cn, cva } from '@refraction-ui/shared'
+import { cn, cva, devWarn } from '@refraction-ui/shared'
 import { Slot } from './slot.js'
 
 /**
@@ -77,9 +77,17 @@ function useFormField() {
   })
 
   if (!fieldContext) {
+    devWarn(
+      'react-form/use-form-field-outside-form-field',
+      'useFormField (via FormLabel/FormControl/FormDescription/FormMessage) must be used inside a <FormField>. The missing FormFieldContext makes this throw.',
+    )
     throw new Error('useFormField must be used within a <FormField>')
   }
   if (!itemContext) {
+    devWarn(
+      'react-form/use-form-field-outside-form-item',
+      'useFormField (via FormLabel/FormControl/FormDescription/FormMessage) must be used inside a <FormItem>. The missing FormItemContext makes this throw.',
+    )
     throw new Error('useFormField must be used within a <FormItem>')
   }
 

--- a/packages/react-popover/__tests__/devwarn.test.tsx
+++ b/packages/react-popover/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { PopoverTrigger } from '../src/popover.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-popover devWarn (footgun: compound part outside <Popover>)', () => {
+  it('warns once in dev AND still throws when used outside <Popover>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(PopoverTrigger, null, 'Open')),
+    ).toThrow('Popover compound components must be used within <Popover>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-popover/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(PopoverTrigger, null, 'Open')),
+    ).toThrow('Popover compound components must be used within <Popover>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(PopoverTrigger, null, 'Open')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-popover/src/popover.tsx
+++ b/packages/react-popover/src/popover.tsx
@@ -6,7 +6,7 @@ import {
   type PopoverAPI,
 } from '@refraction-ui/popover'
 import type { Side } from '@refraction-ui/shared'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -23,6 +23,10 @@ const PopoverContext = React.createContext<PopoverContextValue | null>(null)
 function usePopoverContext(): PopoverContextValue {
   const ctx = React.useContext(PopoverContext)
   if (!ctx) {
+    devWarn(
+      'react-popover/context-outside-provider',
+      'Popover compound components (PopoverTrigger/PopoverContent/etc.) must be rendered inside a <Popover>. The missing PopoverContext makes this throw.',
+    )
     throw new Error('Popover compound components must be used within <Popover>')
   }
   return ctx

--- a/packages/react-tabs/__tests__/devwarn.test.tsx
+++ b/packages/react-tabs/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { TabsList } from '../src/tabs.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-tabs devWarn (footgun: compound part outside <Tabs>)', () => {
+  it('warns once in dev AND still throws when used outside <Tabs>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(TabsList, null, 'List')),
+    ).toThrow('Tabs compound components must be used within <Tabs>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-tabs/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(TabsList, null, 'List')),
+    ).toThrow('Tabs compound components must be used within <Tabs>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(TabsList, null, 'List')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-tabs/src/tabs.tsx
+++ b/packages/react-tabs/src/tabs.tsx
@@ -5,7 +5,7 @@ import {
   tabsTriggerVariants,
   type TabsProps as CoreTabsProps,
 } from '@refraction-ui/tabs'
-import { cn, createKeyboardHandler, Keys } from '@refraction-ui/shared'
+import { cn, createKeyboardHandler, Keys, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -23,6 +23,10 @@ const TabsContext = React.createContext<TabsContextValue | null>(null)
 function useTabsContext(): TabsContextValue {
   const ctx = React.useContext(TabsContext)
   if (!ctx) {
+    devWarn(
+      'react-tabs/context-outside-provider',
+      'Tabs compound components (TabsList/TabsTrigger/TabsContent) must be rendered inside a <Tabs>. The missing TabsContext makes this throw.',
+    )
     throw new Error('Tabs compound components must be used within <Tabs>')
   }
   return ctx

--- a/packages/react-tooltip/__tests__/devwarn.test.tsx
+++ b/packages/react-tooltip/__tests__/devwarn.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { TooltipTrigger } from '../src/tooltip.js'
+
+// Verifies the footgun devWarn (epic #254 / batch 1C) augments — never
+// replaces — the existing compound-context throw, fires once in dev, and is
+// fully silent in production. Uses the REAL @refraction-ui/shared primitive.
+
+const originalEnv = process.env.NODE_ENV
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = originalEnv
+  warnSpy.mockRestore()
+  resetDevFeedback()
+})
+
+describe('react-tooltip devWarn (footgun: compound part outside <Tooltip>)', () => {
+  it('warns once in dev AND still throws when used outside <Tooltip>', () => {
+    process.env.NODE_ENV = 'development'
+    expect(() =>
+      renderToString(React.createElement(TooltipTrigger, null, 'Hover')),
+    ).toThrow('Tooltip compound components must be used within <Tooltip>')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      'react-tooltip/context-outside-provider',
+    )
+  })
+
+  it('is silent in production but the throw is preserved', () => {
+    process.env.NODE_ENV = 'production'
+    expect(() =>
+      renderToString(React.createElement(TooltipTrigger, null, 'Hover')),
+    ).toThrow('Tooltip compound components must be used within <Tooltip>')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns only once across repeated misuse (warn-once dedupe)', () => {
+    process.env.NODE_ENV = 'development'
+    for (let i = 0; i < 3; i++) {
+      expect(() =>
+        renderToString(React.createElement(TooltipTrigger, null, 'Hover')),
+      ).toThrow()
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-tooltip/src/tooltip.tsx
+++ b/packages/react-tooltip/src/tooltip.tsx
@@ -6,7 +6,7 @@ import {
   type TooltipAPI,
 } from '@refraction-ui/tooltip'
 import type { Side } from '@refraction-ui/shared'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -25,6 +25,10 @@ const TooltipContext = React.createContext<TooltipContextValue | null>(null)
 function useTooltipContext(): TooltipContextValue {
   const ctx = React.useContext(TooltipContext)
   if (!ctx) {
+    devWarn(
+      'react-tooltip/context-outside-provider',
+      'Tooltip compound components (TooltipTrigger/TooltipContent/etc.) must be rendered inside a <Tooltip>. The missing TooltipContext makes this throw.',
+    )
     throw new Error('Tooltip compound components must be used within <Tooltip>')
   }
   return ctx


### PR DESCRIPTION
Epic #254 Wave 1, Batch 1C (high-traffic compound-context throws). devWarn before each existing throw across 10 primitives; throw preserved, prod-stripped. Changeset: 10 pkgs `minor`.

✅ turbo exit 0 (67 tasks). Part of #256.