### PR TITLE
feat(analytics): surface GA4/Azure/PostHog sinks via metas

### DIFF
--- a/.changeset/surface-analytics-sinks.md
+++ b/.changeset/surface-analytics-sinks.md
@@ -1,0 +1,14 @@
+---
+"@refraction-ui/react": minor
+"@refraction-ui/astro": minor
+"@refraction-ui/angular": minor
+---
+
+feat: surface the GA4, Azure App Insights, and PostHog analytics sink factories through the per-framework meta packages
+
+The framework analytics adapters now re-export `createGA4Sink`,
+`createAppInsightsSink`, and `createPostHogSink` (plus their direct-mode
+factories, option/type contracts, and the optional lazy PostHog
+`startSessionReplay`), so consumers of `@refraction-ui/react|astro|angular`
+can fan analytics out to GA4 / Azure / PostHog without depending on the
+private sink packages directly.

--- a/packages/angular-analytics/package.json
+++ b/packages/angular-analytics/package.json
@@ -27,6 +27,9 @@
   },
   "dependencies": {
     "@refraction-ui/analytics": "workspace:*",
+    "@refraction-ui/analytics-sink-app-insights": "workspace:*",
+    "@refraction-ui/analytics-sink-ga4": "workspace:*",
+    "@refraction-ui/analytics-sink-posthog": "workspace:*",
     "@refraction-ui/shared": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/angular-analytics/src/index.ts
+++ b/packages/angular-analytics/src/index.ts
@@ -19,3 +19,52 @@ export type {
   ConsentAPI,
   SessionAPI,
 } from '@refraction-ui/analytics'
+
+// Re-export vendor sink factories so consumers of the public meta can fan
+// out to GA4 / Azure App Insights / PostHog. The sink packages stay private;
+// they reach consumers only through this adapter (and the meta's `export *`).
+// Named re-exports only — `export *` would collide on shared mapping helpers
+// (each sink re-exports its own `mapEvent`). Mapping helpers are intentionally
+// not surfaced here; only the sink factories + their option/type contracts.
+export {
+  createGA4Sink,
+  createGA4HttpSink,
+  createGA4ClientSdkSink,
+} from '@refraction-ui/analytics-sink-ga4'
+export type {
+  GA4SinkOptions,
+  GA4HttpOptions,
+  GA4ClientSdkOptions,
+  GA4ConsentBridge,
+  ConsentState,
+  GtagFn,
+} from '@refraction-ui/analytics-sink-ga4'
+
+export { createAppInsightsSink } from '@refraction-ui/analytics-sink-app-insights'
+export type {
+  AppInsightsSinkOptions,
+  AppInsightsSinkMode,
+  ClientSdkOptions,
+  HttpOptions,
+  AppInsightsLike,
+} from '@refraction-ui/analytics-sink-app-insights'
+
+export {
+  createPostHogSink,
+  createPostHogHttpSink,
+  createPostHogClientSdkSink,
+} from '@refraction-ui/analytics-sink-posthog'
+export type {
+  PostHogSinkMode,
+  PostHogSinkOptions,
+  PostHogHttpSinkOptions,
+  PostHogClientSdkSinkOptions,
+} from '@refraction-ui/analytics-sink-posthog'
+
+// Optional, lazy PostHog session replay (separate `./replay` entry point of
+// the sink package — never on the event path, tree-shaken when unused).
+export { startSessionReplay } from '@refraction-ui/analytics-sink-posthog/replay'
+export type {
+  SessionReplayOptions,
+  SessionReplayHandle,
+} from '@refraction-ui/analytics-sink-posthog/replay'

--- a/packages/astro-analytics/package.json
+++ b/packages/astro-analytics/package.json
@@ -16,6 +16,9 @@
   },
   "dependencies": {
     "@refraction-ui/analytics": "workspace:*",
+    "@refraction-ui/analytics-sink-app-insights": "workspace:*",
+    "@refraction-ui/analytics-sink-ga4": "workspace:*",
+    "@refraction-ui/analytics-sink-posthog": "workspace:*",
     "@refraction-ui/shared": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/astro-analytics/src/index.ts
+++ b/packages/astro-analytics/src/index.ts
@@ -47,3 +47,48 @@ export {
   type CreateMockSinkOptions,
   type Redactor,
 } from '@refraction-ui/analytics'
+
+// Re-export vendor sink factories so consumers of the public meta can fan
+// out to GA4 / Azure App Insights / PostHog. The sink packages stay private;
+// they reach consumers only through this adapter (and the meta's `export *`).
+// Named re-exports only — `export *` would collide on shared mapping helpers
+// (each sink re-exports its own `mapEvent`). Mapping helpers are intentionally
+// not surfaced here; only the sink factories + their option/type contracts.
+export {
+  createGA4Sink,
+  createGA4HttpSink,
+  createGA4ClientSdkSink,
+  type GA4SinkOptions,
+  type GA4HttpOptions,
+  type GA4ClientSdkOptions,
+  type GA4ConsentBridge,
+  type ConsentState,
+  type GtagFn,
+} from '@refraction-ui/analytics-sink-ga4'
+
+export {
+  createAppInsightsSink,
+  type AppInsightsSinkOptions,
+  type AppInsightsSinkMode,
+  type ClientSdkOptions,
+  type HttpOptions,
+  type AppInsightsLike,
+} from '@refraction-ui/analytics-sink-app-insights'
+
+export {
+  createPostHogSink,
+  createPostHogHttpSink,
+  createPostHogClientSdkSink,
+  type PostHogSinkMode,
+  type PostHogSinkOptions,
+  type PostHogHttpSinkOptions,
+  type PostHogClientSdkSinkOptions,
+} from '@refraction-ui/analytics-sink-posthog'
+
+// Optional, lazy PostHog session replay (separate `./replay` entry point of
+// the sink package — never on the event path, tree-shaken when unused).
+export {
+  startSessionReplay,
+  type SessionReplayOptions,
+  type SessionReplayHandle,
+} from '@refraction-ui/analytics-sink-posthog/replay'

--- a/packages/react-analytics/package.json
+++ b/packages/react-analytics/package.json
@@ -27,6 +27,9 @@
   },
   "dependencies": {
     "@refraction-ui/analytics": "workspace:*",
+    "@refraction-ui/analytics-sink-app-insights": "workspace:*",
+    "@refraction-ui/analytics-sink-ga4": "workspace:*",
+    "@refraction-ui/analytics-sink-posthog": "workspace:*",
     "@refraction-ui/shared": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/react-analytics/src/index.ts
+++ b/packages/react-analytics/src/index.ts
@@ -21,3 +21,52 @@ export type {
   AnalyticsSink,
   CallOptions,
 } from '@refraction-ui/analytics'
+
+// Re-export vendor sink factories so consumers of the public meta can fan
+// out to GA4 / Azure App Insights / PostHog. The sink packages stay private;
+// they reach consumers only through this adapter (and the meta's `export *`).
+// Named re-exports only — `export *` would collide on shared mapping helpers
+// (each sink re-exports its own `mapEvent`). Mapping helpers are intentionally
+// not surfaced here; only the sink factories + their option/type contracts.
+export {
+  createGA4Sink,
+  createGA4HttpSink,
+  createGA4ClientSdkSink,
+} from '@refraction-ui/analytics-sink-ga4'
+export type {
+  GA4SinkOptions,
+  GA4HttpOptions,
+  GA4ClientSdkOptions,
+  GA4ConsentBridge,
+  ConsentState,
+  GtagFn,
+} from '@refraction-ui/analytics-sink-ga4'
+
+export { createAppInsightsSink } from '@refraction-ui/analytics-sink-app-insights'
+export type {
+  AppInsightsSinkOptions,
+  AppInsightsSinkMode,
+  ClientSdkOptions,
+  HttpOptions,
+  AppInsightsLike,
+} from '@refraction-ui/analytics-sink-app-insights'
+
+export {
+  createPostHogSink,
+  createPostHogHttpSink,
+  createPostHogClientSdkSink,
+} from '@refraction-ui/analytics-sink-posthog'
+export type {
+  PostHogSinkMode,
+  PostHogSinkOptions,
+  PostHogHttpSinkOptions,
+  PostHogClientSdkSinkOptions,
+} from '@refraction-ui/analytics-sink-posthog'
+
+// Optional, lazy PostHog session replay (separate `./replay` entry point of
+// the sink package — never on the event path, tree-shaken when unused).
+export { startSessionReplay } from '@refraction-ui/analytics-sink-posthog/replay'
+export type {
+  SessionReplayOptions,
+  SessionReplayHandle,
+} from '@refraction-ui/analytics-sink-posthog/replay'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,15 @@ importers:
       '@refraction-ui/analytics':
         specifier: workspace:*
         version: link:../analytics
+      '@refraction-ui/analytics-sink-app-insights':
+        specifier: workspace:*
+        version: link:../analytics-sink-app-insights
+      '@refraction-ui/analytics-sink-ga4':
+        specifier: workspace:*
+        version: link:../analytics-sink-ga4
+      '@refraction-ui/analytics-sink-posthog':
+        specifier: workspace:*
+        version: link:../analytics-sink-posthog
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared
@@ -879,6 +888,15 @@ importers:
       '@refraction-ui/analytics':
         specifier: workspace:*
         version: link:../analytics
+      '@refraction-ui/analytics-sink-app-insights':
+        specifier: workspace:*
+        version: link:../analytics-sink-app-insights
+      '@refraction-ui/analytics-sink-ga4':
+        specifier: workspace:*
+        version: link:../analytics-sink-ga4
+      '@refraction-ui/analytics-sink-posthog':
+        specifier: workspace:*
+        version: link:../analytics-sink-posthog
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2437,6 +2455,15 @@ importers:
       '@refraction-ui/analytics':
         specifier: workspace:*
         version: link:../analytics
+      '@refraction-ui/analytics-sink-app-insights':
+        specifier: workspace:*
+        version: link:../analytics-sink-app-insights
+      '@refraction-ui/analytics-sink-ga4':
+        specifier: workspace:*
+        version: link:../analytics-sink-ga4
+      '@refraction-ui/analytics-sink-posthog':
+        specifier: workspace:*
+        version: link:../analytics-sink-posthog
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Closes the React (and astro/angular) fan-out gap: `@refraction-ui/react@0.6.0` exposed `createAnalytics`/`createHttpSink` but not the vendor sinks. The private `analytics-sink-*` factories are now **named-re-exported** through the `*-analytics` adapters (so they bundle into the metas via the existing `export *`). Sinks stay `private` (per CLAUDE.md); only the 3 public metas are bumped (changeset). Verified: `react-meta/dist` exposes `createGA4Sink`/`createAppInsightsSink`/`createPostHogSink`; turbo build of all 3 metas exit 0, no collisions.