### PR TITLE
fix(release): publish telemetry/analytics libs to npm (remove private)

### DIFF
--- a/packages/analytics-sink-app-insights/package.json
+++ b/packages/analytics-sink-app-insights/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/analytics-sink-app-insights",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,5 +45,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/analytics-sink-app-insights"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/analytics-sink-ga4/package.json
+++ b/packages/analytics-sink-ga4/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/analytics-sink-ga4",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -38,5 +37,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/analytics-sink-ga4"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/analytics-sink-posthog/package.json
+++ b/packages/analytics-sink-posthog/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/analytics-sink-posthog",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -51,5 +50,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/analytics-sink-posthog"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/analytics",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -37,5 +36,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/analytics"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/angular-analytics/package.json
+++ b/packages/angular-analytics/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/angular-analytics",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -44,5 +43,8 @@
     "url": "git+https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/angular-analytics"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/angular-logger/package.json
+++ b/packages/angular-logger/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/angular-logger",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,5 +46,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/angular-logger"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/astro-analytics/package.json
+++ b/packages/astro-analytics/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/astro-analytics",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "exports": {
@@ -32,5 +31,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/astro-analytics"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/astro-logger/package.json
+++ b/packages/astro-logger/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/astro-logger",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "exports": {
@@ -39,5 +38,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/astro-logger"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/logger",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -49,5 +48,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/logger"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/react-analytics/package.json
+++ b/packages/react-analytics/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/react-analytics",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,5 +46,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/react-analytics"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/react-logger/package.json
+++ b/packages/react-logger/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@refraction-ui/react-logger",
-  "private": true,
   "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,5 +46,8 @@
     "url": "https://github.com/elloloop/refraction-ui.git",
     "directory": "packages/react-logger"
   },
-  "homepage": "https://elloloop.github.io/refraction-ui/"
+  "homepage": "https://elloloop.github.io/refraction-ui/",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
**Why nothing reached npm:** `publish-oidc.mjs` does `filter(pkg => !pkg.private)`; all our packages were scaffolded `private: true` (repo convention for internal component pkgs). These are standalone **libraries** (consumer-supplied backend URL) intended for npm consumption — divergence from the all-private convention is intentional and matches the stated product goal.

Removes `private` + adds `publishConfig.access=public` on 11 packages (logger, analytics, react/astro/angular-logger+analytics, 3 analytics sinks). `analytics-relay-reference` stays **private** (reference impl). Versions already at v0.2.0 from #253 and not on npm → next `Release` run's `publish-oidc` publishes them `@latest`. No changeset (no re-bump needed).

✅ turbo build green for the set. Verified `pnpm ls -r` now lists all 11 as public.