### PR TITLE
docs(agents): authoritative CLAUDE.md + fix misleading GEMINI.md (root cause of recurring packaging mistake)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Refraction UI — Agent Instructions (AUTHORITATIVE)
+
+This file is the single source of truth for AI agents. If any other doc
+(GEMINI.md, older notes, a sub-package README) disagrees with this file about
+packaging or releasing, **this file wins**. Read this before creating packages
+or publishing.
+
+## Packaging & Release Architecture — READ FIRST
+
+### The ONLY packages published to npm
+| npm name | dir | notes |
+|---|---|---|
+| `@refraction-ui/react` | `packages/react-meta` | per-framework meta |
+| `@refraction-ui/astro` | `packages/astro-meta` | per-framework meta |
+| `@refraction-ui/angular` | `packages/angular-meta` | per-framework meta |
+| `@refraction-ui/shared` | `packages/shared` | headless shared utils |
+| `@refraction-ui/tailwind-config` | `packages/tailwind-config` | |
+
+**Every other package under `packages/*` is `private: true` and is NEVER
+published to npm.** This includes all headless cores (`ai`, `auth`, `http`,
+`i18n`, `media-engines`, `logger`, `analytics`, `analytics-sink-*`, …) and all
+framework adapters (`react-*`, `astro-*`, `angular-*`). `publish-oidc.mjs`
+filters `!pkg.private`, so private packages are skipped by design.
+
+Flutter is a **single Dart package** `packages/flutter` (`refraction_ui`),
+published to **pub.dev** by the `flutter-publish` tag workflow — a separate
+ecosystem. Not npm, not metas, no changeset.
+
+### How consumers get a feature
+Consumers install **only** the meta (`@refraction-ui/react` etc.) or
+`@refraction-ui/shared`. A feature reaches them only if its framework adapter
+is **wired into the meta**. Headless cores are pulled in transitively by the
+adapters (e.g. `@refraction-ui/ai` is private; `react-ai` depends on it;
+`react-meta` re-exports `react-ai`).
+
+## Hard rules
+
+- **MUST NOT** set a feature/core package to `private: false` or add
+  `publishConfig` to force it onto npm. Individual feature packages are never
+  standalone npm packages.
+- **MUST NOT** run `npm version` / `npm publish` on individual feature
+  packages, or publish from a local machine, or with a stored npm token.
+  Publishing is **only** via CI GitHub-Actions **OIDC trusted publishing**
+  (provenance). Local/token publishing is forbidden (supply-chain + loses
+  provenance).
+- **MUST NOT** expect an individual feature package (e.g.
+  `@refraction-ui/react-logger`) to appear on npm. It never will.
+- Releases are **Changesets-driven**. There ARE changesets and a Version PR.
+  (Ignore any doc claiming "no changesets / manually bump every package".)
+
+## Adding a new framework feature (the correct procedure)
+
+1. Headless core (if any): `packages/<feature>` — `private: true`. Consumed
+   transitively by adapters; never published.
+2. Framework adapter(s): `packages/<fw>-<feature>` (`react-`/`astro-`/
+   `angular-`) — `private: true`. Mirror an existing adapter (`react-ai`).
+3. **Wire each adapter into its meta** (this is the step that was missed 20×):
+   - add `"@refraction-ui/<fw>-<feature>": "workspace:*"` to
+     `packages/<fw>-meta/package.json` **`devDependencies`**
+   - add `export * from '@refraction-ui/<fw>-<feature>'` to
+     `packages/<fw>-meta/src/index.ts`
+   - (this is exactly what `update-meta-packages.cjs` automates)
+4. Build the metas (`pnpm turbo run build --filter=@refraction-ui/react …`) to
+   catch `export *` name collisions before landing.
+
+## Releasing
+
+1. Add a `.changeset/*.md` bumping the affected **public** packages only — the
+   metas (`@refraction-ui/react|astro|angular`) and/or `@refraction-ui/shared`.
+   Never list private feature packages as the release driver (they may be
+   version-bumped by changesets but are not published).
+2. Land it. The Changesets Action opens/updates a **`chore: release packages`
+   Version PR** (it consumes changesets, bumps versions, writes CHANGELOGs).
+3. Merge that Version PR. The next `Release` run sees no changesets → runs
+   `scripts/publish-oidc.mjs` → publishes the **non-private** packages to npm
+   `@latest` via OIDC with provenance.
+4. Verify: `npm view @refraction-ui/react dist-tags --json`.
+
+Existing public packages already have npm OIDC trusted publishers configured
+(that's why they publish). Brand-new public package names would NOT — another
+reason new feature packages must stay private and ride the metas.
+
+## Pre-push
+
+Run `make ci` before pushing to `main`; never push failing code. Use `stax`
+for git/dev workflow, not raw `git`/`gh` (issue/PR skills excepted).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,32 +1,34 @@
 # AI Agent Instructions
 
+> **Authoritative source: [`CLAUDE.md`](./CLAUDE.md).** Read it before creating
+> packages or releasing. This file only covers the pre-push workflow; the
+> packaging/release rules below defer entirely to `CLAUDE.md`.
+
 ## Mandatory Pre-Push Workflow
-Before pushing any commits to the remote repository, you **MUST** run the local CI pipeline to verify that everything works:
+Before pushing any commits to the remote repository, you **MUST** run the local CI pipeline:
 
 1. Run `make ci` in the root directory.
-2. If `make ci` fails, you must fix the errors, commit the fixes, and run `make ci` again until it passes.
+2. If `make ci` fails, fix the errors, commit, and re-run until it passes.
 3. **NEVER** push failing code to the remote repository.
 
-## Mandatory NPM Publish After Every Change
+## Packaging & Release — see CLAUDE.md
 
-Every code change pushed to `main` **MUST** result in a published version on npmjs under the `latest` dist-tag. The only exception is if the user explicitly says "only canary."
+Earlier revisions of this file were **wrong** and caused repeated mistakes.
+They are corrected and the rules now live in `CLAUDE.md`. In short:
 
-### How publishing works
-- The CI pipeline on `main` runs `scripts/publish-oidc.mjs` via GitHub Actions OIDC. It automatically publishes any package whose `package.json` version does not yet exist on npm.
-- **There are no changesets or automated version bumps.** You must manually bump the version yourself.
+- The **only** npm-published packages are the per-framework metas
+  (`@refraction-ui/react|astro|angular` from `packages/*-meta`),
+  `@refraction-ui/shared`, and `@refraction-ui/tailwind-config`.
+- **Every other `packages/*` is `private: true` and never published** — all
+  headless cores and all `react-*`/`astro-*`/`angular-*` adapters.
+- A new feature reaches consumers by wiring its adapter into the meta
+  (`devDependencies` `workspace:*` + `export * from` in `*-meta/src/index.ts`),
+  **not** by publishing the package itself.
+- **Do NOT** `npm version`/`npm publish` individual packages, set feature
+  packages public, or publish locally/with a token.
+- Releases are **Changesets-driven**: changeset bumping the public meta/shared
+  packages → `chore: release packages` Version PR → merge → CI
+  `publish-oidc.mjs` publishes via GitHub OIDC (provenance).
+- Flutter (`packages/flutter`) publishes to **pub.dev** separately.
 
-### Steps to follow after every code change
-1. Identify which packages were modified (check `packages/` directories that were touched).
-2. For each modified package, run `npm version patch --no-git-tag-version --prefix packages/<name>` to bump its version.
-3. Also bump the **meta-packages** that re-export the modified packages:
-   - `packages/react-meta` → publishes as `@refraction-ui/react`
-   - `packages/angular-meta` → publishes as `@refraction-ui/angular`
-   - `packages/astro-meta` → publishes as `@refraction-ui/astro`
-4. Include the version bumps in the same commit or a follow-up commit.
-5. Push directly to `main`. The CI will build, test, and then the Release workflow will publish all new versions to npm with the `latest` tag.
-6. After pushing, confirm publication by running: `npm view @refraction-ui/react dist-tags --json`
-
-### Rules
-- **Default is `latest` tag.** Always publish to the stable `latest` dist-tag unless the user explicitly requests "only canary."
-- **Never skip the version bump.** If you forget to bump, the publish script will see the version already exists on npm and skip it — meaning your change will NOT be published.
-- **Report the version numbers.** After pushing, tell the user the exact version numbers that will be published (e.g., `@refraction-ui/react@0.3.9`).
+Full procedure and rationale: **[`CLAUDE.md`](./CLAUDE.md)**.


### PR DESCRIPTION
The repo's AI-agent doc (`GEMINI.md`) was **wrong**: it told agents there are no changesets, to `npm version` & publish every modified package, and never said feature packages are `private` or must be wired into the `*-meta` packages. That misinstruction is the root cause of the private-vs-public / meta-wiring error recurring ~20× in one session.

- **New `CLAUDE.md`** — authoritative: the only published packages are `@refraction-ui/react|astro|angular` (from `*-meta`) + `shared` + `tailwind-config`; everything else is `private`; new feature = wire adapter into the meta; releases are Changesets→Version PR→OIDC; never force packages public or publish locally/with a token.
- **`GEMINI.md`** — false section removed; defers to `CLAUDE.md`; keeps the `make ci` pre-push rule.

Pure docs, no changeset.