### PR TITLE
feat: footgun devWarn Batch 1D — compound-context remainder (#256)

### DIFF
--- a/.changeset/devwarn-batch-1d.md
+++ b/.changeset/devwarn-batch-1d.md
@@ -1,0 +1,20 @@
+---
+"@refraction-ui/react-app-shell": minor
+"@refraction-ui/react-carousel": minor
+"@refraction-ui/react-radio": minor
+"@refraction-ui/react-sheet": minor
+"@refraction-ui/react-resizable-layout": minor
+"@refraction-ui/react-mobile-nav": minor
+"@refraction-ui/react-search-bar": minor
+"@refraction-ui/react-language-selector": minor
+"@refraction-ui/react-version-selector": minor
+---
+
+feat: dev-only devWarn at compound/context guards (Wave 1 footgun rollout, Batch 1D)
+
+Adds an env-guarded, warn-once `devWarn` from `@refraction-ui/shared`
+immediately before each existing compound/context `throw` in the
+`compound-context-throw` footgun packages. The throw is unchanged; the
+`devWarn` adds an actionable dev-only diagnostic with a stable, greppable
+`code` per guard. Compiled out / silent in production. No new dependencies;
+no telemetry-library dependency (per epic #254 / #256 policy).

--- a/packages/react-app-shell/__tests__/dev-warn.test.tsx
+++ b/packages/react-app-shell/__tests__/dev-warn.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { AppShell, PageShell, AuthShell } from '../src/index.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render-throw style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-app-shell devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when useAppShell is used outside <AppShell>', () => {
+    expect(() =>
+      renderToString(React.createElement(AppShell.Sidebar, null, 'x')),
+    ).toThrow('useAppShell must be used within <AppShell>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-app-shell/use-app-shell-outside-provider',
+    )
+  })
+
+  it('warns and still throws when a PageShell part is used outside <PageShell>', () => {
+    expect(() =>
+      renderToString(React.createElement(PageShell.Nav, null, 'x')),
+    ).toThrow('PageShell compound components must be used within <PageShell>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-app-shell/page-shell-compound-outside-provider',
+    )
+  })
+
+  it('warns and still throws when an AuthShell part is used outside <AuthShell>', () => {
+    expect(() =>
+      renderToString(React.createElement(AuthShell.Card, null, 'x')),
+    ).toThrow('AuthShell compound components must be used within <AuthShell>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-app-shell/auth-shell-compound-outside-provider',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(AppShell.Sidebar, null, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(AppShell.Sidebar, null, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(AppShell.Sidebar, null, 'x')),
+      ).toThrow('useAppShell must be used within <AppShell>')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-app-shell/src/app-shell.tsx
+++ b/packages/react-app-shell/src/app-shell.tsx
@@ -6,7 +6,7 @@ import {
   type AppShellState,
   type AppShellAPI,
 } from '@refraction-ui/app-shell'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -22,6 +22,10 @@ const AppShellContext = React.createContext<AppShellContextValue | null>(null)
 export function useAppShell(): AppShellContextValue {
   const ctx = React.useContext(AppShellContext)
   if (!ctx) {
+    devWarn(
+      'react-app-shell/use-app-shell-outside-provider',
+      'useAppShell() was called outside of <AppShell>. Wrap the consuming component tree in <AppShell>.',
+    )
     throw new Error('useAppShell must be used within <AppShell>')
   }
   return ctx

--- a/packages/react-app-shell/src/auth-shell.tsx
+++ b/packages/react-app-shell/src/auth-shell.tsx
@@ -4,7 +4,7 @@ import {
   type AuthShellConfig,
   type AuthShellAPI,
 } from '@refraction-ui/app-shell'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -19,6 +19,10 @@ const AuthShellContext = React.createContext<AuthShellContextValue | null>(null)
 function useAuthShell(): AuthShellContextValue {
   const ctx = React.useContext(AuthShellContext)
   if (!ctx) {
+    devWarn(
+      'react-app-shell/auth-shell-compound-outside-provider',
+      'An AuthShell compound component was rendered outside of <AuthShell>. Wrap it in <AuthShell>.',
+    )
     throw new Error('AuthShell compound components must be used within <AuthShell>')
   }
   return ctx

--- a/packages/react-app-shell/src/page-shell.tsx
+++ b/packages/react-app-shell/src/page-shell.tsx
@@ -5,7 +5,7 @@ import {
   type SectionConfig,
   type PageShellAPI,
 } from '@refraction-ui/app-shell'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Context
@@ -20,6 +20,10 @@ const PageShellContext = React.createContext<PageShellContextValue | null>(null)
 function usePageShell(): PageShellContextValue {
   const ctx = React.useContext(PageShellContext)
   if (!ctx) {
+    devWarn(
+      'react-app-shell/page-shell-compound-outside-provider',
+      'A PageShell compound component was rendered outside of <PageShell>. Wrap it in <PageShell>.',
+    )
     throw new Error('PageShell compound components must be used within <PageShell>')
   }
   return ctx

--- a/packages/react-carousel/__tests__/dev-warn.test.tsx
+++ b/packages/react-carousel/__tests__/dev-warn.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { CarouselItem, CarouselTrigger, CarouselContent } from '../src/index'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-carousel devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when CarouselItem is used outside <Carousel>', () => {
+    expect(() =>
+      renderToString(React.createElement(CarouselItem, { value: 'a' }, 'x')),
+    ).toThrow('CarouselItem must be within Carousel')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-carousel/carousel-item-outside-carousel',
+    )
+  })
+
+  it('warns and still throws when CarouselTrigger is used outside an item', () => {
+    expect(() =>
+      renderToString(React.createElement(CarouselTrigger, null, 'x')),
+    ).toThrow('CarouselTrigger missing context')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-carousel/carousel-trigger-outside-item',
+    )
+  })
+
+  it('warns and still throws when CarouselContent is used outside an item', () => {
+    expect(() =>
+      renderToString(React.createElement(CarouselContent, null, 'x')),
+    ).toThrow('CarouselContent missing context')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-carousel/carousel-content-outside-item',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(CarouselItem, { value: 'a' }, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(CarouselItem, { value: 'a' }, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(CarouselItem, { value: 'a' }, 'x')),
+      ).toThrow('CarouselItem must be within Carousel')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-carousel/src/carousel.tsx
+++ b/packages/react-carousel/src/carousel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 const CarouselContext = React.createContext<{
   type: 'single' | 'multiple'
@@ -59,7 +59,13 @@ export interface CarouselItemProps extends React.HTMLAttributes<HTMLDivElement> 
 export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
   ({ className, value, ...props }, ref) => {
     const context = React.useContext(CarouselContext)
-    if (!context) throw new Error('CarouselItem must be within Carousel')
+    if (!context) {
+      devWarn(
+        'react-carousel/carousel-item-outside-carousel',
+        'CarouselItem was rendered outside of <Carousel>. Wrap it in <Carousel>.',
+      )
+      throw new Error('CarouselItem must be within Carousel')
+    }
 
     const isOpen = context.type === 'single'
       ? context.value === value
@@ -81,7 +87,13 @@ export const CarouselTrigger = React.forwardRef<HTMLButtonElement, CarouselTrigg
     const carouselContext = React.useContext(CarouselContext)
     const itemContext = React.useContext(CarouselItemContext)
     
-    if (!carouselContext || !itemContext) throw new Error('CarouselTrigger missing context')
+    if (!carouselContext || !itemContext) {
+      devWarn(
+        'react-carousel/carousel-trigger-outside-item',
+        'CarouselTrigger was rendered outside of a <CarouselItem> within <Carousel>. Nest it inside <CarouselItem>.',
+      )
+      throw new Error('CarouselTrigger missing context')
+    }
 
     return (
       <h3 className="flex m-0 p-0">
@@ -124,7 +136,13 @@ export interface CarouselContentProps extends React.HTMLAttributes<HTMLDivElemen
 export const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentProps>(
   ({ className, children, ...props }, ref) => {
     const itemContext = React.useContext(CarouselItemContext)
-    if (!itemContext) throw new Error('CarouselContent missing context')
+    if (!itemContext) {
+      devWarn(
+        'react-carousel/carousel-content-outside-item',
+        'CarouselContent was rendered outside of a <CarouselItem> within <Carousel>. Nest it inside <CarouselItem>.',
+      )
+      throw new Error('CarouselContent missing context')
+    }
 
     return (
       <div

--- a/packages/react-language-selector/__tests__/dev-warn.test.tsx
+++ b/packages/react-language-selector/__tests__/dev-warn.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { devWarn, resetDevFeedback } from '@refraction-ui/shared'
+import * as LanguageSelectorModule from '../src/language-selector.js'
+
+// NOTE / deviation: react-language-selector exports a single monolithic
+// <LanguageSelector>. Its context guard (`useLanguageSelectorContext`) is
+// present per the Wave-0 tier map (compound-context-throw) but is dead code:
+// the hook is never invoked and never exported, so the guard cannot be driven
+// through the package's public API. We therefore assert the guard's devWarn
+// CONTRACT (real @refraction-ui/shared: warns once in dev, stripped in prod)
+// using the exact stable `code` wired at the guard site, and smoke-test the
+// public component, mirroring the existing SSR test style.
+
+const GUARD_CODE = 'react-language-selector/compound-outside-provider'
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-language-selector devWarn (footgun: compound-context-throw)', () => {
+  it('exports the LanguageSelector component (guard module loads)', () => {
+    expect(typeof LanguageSelectorModule.LanguageSelector).toBe('function')
+  })
+
+  it('warns once in dev for the guard code', () => {
+    devWarn(GUARD_CODE, 'misuse')
+    devWarn(GUARD_CODE, 'misuse')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(GUARD_CODE)
+  })
+
+  it('is silent in production for the guard code', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      devWarn(GUARD_CODE, 'misuse')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-language-selector/src/language-selector.tsx
+++ b/packages/react-language-selector/src/language-selector.tsx
@@ -6,7 +6,7 @@ import {
   type LanguageSelectorAPI,
   type LanguageOption,
 } from '@refraction-ui/language-selector'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -26,6 +26,10 @@ const LanguageSelectorContext = React.createContext<LanguageSelectorContextValue
 function useLanguageSelectorContext(): LanguageSelectorContextValue {
   const ctx = React.useContext(LanguageSelectorContext)
   if (!ctx) {
+    devWarn(
+      'react-language-selector/compound-outside-provider',
+      'A LanguageSelector compound component was rendered outside of <LanguageSelector>. Wrap it in <LanguageSelector>.',
+    )
     throw new Error('LanguageSelector compound components must be used within <LanguageSelector>')
   }
   return ctx

--- a/packages/react-mobile-nav/__tests__/dev-warn.test.tsx
+++ b/packages/react-mobile-nav/__tests__/dev-warn.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { MobileNavTrigger } from '../src/mobile-nav.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-mobile-nav devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when a part is used outside <MobileNav>', () => {
+    expect(() =>
+      renderToString(React.createElement(MobileNavTrigger, null, 'x')),
+    ).toThrow('MobileNav compound components must be used within <MobileNav>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-mobile-nav/compound-outside-provider',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(MobileNavTrigger, null, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(MobileNavTrigger, null, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(MobileNavTrigger, null, 'x')),
+      ).toThrow('MobileNav compound components must be used within <MobileNav>')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-mobile-nav/src/mobile-nav.tsx
+++ b/packages/react-mobile-nav/src/mobile-nav.tsx
@@ -6,7 +6,7 @@ import {
   mobileNavTriggerVariants,
   mobileNavLinkVariants,
 } from '@refraction-ui/mobile-nav'
-import { cn, createKeyboardHandler } from '@refraction-ui/shared'
+import { cn, createKeyboardHandler, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -23,6 +23,10 @@ const MobileNavContext = React.createContext<MobileNavContextValue | null>(null)
 function useMobileNavContext(): MobileNavContextValue {
   const ctx = React.useContext(MobileNavContext)
   if (!ctx) {
+    devWarn(
+      'react-mobile-nav/compound-outside-provider',
+      'A MobileNav compound component was rendered outside of <MobileNav>. Wrap it in <MobileNav>.',
+    )
     throw new Error('MobileNav compound components must be used within <MobileNav>')
   }
   return ctx

--- a/packages/react-radio/__tests__/dev-warn.test.tsx
+++ b/packages/react-radio/__tests__/dev-warn.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { RadioItem } from '../src/radio.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-radio devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when RadioItem is used outside <RadioGroup>', () => {
+    expect(() =>
+      renderToString(React.createElement(RadioItem, { value: 'a' }, 'x')),
+    ).toThrow('RadioItem must be used within RadioGroup')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-radio/radio-item-outside-group',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(RadioItem, { value: 'a' }, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(RadioItem, { value: 'a' }, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(RadioItem, { value: 'a' }, 'x')),
+      ).toThrow('RadioItem must be used within RadioGroup')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-radio/src/radio.tsx
+++ b/packages/react-radio/src/radio.tsx
@@ -6,7 +6,7 @@ import {
   radioCircleVariants,
   type RadioGroupProps as CoreRadioGroupProps,
 } from '@refraction-ui/radio'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 interface RadioContextValue {
   value: string | undefined
@@ -71,7 +71,13 @@ export interface RadioItemProps {
 
 export function RadioItem({ value, children, disabled = false, className }: RadioItemProps) {
   const ctx = React.useContext(RadioContext)
-  if (!ctx) throw new Error('RadioItem must be used within RadioGroup')
+  if (!ctx) {
+    devWarn(
+      'react-radio/radio-item-outside-group',
+      'RadioItem was rendered outside of <RadioGroup>. Wrap it in <RadioGroup>.',
+    )
+    throw new Error('RadioItem must be used within RadioGroup')
+  }
 
   const isChecked = ctx.value === value
   const isDisabled = ctx.disabled || disabled

--- a/packages/react-resizable-layout/__tests__/dev-warn.test.tsx
+++ b/packages/react-resizable-layout/__tests__/dev-warn.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { ResizablePane } from '../src/resizable-layout.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-resizable-layout devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when a part is used outside <ResizableLayout>', () => {
+    expect(() =>
+      renderToString(React.createElement(ResizablePane, null, 'x')),
+    ).toThrow('Resizable compound components must be used within <ResizableLayout>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-resizable-layout/compound-outside-provider',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(ResizablePane, null, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(ResizablePane, null, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(ResizablePane, null, 'x')),
+      ).toThrow('Resizable compound components must be used within <ResizableLayout>')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-resizable-layout/src/resizable-layout.tsx
+++ b/packages/react-resizable-layout/src/resizable-layout.tsx
@@ -7,7 +7,7 @@ import {
   type ResizableLayoutProps as CoreProps,
   type ResizableLayoutAPI,
 } from '@refraction-ui/resizable-layout'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 import type { Orientation } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
@@ -26,6 +26,10 @@ const ResizableLayoutContext = React.createContext<ResizableLayoutContextValue |
 function useResizableLayoutContext(): ResizableLayoutContextValue {
   const ctx = React.useContext(ResizableLayoutContext)
   if (!ctx) {
+    devWarn(
+      'react-resizable-layout/compound-outside-provider',
+      'A Resizable compound component was rendered outside of <ResizableLayout>. Wrap it in <ResizableLayout>.',
+    )
     throw new Error('Resizable compound components must be used within <ResizableLayout>')
   }
   return ctx

--- a/packages/react-search-bar/__tests__/dev-warn.test.tsx
+++ b/packages/react-search-bar/__tests__/dev-warn.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { SearchResults } from '../src/search-bar.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-search-bar devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when a part is used outside <SearchBar>', () => {
+    expect(() =>
+      renderToString(React.createElement(SearchResults, null)),
+    ).toThrow('SearchBar compound components must be used within <SearchBar>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-search-bar/compound-outside-provider',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(SearchResults, null)),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(SearchResults, null)),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(SearchResults, null)),
+      ).toThrow('SearchBar compound components must be used within <SearchBar>')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-search-bar/src/search-bar.tsx
+++ b/packages/react-search-bar/src/search-bar.tsx
@@ -5,7 +5,7 @@ import {
   searchResultVariants,
   type SearchBarAPI,
 } from '@refraction-ui/search-bar'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -24,6 +24,10 @@ const SearchBarContext = React.createContext<SearchBarContextValue | null>(null)
 function useSearchBarContext(): SearchBarContextValue {
   const ctx = React.useContext(SearchBarContext)
   if (!ctx) {
+    devWarn(
+      'react-search-bar/compound-outside-provider',
+      'A SearchBar compound component was rendered outside of <SearchBar>. Wrap it in <SearchBar>.',
+    )
     throw new Error('SearchBar compound components must be used within <SearchBar>')
   }
   return ctx

--- a/packages/react-sheet/__tests__/dev-warn.test.tsx
+++ b/packages/react-sheet/__tests__/dev-warn.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { resetDevFeedback } from '@refraction-ui/shared'
+import { SheetTrigger } from '../src/sheet.js'
+
+// Real @refraction-ui/shared devWarn (no mock) — assert via a console.warn spy,
+// mirroring the SSR render style used by the rest of this package's tests.
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-sheet devWarn (footgun: compound-context-throw)', () => {
+  it('warns and still throws when a Sheet part is used outside <Sheet>', () => {
+    expect(() =>
+      renderToString(React.createElement(SheetTrigger, null, 'x')),
+    ).toThrow('Sheet compound components must be used within <Sheet>')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      'react-sheet/sheet-compound-outside-provider',
+    )
+  })
+
+  it('warn-once: a repeated misuse does not warn again for the same code', () => {
+    expect(() =>
+      renderToString(React.createElement(SheetTrigger, null, 'x')),
+    ).toThrow()
+    expect(() =>
+      renderToString(React.createElement(SheetTrigger, null, 'x')),
+    ).toThrow()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('is silent in production (NODE_ENV=production) but still throws', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      expect(() =>
+        renderToString(React.createElement(SheetTrigger, null, 'x')),
+      ).toThrow('Sheet compound components must be used within <Sheet>')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-sheet/src/sheet.tsx
+++ b/packages/react-sheet/src/sheet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import { cn, cva, createKeyboardHandler, generateId } from '@refraction-ui/shared'
+import { cn, cva, createKeyboardHandler, generateId, devWarn } from '@refraction-ui/shared'
 
 // ---------------------------------------------------------------------------
 // Side
@@ -52,6 +52,10 @@ const SheetContext = React.createContext<SheetContextValue | null>(null)
 function useSheetContext(): SheetContextValue {
   const ctx = React.useContext(SheetContext)
   if (!ctx) {
+    devWarn(
+      'react-sheet/sheet-compound-outside-provider',
+      'A Sheet compound component was rendered outside of <Sheet>. Wrap it in <Sheet>.',
+    )
     throw new Error('Sheet compound components must be used within <Sheet>')
   }
   return ctx

--- a/packages/react-version-selector/__tests__/dev-warn.test.tsx
+++ b/packages/react-version-selector/__tests__/dev-warn.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { devWarn, resetDevFeedback } from '@refraction-ui/shared'
+import * as VersionSelectorModule from '../src/version-selector.js'
+
+// NOTE / deviation: react-version-selector exports a single monolithic
+// <VersionSelector>. Its context guard (`useVersionSelectorContext`) is
+// present per the Wave-0 tier map (compound-context-throw) but is dead code:
+// the hook is never invoked and never exported, so the guard cannot be driven
+// through the package's public API. We therefore assert the guard's devWarn
+// CONTRACT (real @refraction-ui/shared: warns once in dev, stripped in prod)
+// using the exact stable `code` wired at the guard site, and smoke-test the
+// public component, mirroring the existing SSR test style.
+
+const GUARD_CODE = 'react-version-selector/compound-outside-provider'
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  resetDevFeedback()
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('react-version-selector devWarn (footgun: compound-context-throw)', () => {
+  it('exports the VersionSelector component (guard module loads)', () => {
+    expect(typeof VersionSelectorModule.VersionSelector).toBe('function')
+  })
+
+  it('warns once in dev for the guard code', () => {
+    devWarn(GUARD_CODE, 'misuse')
+    devWarn(GUARD_CODE, 'misuse')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain(GUARD_CODE)
+  })
+
+  it('is silent in production for the guard code', () => {
+    const prev = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    try {
+      devWarn(GUARD_CODE, 'misuse')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      process.env.NODE_ENV = prev
+    }
+  })
+})

--- a/packages/react-version-selector/src/version-selector.tsx
+++ b/packages/react-version-selector/src/version-selector.tsx
@@ -7,7 +7,7 @@ import {
   type VersionSelectorAPI,
   type VersionOption,
 } from '@refraction-ui/version-selector'
-import { cn } from '@refraction-ui/shared'
+import { cn, devWarn } from '@refraction-ui/shared'
 
 /* ------------------------------------------------------------------ */
 /*  Context                                                            */
@@ -26,6 +26,10 @@ const VersionSelectorContext = React.createContext<VersionSelectorContextValue |
 function useVersionSelectorContext(): VersionSelectorContextValue {
   const ctx = React.useContext(VersionSelectorContext)
   if (!ctx) {
+    devWarn(
+      'react-version-selector/compound-outside-provider',
+      'A VersionSelector compound component was rendered outside of <VersionSelector>. Wrap it in <VersionSelector>.',
+    )
     throw new Error('VersionSelector compound components must be used within <VersionSelector>')
   }
   return ctx


### PR DESCRIPTION
Epic #254 Wave 1, Batch 1D (final batch). devWarn before existing throw across 9 remaining footgun packages (13 guard sites); throw preserved, prod-stripped. Two (language/version-selector) have unreachable guard dead-code — instrumented + contract-tested per spec. Changeset: 9 pkgs `minor`.

✅ turbo exit 0 (63 tasks). **Completes #254 Wave 1** — all 27 footgun React packages now carry devWarn.