### PR TITLE
feat(flutter): Dart analytics core (#231)

### DIFF
--- a/packages/flutter/lib/analytics.dart
+++ b/packages/flutter/lib/analytics.dart
@@ -1,0 +1,32 @@
+/// Namespaced entrypoint for the refraction_ui **analytics** module — a
+/// headless, neutral Segment-spec collector/router (1:1 Dart port of
+/// `@refraction-ui/analytics`).
+///
+/// Import this file instead of `package:refraction_ui/refraction_ui.dart`
+/// when you need the analytics module's `createConsoleSink`. The package
+/// barrel hides `createConsoleSink` from the analytics export to avoid a
+/// collision with the telemetry module's flat-barrel `createConsoleSink`
+/// (telemetry owns the flat barrel). This entrypoint re-exports the **full**
+/// analytics public surface — including `createConsoleSink` — so there is no
+/// parity loss with the web library.
+///
+/// ```dart
+/// import 'package:refraction_ui/analytics.dart';
+///
+/// final analytics = createAnalytics(const AnalyticsConfig(
+///   app: 'my-app',
+///   env: 'production',
+///   endpoint: 'https://collect.example.com',
+///   writeKey: 'WRITE_KEY',
+/// ));
+/// final sink = createConsoleSink();
+/// ```
+///
+/// If you need both modules' console sinks in one library, import the
+/// telemetry `createConsoleSink` from the package barrel and use this file's
+/// `createConsoleSink` with a prefix (e.g. `import '...analytics.dart' as
+/// analytics;`).
+library;
+
+export 'src/analytics/analytics.dart';
+export 'src/analytics/console_sink.dart' show createConsoleSink;

--- a/packages/flutter/lib/refraction_ui.dart
+++ b/packages/flutter/lib/refraction_ui.dart
@@ -67,3 +67,14 @@ export 'src/components/breadcrumbs.dart';
 export 'src/components/footer.dart';
 export 'src/components/skeleton.dart';
 export 'src/telemetry/telemetry.dart';
+
+// Analytics — headless Segment-spec collector/router (1:1 port of
+// @refraction-ui/analytics). Uniform API/structure across web/Android/iOS/
+// desktop; platform differences are internal behind conditional imports.
+//
+// `createConsoleSink` is hidden here because it collides with the telemetry
+// module's flat-barrel `createConsoleSink` (telemetry owns the flat barrel,
+// unchanged). The full analytics surface — including its `createConsoleSink`
+// — is available with no parity loss via the namespaced entrypoint
+// `package:refraction_ui/analytics.dart`.
+export 'src/analytics/analytics.dart' hide createConsoleSink;

--- a/packages/flutter/lib/src/analytics/analytics.dart
+++ b/packages/flutter/lib/src/analytics/analytics.dart
@@ -1,0 +1,55 @@
+/// refraction_ui analytics — a headless, neutral **Segment-spec
+/// collector/router** for product analytics. 1:1 Dart port of
+/// `@refraction-ui/analytics`.
+///
+/// The app instruments **once** — it never names a vendor. The library
+/// collects the canonical event envelope and **fans it out** to N pluggable
+/// sinks (your own backend, GA4, Azure, PostHog, …). **There is no privileged
+/// engine** — every vendor is just a sink. The consumer specifies the backend
+/// URL → events go to *their* endpoint, never refraction-ui's.
+///
+/// The public API, the canonical Segment `AnalyticsEvent` envelope, the
+/// `AnalyticsSink` SPI, and the built-in HTTP sink's wire contract are reused
+/// **verbatim** from the web library (#213 / #214 / #221).
+///
+/// Structure and public API are **identical across Flutter web, Android, iOS
+/// and desktop**. Platform differences (persistent storage, HTTP transport)
+/// are internal implementation details resolved by conditional imports behind
+/// this single surface — there is no per-platform package or divergence.
+///
+/// ```dart
+/// import 'package:refraction_ui/refraction_ui.dart';
+///
+/// final analytics = createAnalytics(const AnalyticsConfig(
+///   app: 'my-app',
+///   env: 'production',
+///   endpoint: 'https://collect.example.com', // YOUR backend
+///   writeKey: 'WRITE_KEY',
+///   consent: ConsentConfig(granted: ['analytics']),
+/// ));
+///
+/// analytics.track('Signup Clicked', {'plan': 'pro'});
+/// analytics.identify('user_42', {'plan': 'pro'});
+/// analytics.screen('Dashboard');
+/// await analytics.flush();
+/// analytics.reset();
+/// ```
+library;
+
+export 'analytics_manager.dart' show createAnalytics;
+export 'console_sink.dart' show ConsoleSink, AnalyticsLogger, createConsoleSink;
+export 'consent.dart' show Consent;
+export 'http_sink.dart' show HttpSink, createHttpSink;
+export 'identity.dart' show Identity, IdentityStitch;
+// NOTE: mock_sink.dart is intentionally NOT re-exported. Its `createMockSink`,
+// `MockSink`, `MockSinkExtended` and `MockDelivery` are test-only helpers and
+// would collide with the telemetry module's flat-barrel `createMockSink` /
+// `MockSinkExtended`. Analytics tests import it directly from
+// `package:refraction_ui/src/analytics/mock_sink.dart`.
+export 'noop.dart' show NoopAnalytics, createNoopAnalytics;
+export 'redaction.dart' show Redactor, piiDenyList, piiExactKeys, redacted;
+export 'session.dart'
+    show Session, campaignFingerprint, defaultSessionTimeoutMs;
+export 'storage.dart' show MemoryStorage, createMemoryStorage, resolveStorage;
+export 'types.dart';
+export 'uuid.dart' show uuidv4, isUuidV4, uuidV4Re;

--- a/packages/flutter/lib/src/analytics/analytics_manager.dart
+++ b/packages/flutter/lib/src/analytics/analytics_manager.dart
@@ -1,0 +1,363 @@
+/// createAnalytics — the neutral Segment-spec collector/router.
+///
+/// 1:1 Dart port of `createAnalytics` from `@refraction-ui/analytics`. A
+/// single factory returns the entire public surface and fans the canonical
+/// envelope out to registered sinks. There is NO privileged engine — the
+/// built-in HTTP sink and every vendor adapter are equal sinks.
+///
+/// Presets:
+///   dev  — synchronous delivery + a console sink (see exactly what ships).
+///   prod — batching + sampling + a background/unload beacon flush.
+///
+/// When `enabled: false`, a noop is returned and no live collector / sink
+/// code runs. The structure and public API are identical across Flutter web,
+/// Android, iOS and desktop — platform differences (storage, transport) are
+/// internal, behind conditional imports.
+library;
+
+import 'dart:async';
+import 'dart:math';
+
+import 'consent.dart';
+import 'console_sink.dart';
+import 'http_sink.dart';
+import 'identity.dart';
+import 'noop.dart';
+import 'redaction.dart';
+import 'session.dart';
+import 'types.dart';
+import 'uuid.dart';
+
+const AnalyticsLibrary _library = AnalyticsLibrary(
+  name: '@refraction-ui/analytics',
+  version: '0.1.0',
+);
+
+/// The shared collector. One instance backs the root facade and every
+/// `withContext()` child — identical to the shared closure in the TS port.
+class _Core {
+  _Core(this.config)
+    : preset = config.preset ?? (config.env == 'production' ? 'prod' : 'dev'),
+      sampleRate = config.sampleRate,
+      batchSize = config.batchSize,
+      session = Session(config.session, now: config.now),
+      identity = Identity(config.identity),
+      consent = Consent(config.consent),
+      redactor = Redactor(config.redactKeys),
+      random = config.random ?? Random().nextDouble {
+    if (config.endpoint != null) {
+      registerSink(
+        createHttpSink(
+          HttpSinkOptions(
+            endpoint: config.endpoint!,
+            writeKey: config.writeKey ?? '',
+            transport: config.httpTransport,
+          ),
+        ),
+      );
+    }
+    if (preset == 'dev') {
+      registerSink(createConsoleSink());
+    }
+    for (final s in config.sinks) {
+      registerSink(s);
+    }
+    _startTimer();
+  }
+
+  final AnalyticsConfig config;
+  final String preset;
+  final double sampleRate;
+  final int batchSize;
+  final Session session;
+  final Identity identity;
+  final Consent consent;
+  final Redactor redactor;
+  final double Function() random;
+
+  final Map<String, AnalyticsSink> sinks = {};
+  final List<String> sinkOrder = [];
+  final Set<String> initialized = {};
+
+  final List<AnalyticsEvent> buffer = [];
+  Timer? _timer;
+
+  void registerSink(AnalyticsSink sink) {
+    if (!sinks.containsKey(sink.name)) sinkOrder.add(sink.name);
+    sinks[sink.name] = sink;
+  }
+
+  void removeSink(String name) {
+    if (sinks.containsKey(name)) {
+      sinks.remove(name);
+      sinkOrder.remove(name);
+      initialized.remove(name);
+    }
+  }
+
+  Future<void>? _ensureInit(AnalyticsSink sink) {
+    if (initialized.contains(sink.name)) return null;
+    initialized.add(sink.name);
+    final r = sink.init(
+      SinkInitContext(
+        app: config.app,
+        env: config.env,
+        endpoint: config.endpoint,
+      ),
+    );
+    if (r is Future) return r;
+    return null;
+  }
+
+  void _startTimer() {
+    if (preset != 'prod' || _timer != null) return;
+    _timer = Timer.periodic(
+      Duration(milliseconds: config.flushIntervalMs),
+      (_) => unawaited(flush()),
+    );
+  }
+
+  Future<void> deliverToSinks(List<AnalyticsEvent> batch, bool unload) async {
+    if (batch.isEmpty) return;
+    final ctx = SinkDeliverContext(unload: unload);
+    for (final sinkName in sinkOrder) {
+      final sink = sinks[sinkName];
+      if (sink == null) continue;
+      if (!consent.allows(sink.consentCategories)) continue;
+      final inited = _ensureInit(sink);
+      if (inited != null) await inited;
+      final r = sink.deliver(batch, ctx);
+      if (r is Future) await r;
+    }
+  }
+
+  Future<void> flush({bool unload = false}) async {
+    final batch = List<AnalyticsEvent>.of(buffer);
+    buffer.clear();
+    await deliverToSinks(batch, unload);
+    for (final sinkName in sinkOrder) {
+      final sink = sinks[sinkName];
+      if (sink != null && consent.allows(sink.consentCategories)) {
+        final r = sink.flush();
+        if (r is Future) await r;
+      }
+    }
+  }
+
+  bool _sampled() {
+    if (sampleRate >= 1) return true;
+    if (sampleRate <= 0) return false;
+    return random() < sampleRate;
+  }
+
+  void _enqueue(AnalyticsEvent ev) {
+    if (preset == 'dev') {
+      unawaited(deliverToSinks([ev], false));
+      return;
+    }
+    buffer.add(ev);
+    if (buffer.length >= batchSize) {
+      unawaited(flush());
+    }
+  }
+
+  AnalyticsContext _buildContext(
+    Map<String, Object?>? extra,
+    Map<String, Object?> childCtx,
+  ) {
+    return AnalyticsContext(
+      app: config.app,
+      env: config.env,
+      library: _library,
+      extra: {...childCtx, ...?extra},
+    );
+  }
+
+  void emit(
+    AnalyticsEventType type,
+    Map<String, Object?> fields,
+    Map<String, Object?> childCtx,
+    CallOptions? opts,
+  ) {
+    if (!_sampled()) return;
+
+    final sessionId = session.touch();
+    final sessionProps = session.props();
+
+    var properties = fields['properties'] as AnalyticsProperties?;
+    if (sessionProps != null &&
+        (properties != null ||
+            type == AnalyticsEventType.track ||
+            type == AnalyticsEventType.page ||
+            type == AnalyticsEventType.screen)) {
+      properties = {...sessionProps, ...(properties ?? {})};
+    }
+
+    final ev = AnalyticsEvent(
+      type: type,
+      event: fields['event'] as String?,
+      messageId: uuidv4(),
+      anonymousId: identity.anonymousId(),
+      userId: (fields['userId'] as String?) ?? identity.userId(),
+      groupId: fields['groupId'] as String?,
+      previousId: fields['previousId'] as String?,
+      sessionId: sessionId,
+      properties: properties,
+      traits: fields['traits'] as AnalyticsProperties?,
+      context: _buildContext(opts?.context, childCtx),
+      timestamp: opts?.timestamp ?? DateTime.now().toUtc().toIso8601String(),
+      schemaVersion: kSchemaVersion,
+    );
+
+    _enqueue(ev);
+  }
+}
+
+class _SessionFacade implements SessionApi {
+  _SessionFacade(this._s);
+  final Session _s;
+  @override
+  String id() => _s.id();
+  @override
+  String start() => _s.start();
+  @override
+  void end() => _s.end();
+  @override
+  void set(AnalyticsProperties props) => _s.set(props);
+}
+
+/// A thin facade over a shared [_Core]. The root and every `withContext()`
+/// child are facades over the same core, differing only by `_childCtx`
+/// (mirrors `makeApi(childCtx)` in the TS port).
+class _Facade implements Analytics {
+  _Facade(this._core, this._childCtx);
+
+  final _Core _core;
+  final Map<String, Object?> _childCtx;
+
+  @override
+  void track(
+    String event, [
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {
+    _core.emit(
+      AnalyticsEventType.track,
+      {'event': event, 'properties': _core.redactor.redact(properties)},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  void identify(
+    String userId, [
+    AnalyticsProperties? traits,
+    CallOptions? opts,
+  ]) {
+    _core.identity.setUserId(userId);
+    _core.emit(
+      AnalyticsEventType.identify,
+      {'traits': _core.redactor.redact(traits)},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  void page([
+    String? name,
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {
+    _core.emit(
+      AnalyticsEventType.page,
+      {'event': name, 'properties': _core.redactor.redact(properties)},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  void screen([
+    String? name,
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {
+    _core.emit(
+      AnalyticsEventType.screen,
+      {'event': name, 'properties': _core.redactor.redact(properties)},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  void group(String groupId, [AnalyticsProperties? traits, CallOptions? opts]) {
+    _core.emit(
+      AnalyticsEventType.group,
+      {'groupId': groupId, 'traits': _core.redactor.redact(traits)},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  void alias(String userId, [String? previousId, CallOptions? opts]) {
+    final stitch = _core.identity.alias(userId, previousId);
+    _core.emit(
+      AnalyticsEventType.alias,
+      {'userId': stitch.userId, 'previousId': stitch.previousId},
+      _childCtx,
+      opts,
+    );
+  }
+
+  @override
+  SessionApi get session => _SessionFacade(_core.session);
+
+  @override
+  ConsentApi get consent => _core.consent;
+
+  @override
+  String anonymousId() => _core.identity.anonymousId();
+
+  @override
+  String? userId() => _core.identity.userId();
+
+  @override
+  Analytics withContext(Map<String, Object?> context) {
+    return _Facade(_core, {..._childCtx, ...context});
+  }
+
+  @override
+  void addSink(AnalyticsSink sink) => _core.registerSink(sink);
+
+  @override
+  void removeSink(String name) => _core.removeSink(name);
+
+  @override
+  List<String> get sinks => List<String>.of(_core.sinkOrder);
+
+  @override
+  Future<void> flush() => _core.flush();
+
+  @override
+  void reset() {
+    _core.identity.reset();
+    _core.session.end();
+  }
+
+  @override
+  bool get enabled => true;
+}
+
+/// createAnalytics — the neutral Segment-spec collector/router. Returns the
+/// entire public [Analytics] surface. When `enabled: false`, a noop is
+/// returned and the live collector code does not run.
+Analytics createAnalytics(AnalyticsConfig config) {
+  if (!config.enabled) {
+    return createNoopAnalytics();
+  }
+  return _Facade(_Core(config), const {});
+}

--- a/packages/flutter/lib/src/analytics/consent.dart
+++ b/packages/flutter/lib/src/analytics/consent.dart
@@ -1,0 +1,42 @@
+/// Consent gate.
+///
+/// Holds the set of granted consent categories. The router asks the gate, per
+/// sink, whether *all* of that sink's required categories are granted before
+/// delivering. A sink with no declared categories is always allowed (it is the
+/// sink author's responsibility to declare what it needs).
+library;
+
+import 'types.dart';
+
+/// Consent gate. Mirrors `createConsent` from `@refraction-ui/analytics`.
+class Consent implements ConsentApi {
+  Consent(ConsentConfig? config)
+    : strict = config?.strict ?? false,
+      _granted = {...(config?.granted ?? const <String>[])};
+
+  /// True when at least one sink could receive (used by strict mode).
+  final bool strict;
+  final Set<String> _granted;
+
+  @override
+  void grant(List<String> categories) {
+    _granted.addAll(categories);
+  }
+
+  @override
+  void revoke(List<String> categories) {
+    _granted.removeAll(categories);
+  }
+
+  @override
+  List<String> granted() => _granted.toList();
+
+  @override
+  bool isGranted(String category) => _granted.contains(category);
+
+  /// True when every required category is granted (empty list ⇒ allowed).
+  bool allows(List<String>? required) {
+    if (required == null || required.isEmpty) return true;
+    return required.every(_granted.contains);
+  }
+}

--- a/packages/flutter/lib/src/analytics/console_sink.dart
+++ b/packages/flutter/lib/src/analytics/console_sink.dart
@@ -1,0 +1,52 @@
+/// Built-in `console` sink — the dev preset's default. Prints each canonical
+/// envelope so engineers can see exactly what would ship over the wire.
+library;
+
+import 'types.dart';
+
+/// Logger SPI (defaults to `print`). Injectable for tests / custom routing.
+typedef AnalyticsLogger = void Function(String message);
+
+class ConsoleSink implements AnalyticsSink {
+  ConsoleSink({AnalyticsLogger? logger, List<String>? consentCategories})
+    : _logger = logger ?? _printLogger,
+      _consentCategories = consentCategories;
+
+  static void _printLogger(String message) {
+    // ignore: avoid_print
+    print(message);
+  }
+
+  final AnalyticsLogger _logger;
+  final List<String>? _consentCategories;
+
+  @override
+  String get name => 'console';
+
+  @override
+  List<String>? get consentCategories => _consentCategories;
+
+  @override
+  void deliver(List<AnalyticsEvent> batch, SinkDeliverContext ctx) {
+    for (final ev in batch) {
+      final label =
+          '[analytics] ${ev.type.wire}${ev.event != null ? ' ${ev.event}' : ''}';
+      _logger('$label ${ev.toJson()}');
+    }
+  }
+
+  @override
+  void init(SinkInitContext ctx) {}
+
+  @override
+  void flush() {}
+
+  @override
+  void shutdown() {}
+}
+
+/// Create the built-in dev-preset console sink.
+AnalyticsSink createConsoleSink({
+  AnalyticsLogger? logger,
+  List<String>? consentCategories,
+}) => ConsoleSink(logger: logger, consentCategories: consentCategories);

--- a/packages/flutter/lib/src/analytics/http_sink.dart
+++ b/packages/flutter/lib/src/analytics/http_sink.dart
@@ -1,0 +1,188 @@
+/// Built-in `http` sink — Segment HTTP Tracking API wire contract.
+///
+/// Wire contract (adopt, do not invent — RudderStack/Jitsu/Segment conform):
+///
+///   POST {endpoint}/v{schemaVersion}/batch
+///   Content-Type: application/json
+///   Authorization: Basic base64(writeKey:)         (note the trailing colon)
+///   Body: { batch: AnalyticsEvent[], sentAt, batchId }
+///
+/// Each event carries `messageId` (idempotency — backends MUST dedupe),
+/// `anonymousId`, `userId?`, `sessionId`, `type`, `event?`,
+/// `properties`/`traits`, `context`, `timestamp`, `schemaVersion`.
+///
+/// Response handling (accept-and-queue semantics):
+///   2xx       accepted (the backend has only queued it, not processed it)
+///   400       malformed       → DROP, never retry
+///   401       bad write key   → DROP, never retry
+///   413       payload too big → DROP (we also pre-split under the size caps)
+///   429 / 5xx transient       → exponential backoff retry
+///   network   transient       → exponential backoff retry
+///
+/// Clock skew: the backend corrects with
+///   corrected = timestamp + (receivedAt − sentAt)
+/// so we always stamp an honest client `sentAt`.
+///
+/// Beacon caveat: the unload/background path uses a beacon, which cannot set
+/// an `Authorization` header. On that path we fall back to `?writeKey=` in the
+/// query string with a `text/plain` body (the wire contract requires the
+/// backend to accept this).
+library;
+
+import 'dart:convert';
+
+import 'http_transport.dart';
+import 'types.dart';
+import 'uuid.dart';
+
+const Set<int> _noRetry = {400, 401, 413};
+
+int _byteLength(String s) => utf8.encode(s).length;
+
+class _SplitResult {
+  _SplitResult(this.batches, this.dropped);
+  final List<List<AnalyticsEvent>> batches;
+  final List<AnalyticsEvent> dropped;
+}
+
+/// Split a batch so neither the per-event nor per-batch byte caps are
+/// exceeded. Over-sized single events are dropped (they can never be sent).
+_SplitResult _splitBatch(
+  List<AnalyticsEvent> batch,
+  int maxBatchBytes,
+  int maxEventBytes,
+) {
+  final batches = <List<AnalyticsEvent>>[];
+  final dropped = <AnalyticsEvent>[];
+  var current = <AnalyticsEvent>[];
+  var currentBytes = 2; // "[]"
+
+  for (final ev in batch) {
+    final evBytes = _byteLength(jsonEncode(ev.toJson()));
+    if (evBytes > maxEventBytes) {
+      dropped.add(ev);
+      continue;
+    }
+    if (current.isNotEmpty && currentBytes + evBytes + 1 > maxBatchBytes) {
+      batches.add(current);
+      current = <AnalyticsEvent>[];
+      currentBytes = 2;
+    }
+    current.add(ev);
+    currentBytes += evBytes + 1;
+  }
+  if (current.isNotEmpty) batches.add(current);
+  return _SplitResult(batches, dropped);
+}
+
+/// The built-in Segment-spec HTTP sink.
+class HttpSink implements AnalyticsSink {
+  HttpSink(HttpSinkOptions options)
+    : _writeKey = options.writeKey,
+      _maxRetries = options.maxRetries,
+      _backoffBaseMs = options.backoffBaseMs,
+      _maxBatchBytes = options.maxBatchBytes,
+      _maxEventBytes = options.maxEventBytes,
+      _consentCategories = options.consentCategories,
+      _transport = options.transport ?? resolveHttpTransport(),
+      _sleep = options.sleep ?? ((d) => Future<void>.delayed(d)),
+      _url =
+          '${options.endpoint.replaceAll(RegExp(r"/+$"), "")}'
+          '/v$kSchemaVersion/batch',
+      _authHeader =
+          'Basic ${base64.encode(utf8.encode("${options.writeKey}:"))}';
+
+  final String _writeKey;
+  final int _maxRetries;
+  final int _backoffBaseMs;
+  final int _maxBatchBytes;
+  final int _maxEventBytes;
+  final List<String> _consentCategories;
+  final HttpTransport _transport;
+  final Future<void> Function(Duration) _sleep;
+  final String _url;
+  final String _authHeader;
+
+  @override
+  String get name => 'http';
+
+  @override
+  List<String>? get consentCategories => _consentCategories;
+
+  Map<String, Object?> _envelope(List<AnalyticsEvent> batch) => {
+    'batch': batch.map((e) => e.toJson()).toList(),
+    'sentAt': DateTime.now().toUtc().toIso8601String(),
+    'batchId': uuidv4(),
+  };
+
+  /// Beacon path: writeKey via query string, text/plain body.
+  bool _sendViaBeacon(List<AnalyticsEvent> batch) {
+    final beaconUrl = '$_url?writeKey=${Uri.encodeQueryComponent(_writeKey)}';
+    return _transport.beacon(
+      url: beaconUrl,
+      body: jsonEncode(_envelope(batch)),
+    );
+  }
+
+  /// Standard path: POST + Authorization header, with backoff retries.
+  Future<void> _sendViaFetch(List<AnalyticsEvent> batch) async {
+    final body = jsonEncode(_envelope(batch));
+    for (var attempt = 0; ; attempt++) {
+      int status;
+      try {
+        status = await _transport.post(
+          url: _url,
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': _authHeader,
+          },
+          body: body,
+        );
+      } catch (_) {
+        // Network error — treat as transient.
+        status = 0;
+      }
+
+      if (status >= 200 && status < 300) return; // accepted-and-queued
+      if (_noRetry.contains(status)) return; // 400/401/413 — drop, never retry
+
+      // 429 / 5xx / network (0) → backoff retry.
+      if (attempt >= _maxRetries) return;
+      final delay = _backoffBaseMs * (1 << attempt);
+      await _sleep(Duration(milliseconds: delay));
+    }
+  }
+
+  @override
+  Future<void> deliver(
+    List<AnalyticsEvent> batch,
+    SinkDeliverContext ctx,
+  ) async {
+    if (batch.isEmpty) return;
+    final split = _splitBatch(batch, _maxBatchBytes, _maxEventBytes);
+    // Oversized events are unsendable by contract — silently dropped.
+
+    for (final part in split.batches) {
+      if (ctx.unload) {
+        // Unload path: try beacon first; fall back to keepalive fetch.
+        if (_sendViaBeacon(part)) continue;
+        // ignore: unawaited_futures
+        _sendViaFetch(part);
+      } else {
+        await _sendViaFetch(part);
+      }
+    }
+  }
+
+  @override
+  Future<void> init(SinkInitContext ctx) async {}
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> shutdown() async {}
+}
+
+/// Create the built-in Segment-spec HTTP sink.
+AnalyticsSink createHttpSink(HttpSinkOptions options) => HttpSink(options);

--- a/packages/flutter/lib/src/analytics/http_transport.dart
+++ b/packages/flutter/lib/src/analytics/http_transport.dart
@@ -1,0 +1,15 @@
+/// Resolves the default [HttpTransport] for the current platform via a
+/// conditional import. dart:io HttpClient on Android/iOS/desktop; browser
+/// fetch/sendBeacon on Flutter web. The platform difference is internal —
+/// the consumer never sees it, the HTTP sink only ever talks to the SPI.
+library;
+
+import 'types.dart';
+import 'http_transport_stub.dart'
+    if (dart.library.io) 'http_transport_io.dart'
+    if (dart.library.html) 'http_transport_html.dart'
+    as platform;
+
+/// Resolve the platform transport (throws if no transport is reachable —
+/// the caller is expected to inject one in that case).
+HttpTransport resolveHttpTransport() => platform.createPlatformTransport();

--- a/packages/flutter/lib/src/analytics/http_transport_html.dart
+++ b/packages/flutter/lib/src/analytics/http_transport_html.dart
@@ -1,0 +1,49 @@
+/// Flutter-web transport (dart:html). Standard path uses HttpRequest with the
+/// Authorization header; the unload path uses the real `navigator.sendBeacon`
+/// (cannot set headers — write key travels in the query string per the wire
+/// contract).
+library;
+
+// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
+import 'dart:html' as html;
+
+import 'types.dart';
+
+class _HtmlTransport implements HttpTransport {
+  @override
+  Future<int> post({
+    required String url,
+    required Map<String, String> headers,
+    required String body,
+  }) async {
+    try {
+      final res = await html.HttpRequest.request(
+        url,
+        method: 'POST',
+        requestHeaders: headers,
+        sendData: body,
+      );
+      return res.status ?? 0;
+    } on html.ProgressEvent catch (e) {
+      final target = e.target;
+      if (target is html.HttpRequest) {
+        // 4xx/5xx surface as a ProgressEvent — return the real status so the
+        // sink applies the wire-contract retry/no-retry rules.
+        return target.status ?? 0;
+      }
+      // Genuine network failure → transient (throw → sink retries).
+      throw StateError('network error');
+    }
+  }
+
+  @override
+  bool beacon({required String url, required String body}) {
+    try {
+      return html.window.navigator.sendBeacon(url, body);
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+HttpTransport createPlatformTransport() => _HtmlTransport();

--- a/packages/flutter/lib/src/analytics/http_transport_io.dart
+++ b/packages/flutter/lib/src/analytics/http_transport_io.dart
@@ -1,0 +1,51 @@
+/// dart:io transport (Android, iOS, macOS, Windows, Linux). Uses the core
+/// HttpClient so the package stays dependency-free. The unload "beacon" is a
+/// best-effort fire-and-forget keepalive POST (mobile/desktop have no
+/// navigator.sendBeacon; this is the platform-equivalent fallback).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'types.dart';
+
+class _IoTransport implements HttpTransport {
+  final HttpClient _client = HttpClient()
+    ..connectionTimeout = const Duration(seconds: 10);
+
+  @override
+  Future<int> post({
+    required String url,
+    required Map<String, String> headers,
+    required String body,
+  }) async {
+    final req = await _client.postUrl(Uri.parse(url));
+    headers.forEach(req.headers.set);
+    req.add(utf8.encode(body));
+    final res = await req.close();
+    // Drain so the connection can be reused / released.
+    await res.drain<void>();
+    return res.statusCode;
+  }
+
+  @override
+  bool beacon({required String url, required String body}) {
+    // Beacon-equivalent on IO: fire-and-forget POST that we do not await.
+    // Errors are swallowed — this is the unload best-effort path.
+    unawaited(() async {
+      try {
+        final req = await _client.postUrl(Uri.parse(url));
+        req.headers.set(HttpHeaders.contentTypeHeader, 'text/plain');
+        req.add(utf8.encode(body));
+        final res = await req.close();
+        await res.drain<void>();
+      } catch (_) {
+        // best-effort
+      }
+    }());
+    return true;
+  }
+}
+
+HttpTransport createPlatformTransport() => _IoTransport();

--- a/packages/flutter/lib/src/analytics/http_transport_stub.dart
+++ b/packages/flutter/lib/src/analytics/http_transport_stub.dart
@@ -1,0 +1,24 @@
+/// Transport stub for platforms with neither dart:io nor dart:html. A sink
+/// must be given an explicit transport in that (rare) case.
+library;
+
+import 'types.dart';
+
+class _UnavailableTransport implements HttpTransport {
+  @override
+  Future<int> post({
+    required String url,
+    required Map<String, String> headers,
+    required String body,
+  }) {
+    throw StateError(
+      'No HTTP transport available on this platform — inject an '
+      'HttpTransport via HttpSinkOptions.transport.',
+    );
+  }
+
+  @override
+  bool beacon({required String url, required String body}) => false;
+}
+
+HttpTransport createPlatformTransport() => _UnavailableTransport();

--- a/packages/flutter/lib/src/analytics/identity.dart
+++ b/packages/flutter/lib/src/analytics/identity.dart
@@ -1,0 +1,71 @@
+/// Identity engine.
+///
+/// - `anonymousId`: persistent, non-PII, resettable UUIDv4 stored via the
+///   storage SPI (secure platform store on mobile/desktop, localStorage on
+///   web — internal, behind the uniform surface).
+/// - `userId`: opaque, app-supplied; never persisted by the library (the app
+///   owns the user record) — kept only in memory.
+/// - `alias`: records a previous→current stitch for the wire envelope.
+library;
+
+import 'storage.dart';
+import 'types.dart';
+import 'uuid.dart';
+
+const String _defaultKey = 'rfx:analytics:anon';
+
+/// A previous→current identity stitch pair (for `alias`).
+class IdentityStitch {
+  const IdentityStitch({required this.userId, required this.previousId});
+  final String userId;
+  final String previousId;
+}
+
+/// Identity engine. Mirrors `createIdentity` from `@refraction-ui/analytics`.
+class Identity {
+  Identity(IdentityConfig? config)
+    : _storage = resolveStorage(config?.storage),
+      _key = config?.storageKey ?? _defaultKey {
+    _anonymousId = _loadOrMintAnon();
+  }
+
+  final AnalyticsStorage _storage;
+  final String _key;
+
+  String? _userId;
+  late String _anonymousId;
+
+  String _loadOrMintAnon() {
+    final existing = _storage.get(_key);
+    if (isUuidV4(existing)) return existing!;
+    final fresh = uuidv4();
+    _storage.set(_key, fresh);
+    return fresh;
+  }
+
+  String anonymousId() => _anonymousId;
+
+  String? userId() => _userId;
+
+  /// identify(): bind an opaque app user id (no validation, no persistence).
+  void setUserId(String id) {
+    _userId = id;
+  }
+
+  /// alias(): returns the stitch pair for the envelope. `previousId` defaults
+  /// to the current user or anonymous id.
+  IdentityStitch alias(String nextUserId, [String? previousId]) {
+    final prev = previousId ?? _userId ?? _anonymousId;
+    _userId = nextUserId;
+    return IdentityStitch(userId: nextUserId, previousId: prev);
+  }
+
+  /// reset(): privacy-safe logout. Drops the user binding and mints a brand
+  /// new anonymousId so the next visitor is not stitched to the old one.
+  String reset() {
+    _userId = null;
+    _anonymousId = uuidv4();
+    _storage.set(_key, _anonymousId);
+    return _anonymousId;
+  }
+}

--- a/packages/flutter/lib/src/analytics/mock_sink.dart
+++ b/packages/flutter/lib/src/analytics/mock_sink.dart
@@ -1,0 +1,67 @@
+/// A mock sink that records every call — used for testing the router and the
+/// wire-contract conformance suite. Mirrors `createMockSink` from
+/// `@refraction-ui/analytics`.
+library;
+
+import 'types.dart';
+
+class MockDelivery {
+  MockDelivery(this.batch, this.ctx);
+  final List<AnalyticsEvent> batch;
+  final SinkDeliverContext ctx;
+}
+
+class MockSink implements AnalyticsSink {
+  MockSink({String? name, List<String>? consentCategories})
+    : _name = name ?? 'mock',
+      _consentCategories = consentCategories;
+
+  final String _name;
+  final List<String>? _consentCategories;
+
+  /// All events received across all deliver() calls (flattened).
+  final List<AnalyticsEvent> events = [];
+
+  /// Each deliver() call's batch + context.
+  final List<MockDelivery> deliveries = [];
+
+  /// init() call contexts.
+  final List<SinkInitContext> initCalls = [];
+
+  /// flush() invocation count.
+  int flushCalls = 0;
+
+  /// shutdown() invocation count.
+  int shutdownCalls = 0;
+
+  @override
+  String get name => _name;
+
+  @override
+  List<String>? get consentCategories => _consentCategories;
+
+  @override
+  void init(SinkInitContext ctx) {
+    initCalls.add(ctx);
+  }
+
+  @override
+  void deliver(List<AnalyticsEvent> batch, SinkDeliverContext ctx) {
+    deliveries.add(MockDelivery(batch, ctx));
+    events.addAll(batch);
+  }
+
+  @override
+  void flush() {
+    flushCalls++;
+  }
+
+  @override
+  void shutdown() {
+    shutdownCalls++;
+  }
+}
+
+/// Create an [AnalyticsSink] that captures everything for assertion.
+MockSink createMockSink({String? name, List<String>? consentCategories}) =>
+    MockSink(name: name, consentCategories: consentCategories);

--- a/packages/flutter/lib/src/analytics/noop.dart
+++ b/packages/flutter/lib/src/analytics/noop.dart
@@ -1,0 +1,110 @@
+/// The noop collector returned when `enabled: false`.
+///
+/// Every method is empty so calls are free and a production build can compile
+/// analytics off entirely. Kept in its own module so the live collector / sink
+/// code is not reachable on the `enabled:false` path.
+library;
+
+import 'types.dart';
+
+const String _zeroId = '00000000-0000-4000-8000-000000000000';
+
+class _NoopSession implements SessionApi {
+  @override
+  String id() => _zeroId;
+  @override
+  String start() => _zeroId;
+  @override
+  void end() {}
+  @override
+  void set(AnalyticsProperties props) {}
+}
+
+class _NoopConsent implements ConsentApi {
+  @override
+  void grant(List<String> categories) {}
+  @override
+  void revoke(List<String> categories) {}
+  @override
+  List<String> granted() => const [];
+  @override
+  bool isGranted(String category) => false;
+}
+
+class NoopAnalytics implements Analytics {
+  NoopAnalytics();
+
+  @override
+  final SessionApi session = _NoopSession();
+
+  @override
+  final ConsentApi consent = _NoopConsent();
+
+  @override
+  void track(
+    String event, [
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {}
+
+  @override
+  void identify(
+    String userId, [
+    AnalyticsProperties? traits,
+    CallOptions? opts,
+  ]) {}
+
+  @override
+  void page([
+    String? name,
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {}
+
+  @override
+  void screen([
+    String? name,
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]) {}
+
+  @override
+  void group(
+    String groupId, [
+    AnalyticsProperties? traits,
+    CallOptions? opts,
+  ]) {}
+
+  @override
+  void alias(String userId, [String? previousId, CallOptions? opts]) {}
+
+  @override
+  String anonymousId() => _zeroId;
+
+  @override
+  String? userId() => null;
+
+  @override
+  Analytics withContext(Map<String, Object?> context) => this;
+
+  @override
+  void addSink(AnalyticsSink sink) {}
+
+  @override
+  void removeSink(String name) {}
+
+  @override
+  List<String> get sinks => const [];
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void reset() {}
+
+  @override
+  bool get enabled => false;
+}
+
+/// The noop collector returned when `enabled: false`.
+Analytics createNoopAnalytics() => NoopAnalytics();

--- a/packages/flutter/lib/src/analytics/redaction.dart
+++ b/packages/flutter/lib/src/analytics/redaction.dart
@@ -1,0 +1,79 @@
+/// PII redaction.
+///
+/// A built-in deny-list of well-known PII key names (email/phone/name and
+/// common variants) plus any caller-supplied `redactKeys`. Matching is
+/// case-insensitive and substring-based so `userEmail`, `email_address`,
+/// `phoneNumber`, `fullName`, etc. are all caught. Redaction recurses into
+/// nested maps and lists so PII cannot hide one level down.
+library;
+
+import 'types.dart';
+
+/// Built-in PII deny-list (substring, case-insensitive, separator-insensitive).
+const List<String> piiDenyList = [
+  'email',
+  'phone',
+  'mobile',
+  'firstname',
+  'lastname',
+  'fullname',
+  'givenname',
+  'surname',
+  'password',
+  'passwd',
+  'ssn',
+  'creditcard',
+  'cardnumber',
+  'cvv',
+  'dob',
+  'dateofbirth',
+  'address',
+];
+
+/// Keys that are PII only as an *exact* (normalised) match.
+const List<String> piiExactKeys = ['name'];
+
+/// Replacement token written in place of a redacted value.
+const String redacted = '[REDACTED]';
+
+String _normalize(String key) =>
+    key.toLowerCase().replaceAll(RegExp(r'[_\-\s]'), '');
+
+/// Build a key matcher from the deny-list + extra keys. `extra` entries match
+/// exactly (case-insensitive, normalised); deny-list entries match as
+/// substrings.
+class Redactor {
+  Redactor([List<String> extraKeys = const []])
+    : _exact = {...extraKeys.map(_normalize), ...piiExactKeys.map(_normalize)},
+      _deny = piiDenyList.map(_normalize).toList();
+
+  final Set<String> _exact;
+  final List<String> _deny;
+
+  bool shouldRedact(String key) {
+    final n = _normalize(key);
+    if (_exact.contains(n)) return true;
+    return _deny.any(n.contains);
+  }
+
+  Object? _walk(Object? value) {
+    if (value is List) {
+      return value.map(_walk).toList();
+    }
+    if (value is Map) {
+      final out = <String, Object?>{};
+      value.forEach((k, v) {
+        final key = '$k';
+        out[key] = shouldRedact(key) ? redacted : _walk(v);
+      });
+      return out;
+    }
+    return value;
+  }
+
+  /// Redact a properties/traits bag (returns a new map).
+  AnalyticsProperties? redact(AnalyticsProperties? props) {
+    if (props == null) return null;
+    return _walk(props) as AnalyticsProperties;
+  }
+}

--- a/packages/flutter/lib/src/analytics/session.dart
+++ b/packages/flutter/lib/src/analytics/session.dart
@@ -1,0 +1,177 @@
+/// Session engine.
+///
+/// A session is a span of continuous activity. It ends after `timeoutMs` of
+/// inactivity (GA4 parity, default 30 min) or when a *new* campaign is
+/// detected. State is persisted via the storage SPI so it survives relaunch
+/// (and is shared cross-isolate when the same storage is injected).
+library;
+
+import 'dart:convert';
+
+import 'storage.dart';
+import 'types.dart';
+import 'uuid.dart';
+
+/// GA4 parity: 30 minutes of inactivity ends a session.
+const int defaultSessionTimeoutMs = 30 * 60 * 1000;
+
+const String _defaultKey = 'rfx:analytics:session';
+
+/// Recognised campaign params (UTM + common click ids). GA4 parity.
+const List<String> _campaignParams = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'gclid',
+  'fbclid',
+  'msclkid',
+];
+
+/// Derive a stable campaign fingerprint from a URL's query string. A change in
+/// this fingerprint (a *new* campaign, not its absence) forces a new session,
+/// matching GA4's "campaign change resets the session" behaviour.
+String? campaignFingerprint(String? search) {
+  if (search == null || search.isEmpty) return null;
+  var qs = search;
+  final q = qs.indexOf('?');
+  if (q != -1) qs = qs.substring(q + 1);
+
+  final params = <String, String>{};
+  for (final pair in qs.split('&')) {
+    if (pair.isEmpty) continue;
+    final eq = pair.indexOf('=');
+    if (eq == -1) {
+      params[Uri.decodeQueryComponent(pair)] = '';
+    } else {
+      final k = Uri.decodeQueryComponent(pair.substring(0, eq));
+      final v = Uri.decodeQueryComponent(pair.substring(eq + 1));
+      params[k] = v;
+    }
+  }
+
+  final pairs = <String>[];
+  for (final p in _campaignParams) {
+    final v = params[p];
+    if (v != null && v.isNotEmpty) pairs.add('$p=$v');
+  }
+  return pairs.isEmpty ? null : pairs.join('&');
+}
+
+class _PersistedSession {
+  _PersistedSession({
+    required this.id,
+    required this.lastActivity,
+    this.campaign,
+    this.props,
+  });
+
+  final String id;
+  int lastActivity;
+  final String? campaign;
+  AnalyticsProperties? props;
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'lastActivity': lastActivity,
+    if (campaign != null) 'campaign': campaign,
+    if (props != null) 'props': props,
+  };
+
+  static _PersistedSession? tryParse(String raw) {
+    try {
+      final m = jsonDecode(raw);
+      if (m is Map && m['id'] is String) {
+        return _PersistedSession(
+          id: m['id'] as String,
+          lastActivity: (m['lastActivity'] as num?)?.toInt() ?? 0,
+          campaign: m['campaign'] as String?,
+          props: (m['props'] as Map?)?.cast<String, Object?>(),
+        );
+      }
+    } catch (_) {
+      // corrupt — treat as none
+    }
+    return null;
+  }
+}
+
+/// Session engine. Mirrors `createSession` from `@refraction-ui/analytics`.
+class Session {
+  Session(SessionConfig? config, {int Function()? now})
+    : _storage = resolveStorage(config?.storage),
+      _key = config?.storageKey ?? _defaultKey,
+      _timeoutMs = config?.timeoutMs ?? defaultSessionTimeoutMs,
+      _resetOnCampaign = config?.resetOnCampaign ?? true,
+      _now = now ?? (() => DateTime.now().millisecondsSinceEpoch);
+
+  final AnalyticsStorage _storage;
+  final String _key;
+  final int _timeoutMs;
+  final bool _resetOnCampaign;
+  final int Function() _now;
+
+  _PersistedSession? _read() {
+    final raw = _storage.get(_key);
+    if (raw == null) return null;
+    return _PersistedSession.tryParse(raw);
+  }
+
+  void _write(_PersistedSession s) {
+    _storage.set(_key, jsonEncode(s.toJson()));
+  }
+
+  _PersistedSession _mint(String? campaign) {
+    final s = _PersistedSession(
+      id: uuidv4(),
+      lastActivity: _now(),
+      campaign: campaign,
+    );
+    _write(s);
+    return s;
+  }
+
+  /// Return the live session, creating/rotating it as required by the
+  /// inactivity timeout and (optionally) a campaign change.
+  _PersistedSession _ensure([String? campaign]) {
+    final existing = _read();
+    final t = _now();
+    if (existing == null) return _mint(campaign);
+
+    if (t - existing.lastActivity > _timeoutMs) {
+      return _mint(campaign);
+    }
+    if (_resetOnCampaign && campaign != null && existing.campaign != campaign) {
+      return _mint(campaign);
+    }
+    return existing;
+  }
+
+  /// Get the current session id, rotating if expired.
+  String id([String? campaign]) => _ensure(campaign).id;
+
+  /// Force a brand-new session.
+  String start([String? campaign]) => _mint(campaign).id;
+
+  /// End the current session (next id() mints a fresh one).
+  void end() => _storage.remove(_key);
+
+  /// Touch activity so the inactivity window slides forward.
+  String touch([String? campaign]) {
+    final s = _ensure(campaign);
+    s.lastActivity = _now();
+    _write(s);
+    return s.id;
+  }
+
+  /// Attach/merge session-scoped properties.
+  void set(AnalyticsProperties props) {
+    final s = _ensure();
+    s.props = {...(s.props ?? {}), ...props};
+    _write(s);
+  }
+
+  /// Read session-scoped properties (null when none).
+  AnalyticsProperties? props() => _read()?.props;
+}

--- a/packages/flutter/lib/src/analytics/storage.dart
+++ b/packages/flutter/lib/src/analytics/storage.dart
@@ -1,0 +1,52 @@
+/// Storage adapters.
+///
+/// Order of preference for the default: platform persistent storage
+/// (browser localStorage on Flutter web; an app-support file on
+/// Android/iOS/desktop) → in-memory. The package is platform-agnostic;
+/// consumers can inject any [AnalyticsStorage] via config. The platform
+/// difference is resolved by a conditional import and is invisible to the
+/// consumer — uniform across every Flutter target.
+library;
+
+import 'types.dart';
+// Default platform storage is selected at compile time. dart:io on
+// Android/iOS/desktop, dart:html on Flutter web, memory otherwise.
+import 'storage_stub.dart'
+    if (dart.library.io) 'storage_io.dart'
+    if (dart.library.html) 'storage_html.dart'
+    as platform;
+
+/// Volatile per-process store (no-persistence fallback).
+class MemoryStorage implements AnalyticsStorage {
+  final Map<String, String> _map = {};
+
+  @override
+  String? get(String key) => _map[key];
+
+  @override
+  void set(String key, String value) {
+    _map[key] = value;
+  }
+
+  @override
+  void remove(String key) {
+    _map.remove(key);
+  }
+}
+
+/// Construct an in-memory store.
+AnalyticsStorage createMemoryStorage() => MemoryStorage();
+
+/// Resolve the default storage for the current platform. A caller-supplied
+/// storage always wins. Falls back to in-memory when no durable platform
+/// store is reachable.
+AnalyticsStorage resolveStorage([AnalyticsStorage? override]) {
+  if (override != null) return override;
+  try {
+    final s = platform.createPlatformStorage();
+    if (s != null) return s;
+  } catch (_) {
+    // Any platform-storage failure degrades silently to memory.
+  }
+  return createMemoryStorage();
+}

--- a/packages/flutter/lib/src/analytics/storage_html.dart
+++ b/packages/flutter/lib/src/analytics/storage_html.dart
@@ -1,0 +1,50 @@
+/// Default persistent storage for Flutter web (dart:html). Uses
+/// `window.localStorage`, degrading silently when it is unavailable
+/// (private mode / disabled) so the resolver can fall back to memory.
+library;
+
+// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
+import 'dart:html' as html;
+
+import 'types.dart';
+
+class _LocalStorage implements AnalyticsStorage {
+  @override
+  String? get(String key) {
+    try {
+      return html.window.localStorage[key];
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  void set(String key, String value) {
+    try {
+      html.window.localStorage[key] = value;
+    } catch (_) {
+      // Quota / disabled — degrade silently.
+    }
+  }
+
+  @override
+  void remove(String key) {
+    try {
+      html.window.localStorage.remove(key);
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+AnalyticsStorage? createPlatformStorage() {
+  try {
+    // Probe — private mode can throw on write.
+    const probe = '__rfx_a_probe__';
+    html.window.localStorage[probe] = '1';
+    html.window.localStorage.remove(probe);
+    return _LocalStorage();
+  } catch (_) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/analytics/storage_io.dart
+++ b/packages/flutter/lib/src/analytics/storage_io.dart
@@ -1,0 +1,73 @@
+/// Default persistent storage for dart:io targets (Android, iOS, macOS,
+/// Windows, Linux). A single JSON file under the OS temp/app dir holds the
+/// small set of analytics keys (anonymousId, session). This keeps the package
+/// dependency-free (no shared_preferences / path_provider) while still being
+/// durable across launches. The file path is namespaced so it does not
+/// collide with the consuming app's own data.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'types.dart';
+
+class _FileStorage implements AnalyticsStorage {
+  _FileStorage(this._file) {
+    _load();
+  }
+
+  final File _file;
+  final Map<String, String> _cache = {};
+
+  void _load() {
+    try {
+      if (_file.existsSync()) {
+        final raw = _file.readAsStringSync();
+        if (raw.isNotEmpty) {
+          final decoded = jsonDecode(raw);
+          if (decoded is Map) {
+            decoded.forEach((k, v) {
+              if (v is String) _cache['$k'] = v;
+            });
+          }
+        }
+      }
+    } catch (_) {
+      // Corrupt / unreadable — treat as empty.
+    }
+  }
+
+  void _persist() {
+    try {
+      _file.parent.createSync(recursive: true);
+      _file.writeAsStringSync(jsonEncode(_cache), flush: true);
+    } catch (_) {
+      // Read-only FS / quota — degrade silently (in-memory cache still works).
+    }
+  }
+
+  @override
+  String? get(String key) => _cache[key];
+
+  @override
+  void set(String key, String value) {
+    _cache[key] = value;
+    _persist();
+  }
+
+  @override
+  void remove(String key) {
+    _cache.remove(key);
+    _persist();
+  }
+}
+
+AnalyticsStorage? createPlatformStorage() {
+  try {
+    final base = Directory.systemTemp.path;
+    final file = File('$base/refraction_ui_analytics/store.json');
+    return _FileStorage(file);
+  } catch (_) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/analytics/storage_stub.dart
+++ b/packages/flutter/lib/src/analytics/storage_stub.dart
@@ -1,0 +1,7 @@
+/// Default-storage stub for platforms with neither dart:io nor dart:html.
+/// Returns null so the resolver falls back to in-memory storage.
+library;
+
+import 'types.dart';
+
+AnalyticsStorage? createPlatformStorage() => null;

--- a/packages/flutter/lib/src/analytics/types.dart
+++ b/packages/flutter/lib/src/analytics/types.dart
@@ -1,0 +1,521 @@
+/// refraction_ui analytics — type contracts.
+///
+/// 1:1 Dart port of `@refraction-ui/analytics`. The library is a neutral
+/// Segment-spec collector/router. The app instruments once via the canonical
+/// API; the router fans the canonical envelope out to N pluggable sinks.
+/// There is NO privileged engine — every vendor is a sink.
+///
+/// The public API, the canonical Segment `AnalyticsEvent` envelope, the
+/// `AnalyticsSink` SPI, and the built-in HTTP sink's wire contract are reused
+/// verbatim from the web library (#213 / #214 / #221). Platform differences
+/// (storage, transport) are internal implementation details behind one
+/// identical surface — uniform across Flutter web/Android/iOS/desktop.
+library;
+
+import 'dart:async';
+
+/// Canonical Segment event types.
+enum AnalyticsEventType { track, identify, page, screen, group, alias }
+
+/// Wire name for an [AnalyticsEventType] (matches the TS string union).
+extension AnalyticsEventTypeWire on AnalyticsEventType {
+  String get wire {
+    switch (this) {
+      case AnalyticsEventType.track:
+        return 'track';
+      case AnalyticsEventType.identify:
+        return 'identify';
+      case AnalyticsEventType.page:
+        return 'page';
+      case AnalyticsEventType.screen:
+        return 'screen';
+      case AnalyticsEventType.group:
+        return 'group';
+      case AnalyticsEventType.alias:
+        return 'alias';
+    }
+  }
+}
+
+/// Schema version stamped onto every envelope and the wire contract path.
+const int kSchemaVersion = 1;
+
+/// Arbitrary, JSON-serialisable bag of values.
+typedef AnalyticsProperties = Map<String, Object?>;
+
+/// Library identity stamped into [AnalyticsContext.library].
+class AnalyticsLibrary {
+  const AnalyticsLibrary({required this.name, required this.version});
+
+  final String name;
+  final String version;
+
+  Map<String, Object?> toJson() => {'name': name, 'version': version};
+}
+
+/// Page block attached to an event when a navigation context is available.
+class AnalyticsPage {
+  const AnalyticsPage({
+    this.path,
+    this.url,
+    this.referrer,
+    this.title,
+    this.search,
+  });
+
+  final String? path;
+  final String? url;
+  final String? referrer;
+  final String? title;
+  final String? search;
+
+  Map<String, Object?> toJson() {
+    final out = <String, Object?>{};
+    if (path != null) out['path'] = path;
+    if (url != null) out['url'] = url;
+    if (referrer != null) out['referrer'] = referrer;
+    if (title != null) out['title'] = title;
+    if (search != null) out['search'] = search;
+    return out;
+  }
+}
+
+/// The context block attached to every event. `library` identifies the
+/// collector; `app`/`env` identify the product instance. Free-form additions
+/// are contributed by `with(context)` children via [extra].
+class AnalyticsContext {
+  const AnalyticsContext({
+    required this.app,
+    required this.env,
+    required this.library,
+    this.page,
+    this.extra = const {},
+  });
+
+  final String app;
+  final String env;
+  final AnalyticsLibrary library;
+  final AnalyticsPage? page;
+
+  /// Free-form additions contributed by `with(context)` children.
+  final Map<String, Object?> extra;
+
+  Map<String, Object?> toJson() {
+    final out = <String, Object?>{'app': app, 'env': env};
+    if (page != null) out['page'] = page!.toJson();
+    out.addAll(extra);
+    // `library` is fixed last (mirrors the TS spread order so `with()` cannot
+    // clobber the collector identity).
+    out['library'] = library.toJson();
+    return out;
+  }
+}
+
+/// The canonical Segment envelope. Every sink receives events in exactly this
+/// shape; the built-in HTTP sink ships it verbatim over the wire contract.
+class AnalyticsEvent {
+  const AnalyticsEvent({
+    required this.type,
+    required this.messageId,
+    required this.anonymousId,
+    required this.sessionId,
+    required this.context,
+    required this.timestamp,
+    required this.schemaVersion,
+    this.event,
+    this.userId,
+    this.groupId,
+    this.previousId,
+    this.properties,
+    this.traits,
+  });
+
+  /// Segment call type.
+  final AnalyticsEventType type;
+
+  /// Event name (track/screen) or page name (page).
+  final String? event;
+
+  /// Idempotency key — backends MUST dedupe on this.
+  final String messageId;
+
+  /// Persistent, non-PII, resettable client id.
+  final String anonymousId;
+
+  /// Opaque app-supplied id (set after identify).
+  final String? userId;
+
+  /// Group id (group calls).
+  final String? groupId;
+
+  /// Previous id (alias calls).
+  final String? previousId;
+
+  /// Analytics session id (UUIDv4, minted at session start).
+  final String sessionId;
+
+  /// track/page/screen/group payload.
+  final AnalyticsProperties? properties;
+
+  /// identify/group trait payload.
+  final AnalyticsProperties? traits;
+
+  /// Collector + product context.
+  final AnalyticsContext context;
+
+  /// ISO-8601 client timestamp.
+  final String timestamp;
+
+  /// Envelope schema version.
+  final int schemaVersion;
+
+  AnalyticsEvent copyWith({AnalyticsProperties? properties}) {
+    return AnalyticsEvent(
+      type: type,
+      event: event,
+      messageId: messageId,
+      anonymousId: anonymousId,
+      userId: userId,
+      groupId: groupId,
+      previousId: previousId,
+      sessionId: sessionId,
+      properties: properties ?? this.properties,
+      traits: traits,
+      context: context,
+      timestamp: timestamp,
+      schemaVersion: schemaVersion,
+    );
+  }
+
+  /// Canonical wire JSON — key order/shape identical to the TS envelope.
+  Map<String, Object?> toJson() {
+    final out = <String, Object?>{
+      'type': type.wire,
+      'messageId': messageId,
+      'anonymousId': anonymousId,
+      'sessionId': sessionId,
+    };
+    if (event != null) out['event'] = event;
+    if (userId != null) out['userId'] = userId;
+    if (groupId != null) out['groupId'] = groupId;
+    if (previousId != null) out['previousId'] = previousId;
+    if (properties != null) out['properties'] = properties;
+    if (traits != null) out['traits'] = traits;
+    out['context'] = context.toJson();
+    out['timestamp'] = timestamp;
+    out['schemaVersion'] = schemaVersion;
+    return out;
+  }
+}
+
+/// Context handed to `sink.init`.
+class SinkInitContext {
+  const SinkInitContext({required this.app, required this.env, this.endpoint});
+
+  final String app;
+  final String env;
+  final String? endpoint;
+}
+
+/// Context handed to every `sink.deliver`.
+class SinkDeliverContext {
+  const SinkDeliverContext({required this.unload});
+
+  /// True on the unload/background path — sinks should prefer a beacon.
+  final bool unload;
+}
+
+/// Sink SPI — implemented by adapter packages (GA4, Azure, PostHog) and by the
+/// built-in HTTP sink. A sink declares the consent categories it requires; the
+/// router will not deliver to a sink whose categories are not all granted.
+abstract class AnalyticsSink {
+  /// Stable sink identifier.
+  String get name;
+
+  /// Consent categories this sink requires (e.g. `['analytics']`).
+  List<String>? get consentCategories;
+
+  /// Called once before the first delivery.
+  FutureOr<void> init(SinkInitContext ctx) {}
+
+  /// Deliver a batch of canonical events.
+  FutureOr<void> deliver(List<AnalyticsEvent> batch, SinkDeliverContext ctx);
+
+  /// Flush any buffered state (best-effort).
+  FutureOr<void> flush() {}
+
+  /// Release resources on reset()/shutdown.
+  FutureOr<void> shutdown() {}
+}
+
+/// Cross-platform persistence SPI. The default picks platform storage
+/// (web localStorage / IO file) internally — invisible to the consumer.
+abstract class AnalyticsStorage {
+  String? get(String key);
+  void set(String key, String value);
+  void remove(String key);
+}
+
+/// Session engine configuration.
+class SessionConfig {
+  const SessionConfig({
+    this.timeoutMs,
+    this.resetOnCampaign,
+    this.storage,
+    this.storageKey,
+  });
+
+  /// Inactivity timeout in ms before a new session is minted. GA4 = 30 min.
+  final int? timeoutMs;
+
+  /// Reset the session when a campaign/utm change is detected.
+  final bool? resetOnCampaign;
+
+  /// Persistence backend; defaults to platform storage → memory.
+  final AnalyticsStorage? storage;
+
+  /// Storage key namespace.
+  final String? storageKey;
+}
+
+/// Identity engine configuration.
+class IdentityConfig {
+  const IdentityConfig({this.storage, this.storageKey});
+
+  final AnalyticsStorage? storage;
+  final String? storageKey;
+}
+
+/// Consent gate configuration.
+class ConsentConfig {
+  const ConsentConfig({this.granted, this.strict});
+
+  /// Categories granted at boot.
+  final List<String>? granted;
+
+  /// If true, an event is dropped entirely when NO sink can receive it.
+  /// If false (default), events are still buffered until consent is granted.
+  final bool? strict;
+}
+
+/// Consent gate runtime API.
+abstract class ConsentApi {
+  void grant(List<String> categories);
+  void revoke(List<String> categories);
+  List<String> granted();
+  bool isGranted(String category);
+}
+
+/// Session runtime API.
+abstract class SessionApi {
+  /// Current session id (mints one lazily if none active).
+  String id();
+
+  /// Force-start a new session, returning the new id.
+  String start();
+
+  /// End the current session.
+  void end();
+
+  /// Attach arbitrary session-scoped properties.
+  void set(AnalyticsProperties props);
+}
+
+/// HTTP transport SPI — the built-in HTTP sink talks to this, never to a
+/// concrete client. The default resolves a platform transport (dart:io /
+/// browser) via conditional import — platform difference is internal.
+abstract class HttpTransport {
+  /// Issue a POST. Returns the HTTP status code. Throw to signal a network
+  /// error (the sink treats a throw as transient → retry).
+  Future<int> post({
+    required String url,
+    required Map<String, String> headers,
+    required String body,
+  });
+
+  /// Best-effort beacon (unload/background path). Returns true if accepted.
+  bool beacon({required String url, required String body});
+}
+
+/// Built-in HTTP sink options (Segment HTTP Tracking API wire contract).
+class HttpSinkOptions {
+  const HttpSinkOptions({
+    required this.endpoint,
+    required this.writeKey,
+    this.maxRetries = 3,
+    this.backoffBaseMs = 500,
+    this.transport,
+    this.consentCategories = const ['analytics'],
+    this.maxBatchBytes = 500000,
+    this.maxEventBytes = 32000,
+    this.sleep,
+  });
+
+  /// Base endpoint; events POST to `{endpoint}/v{schemaVersion}/batch`.
+  final String endpoint;
+
+  /// Write key — sent as `Authorization: Basic base64(writeKey:)`.
+  final String writeKey;
+
+  /// Max retries for 429/5xx (exponential backoff). Default 3.
+  final int maxRetries;
+
+  /// Base backoff delay in ms. Default 500.
+  final int backoffBaseMs;
+
+  /// Injected transport (defaults to the resolved platform transport).
+  final HttpTransport? transport;
+
+  /// Consent categories this sink requires. Default `['analytics']`.
+  final List<String> consentCategories;
+
+  /// Soft per-batch byte cap (Segment ≈ 500KB). Default 500000.
+  final int maxBatchBytes;
+
+  /// Soft per-event byte cap (Segment ≈ 32KB). Default 32000.
+  final int maxEventBytes;
+
+  /// Injected sleep (for deterministic backoff tests).
+  final Future<void> Function(Duration)? sleep;
+}
+
+/// `createAnalytics` configuration.
+class AnalyticsConfig {
+  const AnalyticsConfig({
+    required this.app,
+    required this.env,
+    this.endpoint,
+    this.writeKey,
+    this.enabled = true,
+    this.sampleRate = 1,
+    this.redactKeys = const [],
+    this.sinks = const [],
+    this.session,
+    this.identity,
+    this.consent,
+    this.preset,
+    this.batchSize = 20,
+    this.flushIntervalMs = 10000,
+    this.httpTransport,
+    this.random,
+    this.now,
+  });
+
+  /// Product/app identifier (stamped into context.app).
+  final String app;
+
+  /// Environment, e.g. 'development' | 'production'. Drives presets.
+  final String env;
+
+  /// When set, a built-in HTTP sink is auto-registered to this endpoint.
+  final String? endpoint;
+
+  /// Write key for the auto-registered HTTP sink.
+  final String? writeKey;
+
+  /// Kill switch — when false, a tree-shakeable noop is returned. Default true.
+  final bool enabled;
+
+  /// 0..1 sampling rate applied per top-level call. Default 1.
+  final double sampleRate;
+
+  /// Extra property/trait keys to redact (in addition to the PII deny-list).
+  final List<String> redactKeys;
+
+  /// Explicit sinks (in addition to / instead of the auto HTTP sink).
+  final List<AnalyticsSink> sinks;
+
+  /// Session engine config.
+  final SessionConfig? session;
+
+  /// Identity engine config.
+  final IdentityConfig? identity;
+
+  /// Consent gate config.
+  final ConsentConfig? consent;
+
+  /// Force a preset. Defaults: env=='production' → 'prod', else 'dev'.
+  final String? preset;
+
+  /// Batch size before an automatic flush (prod). Default 20.
+  final int batchSize;
+
+  /// Auto-flush interval in ms (prod). Default 10000.
+  final int flushIntervalMs;
+
+  /// Transport for the auto-registered HTTP sink (test injection).
+  final HttpTransport? httpTransport;
+
+  /// Injected RNG for deterministic sampling tests (0..1).
+  final double Function()? random;
+
+  /// Injected clock (epoch ms) for deterministic session tests.
+  final int Function()? now;
+}
+
+/// Options accepted by every top-level call.
+class CallOptions {
+  const CallOptions({this.timestamp, this.context});
+
+  /// Per-call timestamp override (ISO-8601).
+  final String? timestamp;
+
+  /// Per-call context overrides (shallow-merged into context.extra).
+  final Map<String, Object?>? context;
+}
+
+/// The public analytics surface returned by `createAnalytics`.
+abstract class Analytics {
+  void track(
+    String event, [
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]);
+  void identify(
+    String userId, [
+    AnalyticsProperties? traits,
+    CallOptions? opts,
+  ]);
+  void page([String? name, AnalyticsProperties? properties, CallOptions? opts]);
+  void screen([
+    String? name,
+    AnalyticsProperties? properties,
+    CallOptions? opts,
+  ]);
+  void group(String groupId, [AnalyticsProperties? traits, CallOptions? opts]);
+  void alias(String userId, [String? previousId, CallOptions? opts]);
+
+  /// Analytics-session API (NOT replay).
+  SessionApi get session;
+
+  /// Consent gate API.
+  ConsentApi get consent;
+
+  /// Persistent, non-PII anonymous id.
+  String anonymousId();
+
+  /// Current opaque user id (if identified).
+  String? userId();
+
+  /// Derive a child that merges extra context into every event.
+  Analytics withContext(Map<String, Object?> context);
+
+  /// Register an additional sink at runtime.
+  void addSink(AnalyticsSink sink);
+
+  /// Remove a sink by name.
+  void removeSink(String name);
+
+  /// Registered sink names.
+  List<String> get sinks;
+
+  /// Flush all sinks (and the internal batch).
+  Future<void> flush();
+
+  /// Reset identity + session (privacy-safe logout). Mints a fresh
+  /// anonymousId and ends the session.
+  void reset();
+
+  /// Whether this is a live collector (false for the noop).
+  bool get enabled;
+}

--- a/packages/flutter/lib/src/analytics/uuid.dart
+++ b/packages/flutter/lib/src/analytics/uuid.dart
@@ -1,0 +1,46 @@
+/// uuidv4 — RFC 4122 version 4 UUID.
+///
+/// Uses `Random.secure()` when available and degrades to a non-secure
+/// `Random` only as a last resort. No external dependency by design (this is
+/// the neutral router; the package ships zero deps beyond Flutter).
+library;
+
+import 'dart:math';
+
+Random _rng() {
+  try {
+    return Random.secure();
+  } catch (_) {
+    return Random();
+  }
+}
+
+/// Generate an RFC 4122 v4 UUID.
+String uuidv4([Random? random]) {
+  final rng = random ?? _rng();
+  final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+
+  // Per RFC 4122 §4.4: set version (4) and variant (10xx) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  String hex(int b) => b.toRadixString(16).padLeft(2, '0');
+
+  final b = bytes.map(hex).toList();
+  return '${b[0]}${b[1]}${b[2]}${b[3]}-'
+      '${b[4]}${b[5]}-'
+      '${b[6]}${b[7]}-'
+      '${b[8]}${b[9]}-'
+      '${b[10]}${b[11]}${b[12]}${b[13]}${b[14]}${b[15]}';
+}
+
+/// RFC 4122 v4 shape matcher (case-insensitive).
+final RegExp uuidV4Re = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+  caseSensitive: false,
+);
+
+/// True when [value] is a well-formed v4 UUID.
+bool isUuidV4(Object? value) {
+  return value is String && uuidV4Re.hasMatch(value);
+}

--- a/packages/flutter/test/analytics/analytics_manager_test.dart
+++ b/packages/flutter/test/analytics/analytics_manager_test.dart
@@ -1,0 +1,369 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart'
+    hide createMockSink, MockSinkExtended;
+// Test-only mock sink — imported directly (intentionally NOT re-exported by
+// the analytics or package barrels, where it would collide with telemetry's
+// flat-barrel createMockSink / MockSinkExtended).
+import 'package:refraction_ui/src/analytics/mock_sink.dart';
+
+/// Let the dev-preset microtask delivery settle.
+Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+({Analytics a, MockSink sink}) devConfig({
+  MockSink? sink,
+  double sampleRate = 1,
+  List<String> redactKeys = const [],
+  double Function()? random,
+}) {
+  final s = sink ?? createMockSink();
+  final a = createAnalytics(
+    AnalyticsConfig(
+      app: 'test-app',
+      env: 'development',
+      sinks: [s],
+      session: SessionConfig(storage: createMemoryStorage()),
+      identity: IdentityConfig(storage: createMemoryStorage()),
+      consent: const ConsentConfig(granted: ['analytics']),
+      sampleRate: sampleRate,
+      redactKeys: redactKeys,
+      random: random,
+    ),
+  );
+  return (a: a, sink: s);
+}
+
+void main() {
+  group('createAnalytics — envelope shape', () {
+    test('emits a canonical Segment track envelope', () async {
+      final c = devConfig();
+      c.a.track('Signup Clicked', {'plan': 'pro'});
+      await pump();
+      expect(c.sink.events, hasLength(1));
+      final ev = c.sink.events[0];
+      expect(ev.type, AnalyticsEventType.track);
+      expect(ev.event, 'Signup Clicked');
+      expect(ev.properties, containsPair('plan', 'pro'));
+      expect(isUuidV4(ev.messageId), isTrue);
+      expect(isUuidV4(ev.anonymousId), isTrue);
+      expect(isUuidV4(ev.sessionId), isTrue);
+      expect(ev.schemaVersion, kSchemaVersion);
+      expect(DateTime.tryParse(ev.timestamp), isNotNull);
+      expect(ev.context.app, 'test-app');
+      expect(ev.context.env, 'development');
+      expect(ev.context.library.name, '@refraction-ui/analytics');
+      // Wire JSON shape.
+      final json = ev.toJson();
+      expect(json['type'], 'track');
+      expect(json['schemaVersion'], kSchemaVersion);
+      expect((json['context'] as Map)['library'], isNotNull);
+    });
+
+    test('every call type produces the right envelope', () async {
+      final c = devConfig();
+      c.a.identify('user_1', {'plan': 'pro', 'email': 'a@b.com'});
+      c.a.page('Home', {'path': '/'});
+      c.a.screen('Dashboard');
+      c.a.group('org_1', {'name': 'Acme'});
+      c.a.alias('user_2', 'user_1');
+      await pump();
+
+      final byType = {for (final e in c.sink.events) e.type: e};
+      expect(
+        byType[AnalyticsEventType.identify]!.traits,
+        containsPair('plan', 'pro'),
+      );
+      // PII redaction applied to identify traits.
+      expect(
+        byType[AnalyticsEventType.identify]!.traits!['email'],
+        '[REDACTED]',
+      );
+      expect(byType[AnalyticsEventType.identify]!.userId, 'user_1');
+      expect(byType[AnalyticsEventType.page]!.event, 'Home');
+      expect(byType[AnalyticsEventType.screen]!.event, 'Dashboard');
+      expect(byType[AnalyticsEventType.group]!.groupId, 'org_1');
+      // group trait `name` is redacted by the exact-match rule.
+      expect(byType[AnalyticsEventType.group]!.traits!['name'], '[REDACTED]');
+      expect(byType[AnalyticsEventType.alias]!.previousId, 'user_1');
+      expect(byType[AnalyticsEventType.alias]!.userId, 'user_2');
+    });
+
+    test('redacts PII in track properties via the deny-list', () async {
+      final c = devConfig();
+      c.a.track('Form Submitted', {'email': 'a@b.com', 'value': 42});
+      await pump();
+      expect(c.sink.events[0].properties, {'email': '[REDACTED]', 'value': 42});
+    });
+
+    test('redacts caller-supplied redactKeys', () async {
+      final c = devConfig(redactKeys: ['internalScore']);
+      c.a.track('X', {'internalScore': 99, 'ok': 1});
+      await pump();
+      expect(c.sink.events[0].properties, {
+        'internalScore': '[REDACTED]',
+        'ok': 1,
+      });
+    });
+  });
+
+  group('createAnalytics — identity & session', () {
+    test('binds userId after identify and clears it on reset', () {
+      final c = devConfig();
+      expect(c.a.userId(), isNull);
+      c.a.identify('user_9');
+      expect(c.a.userId(), 'user_9');
+      final anonBefore = c.a.anonymousId();
+      c.a.reset();
+      expect(c.a.userId(), isNull);
+      expect(c.a.anonymousId(), isNot(anonBefore));
+    });
+
+    test('exposes a working session API', () {
+      final c = devConfig();
+      final id1 = c.a.session.id();
+      expect(isUuidV4(id1), isTrue);
+      final id2 = c.a.session.start();
+      expect(id2, isNot(id1));
+      c.a.session.end();
+    });
+
+    test('shares one sessionId across events in a session', () async {
+      final c = devConfig();
+      c.a.track('A');
+      c.a.track('B');
+      await pump();
+      expect(c.sink.events[0].sessionId, c.sink.events[1].sessionId);
+    });
+  });
+
+  group('createAnalytics — withContext child', () {
+    test(
+      'merges child context into every event without affecting parent',
+      () async {
+        final c = devConfig();
+        final child = c.a.withContext({'feature': 'checkout'});
+        child.track('Child Event');
+        c.a.track('Parent Event');
+        await pump();
+        final childEv = c.sink.events.firstWhere(
+          (e) => e.event == 'Child Event',
+        );
+        final parentEv = c.sink.events.firstWhere(
+          (e) => e.event == 'Parent Event',
+        );
+        expect(childEv.context.extra['feature'], 'checkout');
+        expect(parentEv.context.extra['feature'], isNull);
+      },
+    );
+
+    test('child shares identity/session/sinks with the parent', () {
+      final c = devConfig();
+      final child = c.a.withContext(const {});
+      expect(child.anonymousId(), c.a.anonymousId());
+      child.addSink(createMockSink(name: 'extra'));
+      expect(c.a.sinks, contains('extra'));
+    });
+  });
+
+  group('createAnalytics — sink registry', () {
+    test('lists, adds, and removes sinks', () {
+      final c = devConfig();
+      expect(c.a.sinks, contains('mock'));
+      c.a.addSink(createMockSink(name: 'extra'));
+      expect(c.a.sinks, contains('extra'));
+      c.a.removeSink('extra');
+      expect(c.a.sinks, isNot(contains('extra')));
+    });
+
+    test('calls sink.init exactly once before the first deliver', () async {
+      final c = devConfig();
+      c.a.track('A');
+      c.a.track('B');
+      await pump();
+      expect(c.sink.initCalls, hasLength(1));
+      expect(c.sink.initCalls[0].app, 'test-app');
+      expect(c.sink.initCalls[0].env, 'development');
+    });
+
+    test('auto-registers a built-in http sink when endpoint is set', () {
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'x',
+          env: 'development',
+          endpoint: 'https://t.example.com',
+          writeKey: 'wk',
+          session: SessionConfig(storage: createMemoryStorage()),
+          identity: IdentityConfig(storage: createMemoryStorage()),
+        ),
+      );
+      expect(a.sinks, contains('http'));
+    });
+
+    test('dev preset auto-adds a console sink', () {
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'x',
+          env: 'development',
+          session: SessionConfig(storage: createMemoryStorage()),
+          identity: IdentityConfig(storage: createMemoryStorage()),
+        ),
+      );
+      expect(a.sinks, contains('console'));
+    });
+  });
+
+  group('createAnalytics — consent gating', () {
+    test(
+      'does not deliver to a sink whose categories are not granted',
+      () async {
+        final open = createMockSink(name: 'open');
+        final gated = createMockSink(
+          name: 'gated',
+          consentCategories: ['marketing'],
+        );
+        final a = createAnalytics(
+          AnalyticsConfig(
+            app: 'x',
+            env: 'development',
+            sinks: [open, gated],
+            session: SessionConfig(storage: createMemoryStorage()),
+            identity: IdentityConfig(storage: createMemoryStorage()),
+            consent: const ConsentConfig(granted: []),
+          ),
+        );
+        a.track('A');
+        await pump();
+        expect(open.events, hasLength(1));
+        expect(gated.events, isEmpty);
+
+        a.consent.grant(['marketing']);
+        a.track('B');
+        await pump();
+        expect(gated.events, hasLength(1));
+      },
+    );
+
+    test('per-sink categories are independent', () async {
+      final analyticsSink = createMockSink(
+        name: 's-analytics',
+        consentCategories: ['analytics'],
+      );
+      final marketingSink = createMockSink(
+        name: 's-marketing',
+        consentCategories: ['marketing'],
+      );
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'x',
+          env: 'development',
+          sinks: [analyticsSink, marketingSink],
+          session: SessionConfig(storage: createMemoryStorage()),
+          identity: IdentityConfig(storage: createMemoryStorage()),
+          consent: const ConsentConfig(granted: ['analytics']),
+        ),
+      );
+      a.track('A');
+      await pump();
+      expect(analyticsSink.events, hasLength(1));
+      expect(marketingSink.events, isEmpty);
+    });
+  });
+
+  group('createAnalytics — batching (prod preset)', () {
+    ({Analytics a, MockSink sink}) prod({int batchSize = 3}) {
+      final s = createMockSink();
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'x',
+          env: 'production',
+          preset: 'prod',
+          batchSize: batchSize,
+          sinks: [s],
+          session: SessionConfig(storage: createMemoryStorage()),
+          identity: IdentityConfig(storage: createMemoryStorage()),
+          consent: const ConsentConfig(granted: ['analytics']),
+        ),
+      );
+      return (a: a, sink: s);
+    }
+
+    test('buffers events and flushes when batchSize is reached', () async {
+      final c = prod(batchSize: 3);
+      c.a.track('1');
+      c.a.track('2');
+      expect(c.sink.events, isEmpty); // still buffered
+      c.a.track('3'); // hits batchSize → auto-flush
+      await pump();
+      expect(c.sink.events, hasLength(3));
+      expect(c.sink.deliveries[0].batch, hasLength(3));
+    });
+
+    test('flush() drains the buffer on demand', () async {
+      final c = prod(batchSize: 100);
+      c.a.track('1');
+      c.a.track('2');
+      expect(c.sink.events, isEmpty);
+      await c.a.flush();
+      expect(c.sink.events, hasLength(2));
+    });
+
+    test('dev preset delivers without batching', () async {
+      final c = devConfig();
+      c.a.track('immediate');
+      await pump();
+      expect(c.sink.events, hasLength(1));
+    });
+  });
+
+  group('createAnalytics — sampling', () {
+    test('drops events below the sample rate', () async {
+      var roll = 0.9;
+      final c = devConfig(sampleRate: 0.5, random: () => roll);
+      c.a.track('dropped');
+      await pump();
+      expect(c.sink.events, isEmpty);
+      roll = 0.1;
+      c.a.track('kept');
+      await pump();
+      expect(c.sink.events, hasLength(1));
+    });
+
+    test('sampleRate >= 1 keeps everything', () async {
+      final c = devConfig(sampleRate: 1);
+      c.a.track('a');
+      c.a.track('b');
+      await pump();
+      expect(c.sink.events, hasLength(2));
+    });
+  });
+
+  group('createAnalytics — noop kill switch', () {
+    test('returns a noop when enabled:false', () {
+      final sink = createMockSink();
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'x',
+          env: 'production',
+          enabled: false,
+          sinks: [sink],
+        ),
+      );
+      expect(a.enabled, isFalse);
+      a.track('nope');
+      a.identify('user');
+      a.page();
+      expect(sink.events, isEmpty);
+      expect(a.sinks, isEmpty);
+      expect(a.userId(), isNull);
+      expect(() {
+        a.session.start();
+        a.consent.grant(['analytics']);
+        a.withContext(const {}).track('still nothing');
+        a.reset();
+      }, returnsNormally);
+    });
+
+    test('a live collector reports enabled:true', () {
+      expect(devConfig().a.enabled, isTrue);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/consent_test.dart
+++ b/packages/flutter/test/analytics/consent_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('Consent', () {
+    test('starts with nothing granted by default', () {
+      final c = Consent(null);
+      expect(c.granted(), isEmpty);
+      expect(c.isGranted('analytics'), isFalse);
+    });
+
+    test('seeds granted categories from config', () {
+      final c = Consent(
+        const ConsentConfig(granted: ['analytics', 'marketing']),
+      );
+      expect(c.isGranted('analytics'), isTrue);
+      expect(c.isGranted('marketing'), isTrue);
+    });
+
+    test('grant/revoke mutate the granted set', () {
+      final c = Consent(null);
+      c.grant(['analytics', 'marketing']);
+      expect(c.granted()..sort(), ['analytics', 'marketing']);
+      c.revoke(['marketing']);
+      expect(c.isGranted('marketing'), isFalse);
+      expect(c.isGranted('analytics'), isTrue);
+    });
+
+    test('allows() requires ALL categories of a sink (per-sink gating)', () {
+      final c = Consent(const ConsentConfig(granted: ['analytics']));
+      expect(c.allows(null), isTrue);
+      expect(c.allows([]), isTrue);
+      expect(c.allows(['analytics']), isTrue);
+      expect(c.allows(['analytics', 'marketing']), isFalse);
+      c.grant(['marketing']);
+      expect(c.allows(['analytics', 'marketing']), isTrue);
+    });
+
+    test('exposes the strict flag from config', () {
+      expect(Consent(null).strict, isFalse);
+      expect(Consent(const ConsentConfig(strict: true)).strict, isTrue);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/http_sink_test.dart
+++ b/packages/flutter/test/analytics/http_sink_test.dart
@@ -1,0 +1,469 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+const ctxOnline = SinkDeliverContext(unload: false);
+const ctxUnload = SinkDeliverContext(unload: true);
+
+AnalyticsEvent makeEvent({String event = 'Test'}) => AnalyticsEvent(
+  type: AnalyticsEventType.track,
+  event: event,
+  messageId: 'mid-${DateTime.now().microsecondsSinceEpoch}-$event',
+  anonymousId: 'anon-1',
+  sessionId: 'sess-1',
+  properties: const {'a': 1},
+  context: const AnalyticsContext(
+    app: 'app',
+    env: 'test',
+    library: AnalyticsLibrary(
+      name: '@refraction-ui/analytics',
+      version: '0.1.0',
+    ),
+  ),
+  timestamp: DateTime.now().toUtc().toIso8601String(),
+  schemaVersion: kSchemaVersion,
+);
+
+class RecordedCall {
+  RecordedCall(this.url, this.headers, this.body);
+  final String url;
+  final Map<String, String> headers;
+  final Map<String, Object?> body;
+}
+
+class RecordedBeacon {
+  RecordedBeacon(this.url, this.body);
+  final String url;
+  final String body;
+}
+
+/// A mock backend transport conforming to the Segment HTTP Tracking API wire
+/// contract. `responder` returns the status code for the Nth call (0-based).
+class MockBackend implements HttpTransport {
+  MockBackend({int Function(int call)? responder, this.throwOnCall})
+    : _responder = responder ?? ((_) => 200);
+
+  final int Function(int call) _responder;
+  final int? throwOnCall;
+
+  final List<RecordedCall> calls = [];
+  final List<RecordedBeacon> beacons = [];
+  bool beaconReturns = true;
+  int _n = 0;
+
+  @override
+  Future<int> post({
+    required String url,
+    required Map<String, String> headers,
+    required String body,
+  }) async {
+    final i = _n++;
+    if (throwOnCall != null && i < throwOnCall!) {
+      throw StateError('network down');
+    }
+    calls.add(
+      RecordedCall(url, headers, jsonDecode(body) as Map<String, Object?>),
+    );
+    return _responder(i);
+  }
+
+  @override
+  bool beacon({required String url, required String body}) {
+    beacons.add(RecordedBeacon(url, body));
+    return beaconReturns;
+  }
+}
+
+/// Deterministic, zero-delay sleep so backoff retry tests run instantly.
+Future<void> noSleep(Duration _) => Future<void>.value();
+
+void main() {
+  group('http sink — Segment wire contract: batch format', () {
+    test(
+      'POSTs to {endpoint}/v{schemaVersion}/batch with the envelope',
+      () async {
+        final be = MockBackend();
+        final sink = createHttpSink(
+          HttpSinkOptions(
+            endpoint: 'https://collector.example.com/',
+            writeKey: 'WK123',
+            transport: be,
+          ),
+        );
+        await sink.deliver([
+          makeEvent(event: 'A'),
+          makeEvent(event: 'B'),
+        ], ctxOnline);
+
+        expect(be.calls, hasLength(1));
+        final call = be.calls[0];
+        expect(
+          call.url,
+          'https://collector.example.com/v$kSchemaVersion/batch',
+        );
+        expect(call.headers['Content-Type'], 'application/json');
+
+        final batch = (call.body['batch'] as List).cast<Map<String, Object?>>();
+        expect(batch, hasLength(2));
+        expect(batch[0]['event'], 'A');
+        expect(call.body['sentAt'], isA<String>());
+        expect(DateTime.tryParse(call.body['sentAt'] as String), isNotNull);
+        expect(isUuidV4(call.body['batchId']), isTrue);
+      },
+    );
+
+    test(
+      'sends Authorization: Basic base64(writeKey:) — trailing colon',
+      () async {
+        final be = MockBackend();
+        final sink = createHttpSink(
+          HttpSinkOptions(
+            endpoint: 'https://c.example.com',
+            writeKey: 'WK123',
+            transport: be,
+          ),
+        );
+        await sink.deliver([makeEvent()], ctxOnline);
+        expect(
+          be.calls[0].headers['Authorization'],
+          'Basic ${base64.encode(utf8.encode('WK123:'))}',
+        );
+      },
+    );
+
+    test('every event carries a distinct messageId idempotency key', () async {
+      final be = MockBackend();
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+        ),
+      );
+      await sink.deliver([
+        makeEvent(event: 'A'),
+        makeEvent(event: 'B'),
+      ], ctxOnline);
+      final batch = (be.calls[0].body['batch'] as List)
+          .cast<Map<String, Object?>>();
+      for (final ev in batch) {
+        expect(ev['messageId'], isA<String>());
+        expect((ev['messageId'] as String).isNotEmpty, isTrue);
+      }
+      expect(batch[0]['messageId'], isNot(batch[1]['messageId']));
+    });
+
+    test('does nothing for an empty batch', () async {
+      final be = MockBackend();
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+        ),
+      );
+      await sink.deliver([], ctxOnline);
+      expect(be.calls, isEmpty);
+    });
+  });
+
+  group('http sink — response codes', () {
+    test('200 accept-and-queue → no retry', () async {
+      final be = MockBackend(responder: (_) => 200);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(1));
+    });
+
+    test('400 malformed → DROP, never retry', () async {
+      final be = MockBackend(responder: (_) => 400);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 5,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(1));
+    });
+
+    test('401 bad key → DROP, never retry', () async {
+      final be = MockBackend(responder: (_) => 401);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 5,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(1));
+    });
+
+    test('413 too large → DROP, never retry', () async {
+      final be = MockBackend(responder: (_) => 413);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 5,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(1));
+    });
+
+    test('429 → backoff retry then give up after maxRetries', () async {
+      final be = MockBackend(responder: (_) => 429);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 3,
+          backoffBaseMs: 1,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      // initial + 3 retries = 4 attempts
+      expect(be.calls, hasLength(4));
+    });
+
+    test('5xx → retried, then succeeds when the backend recovers', () async {
+      final be = MockBackend(responder: (n) => n < 2 ? 503 : 200);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 5,
+          backoffBaseMs: 1,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(3)); // 503, 503, 200
+    });
+
+    test('uses increasing backoff delays between retries', () async {
+      final delays = <int>[];
+      final be = MockBackend(responder: (_) => 500);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 2,
+          backoffBaseMs: 100,
+          transport: be,
+          sleep: (d) {
+            delays.add(d.inMilliseconds);
+            return Future<void>.value();
+          },
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, hasLength(3)); // initial + 2 retries
+      expect(delays, [100, 200]); // exponential: base*2^attempt
+    });
+
+    test('network error is treated as transient and retried', () async {
+      final be = MockBackend(throwOnCall: 1, responder: (_) => 200);
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          maxRetries: 3,
+          backoffBaseMs: 1,
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      // 1st throws (counted in _n), 2nd returns 200 and is recorded.
+      expect(be.calls, hasLength(1));
+    });
+  });
+
+  group('http sink — beacon fallback (unload path)', () {
+    test(
+      'uses beacon with ?writeKey= query (no Authorization header)',
+      () async {
+        final be = MockBackend();
+        final sink = createHttpSink(
+          HttpSinkOptions(
+            endpoint: 'https://c.example.com',
+            writeKey: 'WK secret/with+special',
+            transport: be,
+          ),
+        );
+        await sink.deliver([makeEvent()], ctxUnload);
+
+        expect(be.beacons, hasLength(1));
+        expect(be.calls, isEmpty); // beacon used, not POST
+        final b = be.beacons[0];
+        expect(b.url, contains('/v$kSchemaVersion/batch'));
+        expect(
+          b.url,
+          contains(
+            'writeKey=${Uri.encodeQueryComponent('WK secret/with+special')}',
+          ),
+        );
+        final parsed = jsonDecode(b.body) as Map<String, Object?>;
+        expect((parsed['batch'] as List), hasLength(1));
+        expect(isUuidV4(parsed['batchId']), isTrue);
+      },
+    );
+
+    test('falls back to keepalive POST when beacon is unavailable', () async {
+      final be = MockBackend()..beaconReturns = false;
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxUnload);
+      // beacon attempted (returned false) → POST fallback fired.
+      expect(be.beacons, hasLength(1));
+      // Allow the unawaited fallback POST to complete.
+      await Future<void>.delayed(Duration.zero);
+      expect(be.calls, hasLength(1));
+    });
+
+    test('online path never uses beacon', () async {
+      final be = MockBackend();
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.beacons, isEmpty);
+      expect(be.calls, hasLength(1));
+    });
+  });
+
+  group('http sink — size limits', () {
+    test('splits a batch that exceeds the per-batch byte cap', () async {
+      final be = MockBackend();
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+          maxBatchBytes: 400, // tiny → forces splitting
+          maxEventBytes: 32000,
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([
+        makeEvent(),
+        makeEvent(),
+        makeEvent(),
+        makeEvent(),
+      ], ctxOnline);
+      expect(be.calls.length, greaterThan(1));
+      final total = be.calls.fold<int>(
+        0,
+        (sum, c) => sum + (c.body['batch'] as List).length,
+      );
+      expect(total, 4); // no events lost during splitting
+    });
+
+    test('drops a single event larger than the per-event byte cap', () async {
+      final be = MockBackend();
+      final sink = createHttpSink(
+        HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: be,
+          maxEventBytes: 100, // smaller than any real event
+          sleep: noSleep,
+        ),
+      );
+      await sink.deliver([makeEvent()], ctxOnline);
+      expect(be.calls, isEmpty); // oversized → unsendable, dropped
+    });
+  });
+
+  group('http sink — consent categories', () {
+    test('defaults to requiring the analytics category', () {
+      final sink = createHttpSink(
+        const HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          transport: null,
+        ),
+      );
+      expect(sink.consentCategories, ['analytics']);
+    });
+
+    test('honours a custom consentCategories list', () {
+      final sink = createHttpSink(
+        const HttpSinkOptions(
+          endpoint: 'https://c.example.com',
+          writeKey: 'k',
+          consentCategories: ['marketing', 'analytics'],
+        ),
+      );
+      expect(sink.consentCategories, ['marketing', 'analytics']);
+    });
+  });
+
+  group('http sink — end-to-end via createAnalytics (prod relay)', () {
+    test('routes the canonical batch to the consumer endpoint', () async {
+      final be = MockBackend();
+      final a = createAnalytics(
+        AnalyticsConfig(
+          app: 'shop',
+          env: 'production',
+          preset: 'prod',
+          batchSize: 2,
+          endpoint: 'https://collect.consumer.example',
+          writeKey: 'CONSUMER_KEY',
+          httpTransport: be,
+          session: SessionConfig(storage: createMemoryStorage()),
+          identity: IdentityConfig(storage: createMemoryStorage()),
+          consent: const ConsentConfig(granted: ['analytics']),
+        ),
+      );
+      a.track('Add To Cart', {'sku': 'A1'});
+      a.track('Checkout', {'total': 42});
+      await Future<void>.delayed(Duration.zero);
+
+      expect(be.calls, hasLength(1));
+      final call = be.calls[0];
+      expect(call.url, 'https://collect.consumer.example/v1/batch');
+      expect(
+        call.headers['Authorization'],
+        'Basic ${base64.encode(utf8.encode('CONSUMER_KEY:'))}',
+      );
+      final batch = (call.body['batch'] as List).cast<Map<String, Object?>>();
+      expect(batch, hasLength(2));
+      expect(batch[0]['event'], 'Add To Cart');
+      expect(batch[0]['context'], isNotNull);
+      expect(batch[0]['schemaVersion'], 1);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/identity_test.dart
+++ b/packages/flutter/test/analytics/identity_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('Identity — anonymousId', () {
+    test('mints a UUIDv4 anonymousId on first use', () {
+      final id = Identity(IdentityConfig(storage: createMemoryStorage()));
+      expect(isUuidV4(id.anonymousId()), isTrue);
+    });
+
+    test('persists the anonymousId across instances (cross-tab)', () {
+      final storage = createMemoryStorage();
+      final a = Identity(IdentityConfig(storage: storage));
+      final b = Identity(IdentityConfig(storage: storage));
+      expect(b.anonymousId(), a.anonymousId());
+    });
+
+    test('ignores a corrupt persisted value and re-mints', () {
+      final storage = createMemoryStorage();
+      storage.set('rfx:analytics:anon', 'garbage-not-a-uuid');
+      final id = Identity(IdentityConfig(storage: storage));
+      expect(isUuidV4(id.anonymousId()), isTrue);
+    });
+  });
+
+  group('Identity — userId (opaque, app-supplied)', () {
+    test('is null until identify()', () {
+      final id = Identity(IdentityConfig(storage: createMemoryStorage()));
+      expect(id.userId(), isNull);
+    });
+
+    test('stores the opaque user id verbatim and does not persist it', () {
+      final storage = createMemoryStorage();
+      final id = Identity(IdentityConfig(storage: storage));
+      id.setUserId('user_42');
+      expect(id.userId(), 'user_42');
+      expect(storage.get('rfx:analytics:anon'), isNot(contains('user_42')));
+    });
+  });
+
+  group('Identity — alias stitching', () {
+    test('stitches anonymous → user when no prior user', () {
+      final id = Identity(IdentityConfig(storage: createMemoryStorage()));
+      final anon = id.anonymousId();
+      final stitch = id.alias('user_1');
+      expect(stitch.previousId, anon);
+      expect(stitch.userId, 'user_1');
+      expect(id.userId(), 'user_1');
+    });
+
+    test('stitches old user → new user', () {
+      final id = Identity(IdentityConfig(storage: createMemoryStorage()));
+      id.setUserId('old');
+      final stitch = id.alias('new');
+      expect(stitch.previousId, 'old');
+      expect(stitch.userId, 'new');
+    });
+
+    test('honours an explicit previousId', () {
+      final id = Identity(IdentityConfig(storage: createMemoryStorage()));
+      final stitch = id.alias('new', 'explicit-prev');
+      expect(stitch.previousId, 'explicit-prev');
+    });
+  });
+
+  group('Identity — reset (privacy-safe logout)', () {
+    test('mints a fresh anonymousId and clears the user binding', () {
+      final storage = createMemoryStorage();
+      final id = Identity(IdentityConfig(storage: storage));
+      final before = id.anonymousId();
+      id.setUserId('user_1');
+      final fresh = id.reset();
+      expect(fresh, isNot(before));
+      expect(id.anonymousId(), fresh);
+      expect(id.userId(), isNull);
+      expect(storage.get('rfx:analytics:anon'), fresh);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/redaction_test.dart
+++ b/packages/flutter/test/analytics/redaction_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('Redactor — built-in PII deny-list', () {
+    test('redacts email/phone/name and common variants', () {
+      final r = Redactor();
+      final out = r.redact({
+        'email': 'a@b.com',
+        'userEmail': 'c@d.com',
+        'email_address': 'e@f.com',
+        'phone': '+1555',
+        'phoneNumber': '+1556',
+        'firstName': 'Ada',
+        'lastName': 'Lovelace',
+        'fullName': 'Ada Lovelace',
+        'plan': 'pro',
+      })!;
+      expect(out['email'], redacted);
+      expect(out['userEmail'], redacted);
+      expect(out['email_address'], redacted);
+      expect(out['phone'], redacted);
+      expect(out['phoneNumber'], redacted);
+      expect(out['firstName'], redacted);
+      expect(out['lastName'], redacted);
+      expect(out['fullName'], redacted);
+      expect(out['plan'], 'pro');
+    });
+
+    test('exposes the deny-list and redaction token', () {
+      expect(piiDenyList, contains('email'));
+      expect(piiDenyList, contains('phone'));
+      expect(redacted, '[REDACTED]');
+    });
+
+    test('recurses into nested maps and lists', () {
+      final r = Redactor();
+      final out = r.redact({
+        'profile': {'email': 'x@y.com', 'tier': 'gold'},
+        'contacts': [
+          {'phone': '111'},
+          {'phone': '222'},
+        ],
+      })!;
+      final profile = out['profile'] as Map<String, Object?>;
+      expect(profile['email'], redacted);
+      expect(profile['tier'], 'gold');
+      final contacts = (out['contacts'] as List).cast<Map<String, Object?>>();
+      expect(contacts[0]['phone'], redacted);
+      expect(contacts[1]['phone'], redacted);
+    });
+
+    test('does not mutate the input map', () {
+      final r = Redactor();
+      final input = {'email': 'a@b.com'};
+      r.redact(input);
+      expect(input['email'], 'a@b.com');
+    });
+
+    test('returns null for null input', () {
+      expect(Redactor().redact(null), isNull);
+    });
+
+    test('redacts the exact "name" key but not compounds like userName', () {
+      final r = Redactor();
+      final out = r.redact({
+        'name': 'Ada',
+        'userName': 'ada99',
+        'eventName': 'Signup',
+      })!;
+      expect(out['name'], redacted);
+      expect(out['userName'], 'ada99');
+      expect(out['eventName'], 'Signup');
+    });
+  });
+
+  group('Redactor — caller redactKeys', () {
+    test('redacts extra keys exactly (normalised, case-insensitive)', () {
+      final r = Redactor(['internalScore', 'secret_token']);
+      final out = r.redact({
+        'internalScore': 99,
+        'InternalScore': 98,
+        'secretToken': 'abc',
+        'keep': 'ok',
+      })!;
+      expect(out['internalScore'], redacted);
+      expect(out['InternalScore'], redacted);
+      expect(out['secretToken'], redacted);
+      expect(out['keep'], 'ok');
+    });
+
+    test('shouldRedact reflects both deny-list and extra keys', () {
+      final r = Redactor(['campaignBudget']);
+      expect(r.shouldRedact('email'), isTrue);
+      expect(r.shouldRedact('campaignBudget'), isTrue);
+      expect(r.shouldRedact('eventName'), isFalse);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/session_test.dart
+++ b/packages/flutter/test/analytics/session_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('campaignFingerprint', () {
+    test('returns null when no campaign params are present', () {
+      expect(campaignFingerprint(null), isNull);
+      expect(campaignFingerprint('?foo=bar'), isNull);
+      expect(campaignFingerprint(''), isNull);
+    });
+
+    test('builds a stable fingerprint from utm params and click ids', () {
+      expect(
+        campaignFingerprint('?utm_source=google&utm_medium=cpc&x=1'),
+        'utm_source=google&utm_medium=cpc',
+      );
+      expect(campaignFingerprint('?gclid=abc'), 'gclid=abc');
+    });
+
+    test('accepts a full query string with leading path', () {
+      expect(
+        campaignFingerprint('/p?utm_campaign=launch'),
+        'utm_campaign=launch',
+      );
+    });
+  });
+
+  group('Session — lifecycle', () {
+    test('mints a UUIDv4 session id at first access', () {
+      final s = Session(SessionConfig(storage: createMemoryStorage()));
+      expect(isUuidV4(s.id()), isTrue);
+    });
+
+    test('returns a stable id within an active session', () {
+      final s = Session(SessionConfig(storage: createMemoryStorage()));
+      expect(s.id(), s.id());
+    });
+
+    test('start() forces a brand-new session id', () {
+      final s = Session(SessionConfig(storage: createMemoryStorage()));
+      final a = s.id();
+      final b = s.start();
+      expect(b, isNot(a));
+      expect(isUuidV4(b), isTrue);
+    });
+
+    test('end() drops the session; next id() mints a fresh one', () {
+      final s = Session(SessionConfig(storage: createMemoryStorage()));
+      final a = s.id();
+      s.end();
+      expect(s.id(), isNot(a));
+    });
+
+    test('exposes the GA4-parity default timeout (30 minutes)', () {
+      expect(defaultSessionTimeoutMs, 30 * 60 * 1000);
+    });
+  });
+
+  group('Session — inactivity timeout (GA4 parity)', () {
+    test('rotates the id after the inactivity window elapses', () {
+      var now = 1000000;
+      final s = Session(
+        SessionConfig(storage: createMemoryStorage(), timeoutMs: 1000),
+        now: () => now,
+      );
+      final a = s.touch();
+      now += 500; // within window
+      expect(s.touch(), a);
+      now += 5000; // beyond window
+      expect(s.touch(), isNot(a));
+    });
+
+    test('touch() slides the window forward (no premature rotation)', () {
+      var now = 0;
+      final s = Session(
+        SessionConfig(storage: createMemoryStorage(), timeoutMs: 1000),
+        now: () => now,
+      );
+      final a = s.touch();
+      for (var i = 0; i < 10; i++) {
+        now += 900;
+        expect(s.touch(), a);
+      }
+    });
+  });
+
+  group('Session — campaign reset', () {
+    test('rotates the id when a new campaign appears', () {
+      var now = 0;
+      final s = Session(
+        SessionConfig(storage: createMemoryStorage(), timeoutMs: 60000),
+        now: () => now,
+      );
+      final organic = s.touch();
+      now += 100;
+      final campaignA = s.touch('utm_source=google');
+      expect(campaignA, isNot(organic));
+      now += 100;
+      final campaignB = s.touch('utm_source=bing');
+      expect(campaignB, isNot(campaignA));
+    });
+
+    test('does NOT rotate when the same campaign repeats', () {
+      var now = 0;
+      final s = Session(
+        SessionConfig(storage: createMemoryStorage(), timeoutMs: 60000),
+        now: () => now,
+      );
+      final a = s.touch('utm_source=google');
+      now += 100;
+      expect(s.touch('utm_source=google'), a);
+    });
+
+    test('honours resetOnCampaign:false', () {
+      var now = 0;
+      final s = Session(
+        SessionConfig(
+          storage: createMemoryStorage(),
+          timeoutMs: 60000,
+          resetOnCampaign: false,
+        ),
+        now: () => now,
+      );
+      final a = s.touch('utm_source=google');
+      now += 100;
+      expect(s.touch('utm_source=bing'), a);
+    });
+  });
+
+  group('Session — cross-instance persistence', () {
+    test('shares one session across instances backed by the same storage', () {
+      final storage = createMemoryStorage();
+      final tabA = Session(SessionConfig(storage: storage));
+      final tabB = Session(SessionConfig(storage: storage));
+      expect(tabB.id(), tabA.id());
+    });
+  });
+
+  group('Session — session-scoped properties', () {
+    test('merges and reads session.set props', () {
+      final s = Session(SessionConfig(storage: createMemoryStorage()));
+      s.set({'plan': 'pro'});
+      s.set({'region': 'eu'});
+      expect(s.props(), {'plan': 'pro', 'region': 'eu'});
+    });
+  });
+}

--- a/packages/flutter/test/analytics/sinks_test.dart
+++ b/packages/flutter/test/analytics/sinks_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart'
+    hide createConsoleSink, createMockSink, MockSinkExtended;
+// Analytics' own console sink — the package barrel hides it (telemetry owns
+// the flat-barrel createConsoleSink), so import it directly here.
+import 'package:refraction_ui/src/analytics/console_sink.dart';
+// Test-only mock sink — intentionally not re-exported anywhere; would collide
+// with telemetry's flat-barrel createMockSink / MockSinkExtended.
+import 'package:refraction_ui/src/analytics/mock_sink.dart';
+
+AnalyticsEvent _ev(String event) => AnalyticsEvent(
+  type: AnalyticsEventType.track,
+  event: event,
+  messageId: 'm',
+  anonymousId: 'a',
+  sessionId: 's',
+  properties: const {},
+  context: const AnalyticsContext(
+    app: 'app',
+    env: 'test',
+    library: AnalyticsLibrary(
+      name: '@refraction-ui/analytics',
+      version: '0.1.0',
+    ),
+  ),
+  timestamp: DateTime.now().toUtc().toIso8601String(),
+  schemaVersion: kSchemaVersion,
+);
+
+void main() {
+  group('ConsoleSink', () {
+    test('logs a labelled line per canonical envelope', () {
+      final lines = <String>[];
+      final sink = createConsoleSink(logger: lines.add);
+      sink.deliver([
+        _ev('A'),
+        _ev('B'),
+      ], const SinkDeliverContext(unload: false));
+      expect(lines, hasLength(2));
+      expect(lines[0], startsWith('[analytics] track A'));
+      expect(lines[1], startsWith('[analytics] track B'));
+    });
+
+    test('passes through configured consent categories', () {
+      final sink = createConsoleSink(consentCategories: ['debug']);
+      expect(sink.consentCategories, ['debug']);
+    });
+  });
+
+  group('MockSink', () {
+    test('captures init/deliver/flush/shutdown for assertions', () {
+      final sink = createMockSink(name: 's1', consentCategories: ['x']);
+      expect(sink.name, 's1');
+      expect(sink.consentCategories, ['x']);
+
+      sink.init(const SinkInitContext(app: 'a', env: 'e'));
+      sink.deliver([_ev('A')], const SinkDeliverContext(unload: false));
+      sink.deliver([
+        _ev('B'),
+        _ev('C'),
+      ], const SinkDeliverContext(unload: true));
+      sink.flush();
+      sink.shutdown();
+
+      expect(sink.initCalls, hasLength(1));
+      expect(sink.deliveries, hasLength(2));
+      expect(sink.deliveries[1].ctx.unload, isTrue);
+      expect(sink.events.map((e) => e.event), ['A', 'B', 'C']);
+      expect(sink.flushCalls, 1);
+      expect(sink.shutdownCalls, 1);
+    });
+  });
+
+  group('createNoopAnalytics', () {
+    test('exposes the full Analytics surface, all inert', () async {
+      final a = createNoopAnalytics();
+      expect(a.enabled, isFalse);
+      expect(a.sinks, isEmpty);
+      expect(a.userId(), isNull);
+      expect(a.anonymousId(), startsWith('00000000-0000-4'));
+      expect(a.session.id(), isA<String>());
+      expect(a.consent.granted(), isEmpty);
+      expect(a.consent.isGranted('analytics'), isFalse);
+      expect(a.withContext(const {}), same(a));
+      expect(() {
+        a.track('x');
+        a.identify('u');
+        a.page();
+        a.screen();
+        a.group('g');
+        a.alias('u2');
+        a.session.start();
+        a.session.end();
+        a.session.set(const {});
+        a.consent.grant(['a']);
+        a.consent.revoke(['a']);
+        a.addSink(createMockSink());
+        a.removeSink('mock');
+        a.reset();
+      }, returnsNormally);
+      await a.flush();
+    });
+  });
+}

--- a/packages/flutter/test/analytics/storage_test.dart
+++ b/packages/flutter/test/analytics/storage_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('MemoryStorage', () {
+    test('round-trips values and reports null for missing keys', () {
+      final s = createMemoryStorage();
+      expect(s.get('k'), isNull);
+      s.set('k', 'v');
+      expect(s.get('k'), 'v');
+      s.remove('k');
+      expect(s.get('k'), isNull);
+    });
+  });
+
+  group('resolveStorage', () {
+    test('returns the override when supplied', () {
+      final override = createMemoryStorage();
+      expect(resolveStorage(override), same(override));
+    });
+
+    test('returns a working durable/memory store when no override given', () {
+      // In the dart:io test VM this resolves to the file-backed default;
+      // it must behave as a working AnalyticsStorage either way.
+      final s = resolveStorage();
+      s.set('rfx:storage:probe', 'y');
+      expect(s.get('rfx:storage:probe'), 'y');
+      s.remove('rfx:storage:probe');
+      expect(s.get('rfx:storage:probe'), isNull);
+    });
+  });
+}

--- a/packages/flutter/test/analytics/uuid_test.dart
+++ b/packages/flutter/test/analytics/uuid_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('uuidv4', () {
+    test('produces an RFC 4122 v4 shaped string', () {
+      expect(uuidV4Re.hasMatch(uuidv4()), isTrue);
+    });
+
+    test('sets the version nibble to 4', () {
+      for (var i = 0; i < 50; i++) {
+        expect(uuidv4()[14], '4');
+      }
+    });
+
+    test('sets the variant nibble to 8/9/a/b', () {
+      for (var i = 0; i < 50; i++) {
+        expect('89ab'.contains(uuidv4()[19]), isTrue);
+      }
+    });
+
+    test('is collision-free across many draws', () {
+      final seen = <String>{};
+      for (var i = 0; i < 5000; i++) {
+        seen.add(uuidv4());
+      }
+      expect(seen.length, 5000);
+    });
+  });
+
+  group('isUuidV4', () {
+    test('accepts valid v4 uuids', () {
+      expect(isUuidV4(uuidv4()), isTrue);
+    });
+
+    test('rejects non-uuid strings and non-strings', () {
+      expect(isUuidV4('not-a-uuid'), isFalse);
+      expect(isUuidV4(''), isFalse);
+      expect(isUuidV4(null), isFalse);
+      expect(isUuidV4(123), isFalse);
+      // v1-style (version nibble 1) must be rejected.
+      expect(isUuidV4('00000000-0000-1000-8000-000000000000'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Epic #230 Wave 0. 1:1 Dart port of `@refraction-ui/analytics` into `packages/flutter/lib/src/analytics` — Segment-spec router, canonical envelope, built-in HTTP Segment-Tracking-API wire-contract sink, session/identity/consent with pluggable storage. **Uniform structure across web/android/ios/desktop** (internal conditional imports); consumer-supplied backend URL.

Resolves the integration collision with the landed #226 telemetry module (both defined `createMockSink`/`MockSinkExtended` + `createConsoleSink`): analytics mock-sink not in the public barrel (tests import module path); package barrel exports analytics `hide createConsoleSink`; new `lib/analytics.dart` namespaced entrypoint preserves analytics' `createConsoleSink` with zero parity loss. **Telemetry module untouched** (git diff empty).

✅ flutter pub get / analyze "No issues" · flutter test **+155 all pass** (92 analytics + 63 telemetry/existing). No changeset (Dart pub). Closes #231.