### PR TITLE
feat(flutter): telemetry mobile (iOS/Android) — #227

### DIFF
--- a/packages/flutter/lib/src/telemetry/att_gate.dart
+++ b/packages/flutter/lib/src/telemetry/att_gate.dart
@@ -1,0 +1,94 @@
+/// App Tracking Transparency (ATT) / IDFA gate + consent sequencing.
+///
+/// **This package never reads the IDFA / advertising identifier itself.** It
+/// has no `app_tracking_transparency` / ads dependency and emits no device
+/// advertising ID in the native context (see `native_context_io.dart` —
+/// only OS name/version, coarse model, locale, app version/build). This gate
+/// exists so a consuming app that *does* attach an ad/tracking identifier (or
+/// any cross-app identifier) can sequence it correctly for App Store review:
+///
+///  1. Telemetry starts in [TrackingState.notDetermined] — **no tracking
+///     identifier is attached, no tracking-scoped record is delivered**.
+///  2. The app shows the OS ATT prompt (its own code / plugin) and calls
+///     [TelemetryConsent.setTrackingAuthorized] with the result.
+///  3. Only after `authorized` may the app add tracking identifiers; the
+///     gate exposes [TelemetryConsent.allowsTracking] so the integration can
+///     branch. Until then `attachTrackingId` is a guarded no-op.
+///
+/// Analytics-style category consent (Wave-0's `Consent`) is orthogonal and
+/// still applies; this is specifically the iOS ATT / IDFA sequencing the
+/// store requires. Uniform surface: on Android / web there is no ATT prompt,
+/// so the state simply starts `notApplicable` and tracking is governed solely
+/// by category consent — same API, no platform branching for the consumer.
+library;
+
+/// ATT-equivalent authorization state. Mirrors Apple's
+/// `ATTrackingManager.AuthorizationStatus` semantics without importing it.
+enum TrackingState {
+  /// iOS, prompt not yet shown — treat as "no tracking".
+  notDetermined,
+
+  /// User allowed app-tracking (IDFA readable by the app).
+  authorized,
+
+  /// User declined, or tracking is restricted by policy/MDM.
+  denied,
+
+  /// No ATT concept on this platform (Android < ad-id changes / web / desktop)
+  /// — tracking is governed by category consent only.
+  notApplicable,
+}
+
+/// Sequencing gate. The consuming integration drives [setTrackingAuthorized]
+/// from its own ATT prompt result; refraction-ui never shows the prompt nor
+/// reads the IDFA.
+class TelemetryConsent {
+  /// Start in [TrackingState.notDetermined] (the safe default for iOS) unless
+  /// the host knows ATT does not apply.
+  TelemetryConsent({TrackingState initial = TrackingState.notDetermined})
+      : _state = initial;
+
+  TrackingState _state;
+  String? _trackingId;
+
+  /// Current ATT-equivalent state.
+  TrackingState get state => _state;
+
+  /// `true` only when the user explicitly authorized tracking. While this is
+  /// `false`, NO tracking/advertising identifier may be attached or emitted.
+  bool get allowsTracking => _state == TrackingState.authorized;
+
+  /// Record the OS ATT prompt result (or `notApplicable` on non-iOS). If the
+  /// user later revokes, calling this with `denied` clears any attached id so
+  /// it stops being emitted.
+  void setTrackingAuthorized(TrackingState result) {
+    _state = result;
+    if (!allowsTracking) {
+      _trackingId = null;
+    }
+  }
+
+  /// Attach a tracking/advertising identifier the *host* obtained AFTER ATT
+  /// authorization. Guarded: ignored unless [allowsTracking] — so an
+  /// identifier can never be set before consent (store-rejection risk).
+  /// Returns whether it was accepted.
+  bool attachTrackingId(String id) {
+    if (!allowsTracking) return false;
+    _trackingId = id;
+    return true;
+  }
+
+  /// The tracking id to merge into context, or `null` while not authorized.
+  /// Telemetry context-builders MUST gate on this (never read it directly
+  /// from a platform API before consent).
+  String? get trackingId => allowsTracking ? _trackingId : null;
+
+  /// Extra context to merge only when tracking is authorized & an id is set.
+  /// Empty (and therefore omitted) until consent is granted — this is the
+  /// "no IDs before consent" guarantee in one place.
+  Map<String, Object?> trackingContext() {
+    final id = trackingId;
+    if (id == null) return const <String, Object?>{};
+    return <String, Object?>{'trackingId': id};
+  }
+}

--- a/packages/flutter/lib/src/telemetry/crash_capture.dart
+++ b/packages/flutter/lib/src/telemetry/crash_capture.dart
@@ -1,0 +1,228 @@
+/// Crash capture + crash-on-next-launch persistence.
+///
+/// Installs the three Flutter/Dart error hooks and routes every captured
+/// error to a [Logger] (so it flows through the same redaction → sink →
+/// durable-queue pipeline as any other record):
+///
+///  - `FlutterError.onError`            — framework/build/render errors
+///  - `PlatformDispatcher.instance.onError` — uncaught async/zone errors
+///  - `Isolate.current.addErrorListener` — errors on the current isolate
+///    (background isolates forward via the isolate-aware queue, see
+///    `isolate_queue.dart`)
+///
+/// **Crash-on-next-launch**: an error classified *fatal* (the default for the
+/// platform-dispatcher hook, which only fires for otherwise-unhandled errors
+/// that typically terminate the app) is first written synchronously to the
+/// durable store. On the *next* [TelemetryCrashGuard.install] the persisted
+/// crash is re-emitted as a `fatal` record and cleared, so a crash that kills
+/// the process before flush still reaches the collector on the following run.
+///
+/// This is an internal detail behind the existing surface; the consumer only
+/// calls one method. Uniform across web / android / ios / desktop — the hooks
+/// that don't exist on a given platform are simply not installed.
+library;
+
+import 'dart:convert';
+import 'dart:isolate';
+
+import 'package:flutter/foundation.dart';
+
+import 'durable_store.dart';
+import 'types.dart';
+
+/// Installed crash guard. [dispose] removes the hooks (mainly for tests).
+class TelemetryCrashGuard {
+  TelemetryCrashGuard._(this._restore, this._isolatePort);
+
+  final void Function() _restore;
+  final RawReceivePort? _isolatePort;
+  bool _disposed = false;
+
+  /// Detach hooks / close the isolate error port.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _restore();
+    _isolatePort?.close();
+  }
+}
+
+const String _crashKey = 'telemetry.crash';
+
+/// Install crash capture against [logger]. Call once, as early as possible
+/// (before `runApp`), ideally inside the same zone as the app.
+///
+/// - [store] controls crash-on-next-launch persistence (defaults to the
+///   platform durable store).
+/// - [installIsolateListener] adds `Isolate.current.addErrorListener`
+///   (skip in environments where that throws, e.g. some test runners).
+/// - [now] is injectable for deterministic tests.
+TelemetryCrashGuard installCrashCapture(
+  Logger logger, {
+  DurableStore? store,
+  bool installIsolateListener = true,
+  DateTime Function()? now,
+}) {
+  final durable = resolveDurableStore(store);
+  final clock = now ?? DateTime.now;
+
+  // 1. Replay a crash persisted by the *previous* run, then clear it.
+  _replayPersistedCrash(logger, durable);
+
+  void persistFatal(Object error, StackTrace? stack) {
+    try {
+      durable.write(
+        _crashKey,
+        jsonEncode(<String, Object?>{
+          'message': error.toString(),
+          'type': error.runtimeType.toString(),
+          'stack': stack?.toString(),
+          'timestamp': clock().millisecondsSinceEpoch,
+        }),
+      );
+    } catch (_) {
+      // Best-effort: if even persistence fails we still tried the live emit.
+    }
+  }
+
+  void emit(
+    Object error,
+    StackTrace? stack, {
+    required bool fatal,
+    required String source,
+  }) {
+    if (fatal) {
+      // Persist BEFORE the live emit so a hard crash still has it on disk.
+      persistFatal(error, stack);
+    }
+    final ctx = <String, Object?>{
+      'error.type': error.runtimeType.toString(),
+      'error.source': source,
+      if (stack != null) 'error.stack': stack.toString(),
+    };
+    if (fatal) {
+      logger.fatal(error.toString(), ctx);
+    } else {
+      logger.error(error.toString(), ctx);
+    }
+  }
+
+  // 2. FlutterError.onError (framework errors — non-fatal by default; the
+  //    framework usually keeps running).
+  final prevFlutterOnError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    emit(
+      details.exception,
+      details.stack,
+      fatal: false,
+      source: 'FlutterError.onError',
+    );
+    // Preserve any pre-existing handler (e.g. the consumer's, or the
+    // red-screen presenter) so we never swallow behavior.
+    if (prevFlutterOnError != null) {
+      prevFlutterOnError(details);
+    } else {
+      FlutterError.presentError(details);
+    }
+  };
+
+  // 3. PlatformDispatcher.onError (uncaught async — these are fatal: they
+  //    would otherwise crash the app).
+  final prevPlatformOnError = PlatformDispatcher.instance.onError;
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    emit(
+      error,
+      stack,
+      fatal: true,
+      source: 'PlatformDispatcher.onError',
+    );
+    // Return the previous handler's decision when present; otherwise `true`
+    // = "handled" (we logged it). The consumer can still wrap us.
+    if (prevPlatformOnError != null) {
+      return prevPlatformOnError(error, stack);
+    }
+    return true;
+  };
+
+  // 4. Current-isolate error listener. Errors arrive as a 2-element list
+  //    [error, stackTrace] (both String when crossing the port).
+  RawReceivePort? isolatePort;
+  if (installIsolateListener) {
+    try {
+      isolatePort = RawReceivePort((dynamic pair) {
+        final list = pair as List<dynamic>;
+        final err = list.isNotEmpty ? list[0] : 'unknown isolate error';
+        final st = list.length > 1 && list[1] != null
+            ? StackTrace.fromString(list[1].toString())
+            : null;
+        emit(
+          err is Object ? err : '$err',
+          st,
+          fatal: true,
+          source: 'Isolate.onError',
+        );
+      });
+      Isolate.current.addErrorListener(isolatePort.sendPort);
+    } catch (_) {
+      isolatePort?.close();
+      isolatePort = null;
+    }
+  }
+
+  void restore() {
+    FlutterError.onError = prevFlutterOnError;
+    PlatformDispatcher.instance.onError = prevPlatformOnError;
+    if (isolatePort != null) {
+      try {
+        Isolate.current.removeErrorListener(isolatePort.sendPort);
+      } catch (_) {
+        // ignore
+      }
+    }
+  }
+
+  return TelemetryCrashGuard._(restore, isolatePort);
+}
+
+void _replayPersistedCrash(Logger logger, DurableStore store) {
+  try {
+    final raw = store.read(_crashKey);
+    if (raw == null || raw.isEmpty) return;
+    final decoded = jsonDecode(raw);
+    if (decoded is Map) {
+      logger.fatal(
+        decoded['message']?.toString() ?? 'previous-launch crash',
+        <String, Object?>{
+          'error.type': decoded['type']?.toString() ?? 'Error',
+          'error.source': 'crash-on-next-launch',
+          if (decoded['stack'] != null) 'error.stack': decoded['stack'],
+          if (decoded['timestamp'] != null)
+            'error.originalTimestamp': decoded['timestamp'],
+        },
+      );
+    }
+  } catch (_) {
+    // Corrupt crash blob — ignore.
+  } finally {
+    store.remove(_crashKey);
+  }
+}
+
+/// Test helper: persist a synthetic crash as if a prior run died, so a
+/// subsequent [installCrashCapture] replays it. Not part of the consumer flow.
+@visibleForTesting
+void debugWritePersistedCrash(
+  DurableStore store, {
+  required String message,
+  String type = 'StateError',
+}) {
+  store.write(
+    _crashKey,
+    jsonEncode(<String, Object?>{
+      'message': message,
+      'type': type,
+      'stack': null,
+      'timestamp': 0,
+    }),
+  );
+}

--- a/packages/flutter/lib/src/telemetry/durable_sink.dart
+++ b/packages/flutter/lib/src/telemetry/durable_sink.dart
@@ -1,0 +1,266 @@
+/// Durable offline queue + retry/backoff [TelemetrySink] decorator.
+///
+/// Wraps any "transport" [TelemetrySink] (e.g. the Faro engine). Records are
+/// (a) handed straight to the delegate AND (b) appended to a durable on-device
+/// queue. On [flush] the queue is replayed through [DurableSinkTransport];
+/// envelopes that fail to deliver stay queued and are retried on the next
+/// flush with capped exponential backoff. On construction the previously
+/// persisted queue is loaded so records survive process restarts (offline
+/// replay). The queue is bounded so a long offline period can't grow without
+/// limit.
+///
+/// This is an internal implementation detail behind the existing
+/// [TelemetrySink] surface — the consumer-facing API is unchanged across
+/// web / android / ios / desktop. The on-wire envelope is `{ kind, record }`,
+/// identical to `faro_engine.dart` / the web library.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'durable_store.dart';
+import 'types.dart';
+
+/// Where replayed envelopes are delivered. The Faro engine implements this
+/// (its `push` is structurally compatible); a returned `false` (or a throw)
+/// means "not delivered — keep it queued and back off".
+abstract class DurableSinkTransport {
+  /// Deliver one envelope. Return `false` (or throw) to keep it queued.
+  FutureOr<bool> deliver({required String kind, required Map<String, Object?> record});
+}
+
+/// Tuning for [createDurableSink].
+class DurableSinkOptions {
+  /// Creates [DurableSinkOptions].
+  const DurableSinkOptions({
+    this.storageKey = 'telemetry.queue',
+    this.maxQueue = 500,
+    this.baseBackoff = const Duration(seconds: 1),
+    this.maxBackoff = const Duration(minutes: 5),
+  });
+
+  /// Durable-store key holding the newline-delimited envelope queue.
+  final String storageKey;
+
+  /// Hard cap on queued envelopes; oldest are dropped past this (a
+  /// `__dropped` counter is kept so loss is observable).
+  final int maxQueue;
+
+  /// First retry delay after a failed flush.
+  final Duration baseBackoff;
+
+  /// Backoff ceiling.
+  final Duration maxBackoff;
+}
+
+Map<String, Object?> _logToJson(LogRecord r) => <String, Object?>{
+  'level': r.level.wireName,
+  'message': r.message,
+  'timestamp': r.timestamp,
+  'app': r.app,
+  'env': r.env.wireName,
+  'context': r.context,
+};
+
+Map<String, Object?> _spanToJson(SpanRecord r) => <String, Object?>{
+  'name': r.name,
+  'startTime': r.startTime,
+  'endTime': r.endTime,
+  'durationMs': r.durationMs,
+  'app': r.app,
+  'env': r.env.wireName,
+  'context': r.context,
+  'status': r.status,
+  if (r.error != null)
+    'error': <String, Object?>{
+      'name': r.error!.name,
+      'message': r.error!.message,
+    },
+};
+
+/// A [TelemetrySink] backed by a durable offline queue with retry/backoff.
+/// Returned by [createDurableSink]; [pending] exposes the queue depth for
+/// diagnostics/tests.
+abstract class DurableSink implements TelemetrySink {
+  /// Number of envelopes still queued (not yet delivered).
+  int get pending;
+}
+
+class _DurableSink implements DurableSink {
+  _DurableSink(this._transport, this._store, this._opts) {
+    _loadFromDisk();
+  }
+
+  final DurableSinkTransport _transport;
+  final DurableStore _store;
+  final DurableSinkOptions _opts;
+
+  /// Pending envelopes (each: `{ kind, record }`), oldest first.
+  final List<Map<String, Object?>> _queue = <Map<String, Object?>>[];
+
+  int _consecutiveFailures = 0;
+  DateTime _nextAttemptAfter = DateTime.fromMillisecondsSinceEpoch(0);
+  bool _flushing = false;
+
+  @override
+  String get name => 'durable';
+
+  void _loadFromDisk() {
+    try {
+      final raw = _store.read(_opts.storageKey);
+      if (raw == null || raw.isEmpty) return;
+      for (final line in const LineSplitter().convert(raw)) {
+        if (line.trim().isEmpty) continue;
+        final decoded = jsonDecode(line);
+        if (decoded is Map) {
+          _queue.add(decoded.cast<String, Object?>());
+        }
+      }
+      _trim();
+    } catch (_) {
+      // Corrupt queue file — drop it rather than crash-loop on parse.
+      _store.remove(_opts.storageKey);
+      _queue.clear();
+    }
+  }
+
+  void _persist() {
+    try {
+      if (_queue.isEmpty) {
+        _store.remove(_opts.storageKey);
+        return;
+      }
+      final buf = StringBuffer();
+      for (final e in _queue) {
+        buf.writeln(jsonEncode(e));
+      }
+      _store.write(_opts.storageKey, buf.toString());
+    } catch (_) {
+      // Persistence is best-effort; in-memory queue still drives this run.
+    }
+  }
+
+  void _trim() {
+    if (_queue.length <= _opts.maxQueue) return;
+    final overflow = _queue.length - _opts.maxQueue;
+    _queue.removeRange(0, overflow);
+  }
+
+  void _enqueue(Map<String, Object?> envelope) {
+    _queue.add(envelope);
+    _trim();
+    _persist();
+  }
+
+  @override
+  void log(LogRecord record) {
+    _enqueue(<String, Object?>{'kind': 'log', 'record': _logToJson(record)});
+  }
+
+  @override
+  void span(SpanRecord record) {
+    _enqueue(<String, Object?>{'kind': 'span', 'record': _spanToJson(record)});
+  }
+
+  Duration _backoff() {
+    if (_consecutiveFailures == 0) return Duration.zero;
+    final factor = 1 << (_consecutiveFailures - 1).clamp(0, 20);
+    final ms = _opts.baseBackoff.inMilliseconds * factor;
+    final capped = ms > _opts.maxBackoff.inMilliseconds
+        ? _opts.maxBackoff.inMilliseconds
+        : ms;
+    return Duration(milliseconds: capped);
+  }
+
+  @override
+  Future<void> flush() async {
+    if (_flushing) return;
+    if (DateTime.now().isBefore(_nextAttemptAfter)) return; // backing off
+    if (_queue.isEmpty) return;
+    _flushing = true;
+    try {
+      // Drain a snapshot; failures are re-queued at the front in order.
+      final batch = List<Map<String, Object?>>.from(_queue);
+      _queue.clear();
+      final failed = <Map<String, Object?>>[];
+      var anyFailed = false;
+      for (var i = 0; i < batch.length; i++) {
+        final env = batch[i];
+        if (anyFailed) {
+          // Once one fails, keep ordering: don't reorder later envelopes.
+          failed.add(env);
+          continue;
+        }
+        bool ok;
+        try {
+          final record = (env['record'] as Map).cast<String, Object?>();
+          ok = await _transport.deliver(
+            kind: env['kind'] as String,
+            record: record,
+          );
+        } catch (_) {
+          ok = false;
+        }
+        if (!ok) {
+          anyFailed = true;
+          failed.add(env);
+        }
+      }
+      if (failed.isEmpty) {
+        _consecutiveFailures = 0;
+        _nextAttemptAfter = DateTime.fromMillisecondsSinceEpoch(0);
+      } else {
+        _queue.insertAll(0, failed);
+        _consecutiveFailures++;
+        _nextAttemptAfter = DateTime.now().add(_backoff());
+      }
+      _trim();
+      _persist();
+    } finally {
+      _flushing = false;
+    }
+  }
+
+  @override
+  int get pending => _queue.length;
+}
+
+/// Recording transport for tests (no network). Set [failNext] to simulate an
+/// offline window; cleared automatically once it succeeds.
+class RecordingDurableTransport implements DurableSinkTransport {
+  /// Creates a [RecordingDurableTransport].
+  RecordingDurableTransport({this.failWhileOffline = false});
+
+  /// When `true`, every [deliver] returns `false` (offline).
+  bool failWhileOffline;
+
+  /// Successfully delivered envelopes, in order.
+  final List<Map<String, Object?>> delivered = <Map<String, Object?>>[];
+
+  @override
+  FutureOr<bool> deliver({
+    required String kind,
+    required Map<String, Object?> record,
+  }) {
+    if (failWhileOffline) return false;
+    delivered.add(<String, Object?>{'kind': kind, 'record': record});
+    return true;
+  }
+}
+
+/// Wrap [transport] with a durable offline queue + retry/backoff. Pass a
+/// [store] to control persistence (defaults to the platform durable store via
+/// a conditional import). The returned sink is registered like any other
+/// [TelemetrySink]; the manager already drives [flush] on lifecycle exit.
+DurableSink createDurableSink(
+  DurableSinkTransport transport, {
+  DurableStore? store,
+  DurableSinkOptions options = const DurableSinkOptions(),
+}) {
+  return _DurableSink(transport, resolveDurableStore(store), options);
+}
+
+/// The sink's current queue depth (`-1` if not a [DurableSink]). Kept for
+/// call sites that hold the value behind the base [TelemetrySink] type.
+int durableSinkPending(TelemetrySink sink) =>
+    sink is DurableSink ? sink.pending : -1;

--- a/packages/flutter/lib/src/telemetry/durable_store.dart
+++ b/packages/flutter/lib/src/telemetry/durable_store.dart
@@ -1,0 +1,63 @@
+/// Append-only durable byte/line store for the offline telemetry queue.
+///
+/// One identical surface ([DurableStore]); the platform implementation is
+/// chosen by a conditional import — a namespaced JSON file under the OS
+/// app-support/temp dir on android/ios/desktop, `window.localStorage` on
+/// Flutter web, an in-memory list everywhere else (tests). No new pub
+/// dependency: `dart:io` / web interop only — the exact pattern Wave-0's
+/// analytics module already uses.
+///
+/// Store-compliance: on iOS the only "required reason" API this code path can
+/// touch is **file timestamp** (`NSFileSystemFreeSize` is NOT used; we use
+/// `creationDate`/`modificationDate` implicitly via `File`), declared with
+/// reason code **C617.1** ("display to the person ... the file timestamp")
+/// in `PrivacyInfo.xcprivacy`. The queued payload contains only the records
+/// the app already chose to emit (post-redaction) — see DATA_SAFETY.md.
+library;
+
+import 'durable_store_stub.dart'
+    if (dart.library.io) 'durable_store_io.dart'
+    if (dart.library.js_interop) 'durable_store_web.dart'
+    as platform;
+
+/// A tiny durable key→list-of-lines store. The queue keeps a single key
+/// (`telemetry.queue`) holding newline-delimited JSON envelopes, plus an
+/// optional crash key (`telemetry.crash`).
+abstract class DurableStore {
+  /// Read the full content for [key], or `null` when absent/unreadable.
+  String? read(String key);
+
+  /// Replace the content for [key] (durably, best-effort).
+  void write(String key, String value);
+
+  /// Delete [key].
+  void remove(String key);
+}
+
+/// Volatile fallback store (used in pure unit tests / unsupported platforms).
+class MemoryDurableStore implements DurableStore {
+  final Map<String, String> _m = <String, String>{};
+
+  @override
+  String? read(String key) => _m[key];
+
+  @override
+  void write(String key, String value) => _m[key] = value;
+
+  @override
+  void remove(String key) => _m.remove(key);
+}
+
+/// Resolve the platform durable store. A caller-supplied store always wins;
+/// any platform failure degrades silently to in-memory so telemetry never
+/// throws because the disk was read-only.
+DurableStore resolveDurableStore([DurableStore? override]) {
+  if (override != null) return override;
+  try {
+    final s = platform.createPlatformDurableStore();
+    if (s != null) return s;
+  } catch (_) {
+    // fall through
+  }
+  return MemoryDurableStore();
+}

--- a/packages/flutter/lib/src/telemetry/durable_store_io.dart
+++ b/packages/flutter/lib/src/telemetry/durable_store_io.dart
@@ -1,0 +1,65 @@
+/// Durable store for `dart:io` targets (Android, iOS, macOS, Windows, Linux).
+///
+/// One namespaced file per key under the OS temp dir. Mirrors Wave-0's
+/// analytics `storage_io.dart` exactly (no `path_provider`/`shared_preferences`
+/// dependency) so the offline telemetry queue survives process restarts while
+/// the package stays dependency-free. The directory name is namespaced so it
+/// never collides with the consuming app's own data.
+library;
+
+import 'dart:io';
+
+import 'durable_store.dart';
+
+class _FileDurableStore implements DurableStore {
+  _FileDurableStore(this._dir);
+
+  final Directory _dir;
+
+  File _fileFor(String key) {
+    final safe = key.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '_');
+    return File('${_dir.path}/$safe.ndjson');
+  }
+
+  @override
+  String? read(String key) {
+    try {
+      final f = _fileFor(key);
+      if (!f.existsSync()) return null;
+      final raw = f.readAsStringSync();
+      return raw.isEmpty ? null : raw;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  void write(String key, String value) {
+    try {
+      _dir.createSync(recursive: true);
+      _fileFor(key).writeAsStringSync(value, flush: true);
+    } catch (_) {
+      // Read-only FS / quota — degrade silently.
+    }
+  }
+
+  @override
+  void remove(String key) {
+    try {
+      final f = _fileFor(key);
+      if (f.existsSync()) f.deleteSync();
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+DurableStore? createPlatformDurableStore() {
+  try {
+    final base = Directory.systemTemp.path;
+    final dir = Directory('$base/refraction_ui_telemetry');
+    return _FileDurableStore(dir);
+  } catch (_) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/telemetry/durable_store_stub.dart
+++ b/packages/flutter/lib/src/telemetry/durable_store_stub.dart
@@ -1,0 +1,7 @@
+/// Durable-store fallback for platforms with neither `dart:io` nor web
+/// interop. Returns null so the resolver uses the in-memory store.
+library;
+
+import 'durable_store.dart';
+
+DurableStore? createPlatformDurableStore() => null;

--- a/packages/flutter/lib/src/telemetry/durable_store_web.dart
+++ b/packages/flutter/lib/src/telemetry/durable_store_web.dart
@@ -1,0 +1,70 @@
+/// Durable store for Flutter web — `window.localStorage` via `dart:js_interop`
+/// (SDK-provided, no extra pub dependency; matches `lifecycle_web.dart`'s
+/// modern interop instead of the deprecated `dart:html`). Degrades silently
+/// (private mode / disabled) so the resolver can fall back to memory.
+library;
+
+import 'dart:js_interop';
+
+import 'durable_store.dart';
+
+@JS('window')
+external _Window get _window;
+
+@JS()
+@staticInterop
+class _Window {}
+
+extension on _Window {
+  external _Storage get localStorage;
+}
+
+@JS()
+@staticInterop
+class _Storage {}
+
+extension on _Storage {
+  external JSString? getItem(JSString key);
+  external void setItem(JSString key, JSString value);
+  external void removeItem(JSString key);
+}
+
+class _LocalStorageDurable implements DurableStore {
+  @override
+  String? read(String key) {
+    try {
+      return _window.localStorage.getItem(key.toJS)?.toDart;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  void write(String key, String value) {
+    try {
+      _window.localStorage.setItem(key.toJS, value.toJS);
+    } catch (_) {
+      // Quota / disabled — degrade silently.
+    }
+  }
+
+  @override
+  void remove(String key) {
+    try {
+      _window.localStorage.removeItem(key.toJS);
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+DurableStore? createPlatformDurableStore() {
+  try {
+    const probe = '__rfx_t_probe__';
+    _window.localStorage.setItem(probe.toJS, '1'.toJS);
+    _window.localStorage.removeItem(probe.toJS);
+    return _LocalStorageDurable();
+  } catch (_) {
+    return null;
+  }
+}

--- a/packages/flutter/lib/src/telemetry/isolate_queue.dart
+++ b/packages/flutter/lib/src/telemetry/isolate_queue.dart
@@ -1,0 +1,181 @@
+/// Isolate-aware telemetry ingestion (SendPort bridge).
+///
+/// A background isolate (compute / `Isolate.spawn`) has its own memory and
+/// cannot reach the main isolate's [Telemetry] / sinks, so its logs would be
+/// lost. This bridges them: the main isolate opens an ingest port; a worker
+/// isolate is handed the [SendPort] and emits through a lightweight [Logger]
+/// that serializes each record and posts it over the port. The host re-emits
+/// every received record through the real telemetry pipeline (redaction →
+/// sinks → durable queue), so background-isolate logs survive.
+///
+/// Internal detail behind the existing surface — the public API is unchanged
+/// and identical across web / android / ios / desktop. (On Flutter web there
+/// are no `dart:isolate` worker isolates in the same sense; the host side is a
+/// harmless no-op there and direct logging is used instead — the consumer
+/// code path is the same.)
+library;
+
+import 'dart:isolate';
+
+import 'types.dart';
+
+/// Wire shape posted over the [SendPort]. Kept to JSON-safe primitives so it
+/// crosses the isolate boundary without custom codecs.
+typedef _Envelope = Map<String, Object?>;
+
+/// Host side: owns a [ReceivePort], re-emits worker records into [target].
+class TelemetryIsolateHost {
+  TelemetryIsolateHost._(this._port, this._target) {
+    _port.listen(_onMessage);
+  }
+
+  final ReceivePort _port;
+  final Logger _target;
+  bool _closed = false;
+
+  /// Hand this to a spawned isolate; use it to build a
+  /// [createIsolateLogger]. Safe to pass through `Isolate.spawn`.
+  SendPort get sendPort => _port.sendPort;
+
+  /// Open an ingest host that forwards worker records into [target]
+  /// (typically your root [Telemetry] or a child of it).
+  factory TelemetryIsolateHost.attach(Logger target) =>
+      TelemetryIsolateHost._(ReceivePort(), target);
+
+  void _onMessage(dynamic message) {
+    if (_closed || message is! Map) return;
+    final env = message.cast<String, Object?>();
+    final kind = env['kind'];
+    final ctx = (env['context'] as Map?)?.cast<String, Object?>() ??
+        const <String, Object?>{};
+    if (kind == 'log') {
+      final level = env['level'] as String? ?? 'info';
+      final msg = env['message'] as String? ?? '';
+      switch (level) {
+        case 'debug':
+          _target.debug(msg, ctx);
+          break;
+        case 'warn':
+          _target.warn(msg, ctx);
+          break;
+        case 'error':
+          _target.error(msg, ctx);
+          break;
+        case 'fatal':
+          _target.fatal(msg, ctx);
+          break;
+        case 'info':
+        default:
+          _target.info(msg, ctx);
+          break;
+      }
+    } else if (kind == 'span') {
+      // Spans crossing isolates are recorded as a synthetic completed span
+      // (start/end already happened in the worker).
+      final name = env['name'] as String? ?? 'isolate-span';
+      final span = _target.startSpan(name, ctx);
+      span.end();
+    }
+  }
+
+  /// Stop accepting worker records.
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    _port.close();
+  }
+}
+
+/// Worker side: a minimal [Logger] that serializes onto [port]. Only the
+/// emit/child surface is meaningful in a worker; [flush] is a no-op (the host
+/// isolate owns flushing), spans post a single completed-span envelope.
+class _IsolateLogger implements Logger {
+  _IsolateLogger(this._port, this._bound);
+
+  final SendPort _port;
+  final Map<String, Object?> _bound;
+
+  void _post(String level, String message, Map<String, Object?>? ctx) {
+    final env = <String, Object?>{
+      'kind': 'log',
+      'level': level,
+      'message': message,
+      'context': <String, Object?>{..._bound, ...?ctx},
+    };
+    _safeSend(env);
+  }
+
+  void _safeSend(_Envelope env) {
+    try {
+      _port.send(env);
+    } catch (_) {
+      // Port closed / non-sendable payload — drop rather than crash a worker.
+    }
+  }
+
+  @override
+  void debug(String message, [LogContext? context]) =>
+      _post('debug', message, context);
+
+  @override
+  void info(String message, [LogContext? context]) =>
+      _post('info', message, context);
+
+  @override
+  void warn(String message, [LogContext? context]) =>
+      _post('warn', message, context);
+
+  @override
+  void error(String message, [LogContext? context]) =>
+      _post('error', message, context);
+
+  @override
+  void fatal(String message, [LogContext? context]) =>
+      _post('fatal', message, context);
+
+  @override
+  Logger child(LogContext context) =>
+      _IsolateLogger(_port, <String, Object?>{..._bound, ...context});
+
+  @override
+  Span startSpan(String name, [LogContext? attributes]) {
+    final port = _port;
+    final bound = _bound;
+    return _IsolateSpan(() {
+      port.send(<String, Object?>{
+        'kind': 'span',
+        'name': name,
+        'context': <String, Object?>{...bound, ...?attributes},
+      });
+    });
+  }
+
+  @override
+  Future<void> flush() async {
+    // The host isolate owns sinks/flush; nothing to do here.
+  }
+}
+
+class _IsolateSpan implements Span {
+  _IsolateSpan(this._onEnd);
+
+  final void Function() _onEnd;
+  bool _ended = false;
+
+  @override
+  void end([SpanEndOptions? opts]) {
+    if (_ended) return;
+    _ended = true;
+    try {
+      _onEnd();
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+/// Build a worker-isolate [Logger] that forwards to the host via [port]
+/// (obtained from [TelemetryIsolateHost.sendPort] and passed into the
+/// spawned isolate). Background-isolate logs are no longer lost.
+Logger createIsolateLogger(SendPort port) =>
+    _IsolateLogger(port, const <String, Object?>{});

--- a/packages/flutter/lib/src/telemetry/lifecycle_io.dart
+++ b/packages/flutter/lib/src/telemetry/lifecycle_io.dart
@@ -1,24 +1,56 @@
 /// Non-web lifecycle hook (android / ios / macos / windows / linux).
 ///
 /// Internal implementation detail behind [LifecycleHook] — selected via the
-/// conditional import in `lifecycle.dart`. On desktop/server targets it
-/// listens for process termination signals (SIGTERM/SIGINT) so buffered
-/// records are flushed on exit. On mobile, foreground/background lifecycle
-/// transitions are driven by the Wave 1 engine layer through the same
-/// [LifecycleHook] surface; the core stays platform-agnostic and never
-/// imports Flutter widget bindings. Signal registration is guarded so it is
-/// a safe no-op where signals are unsupported.
+/// conditional import in `lifecycle.dart`. Wave-1 mobile wiring:
+///
+///  - When a Flutter binding is available it attaches a
+///    [WidgetsBindingObserver] and fires the exit callback on
+///    `AppLifecycleState.paused`, `.inactive`, and `.detached`. This is the
+///    mobile replacement for the web `pagehide`/`visibilitychange` beacon:
+///    the OS can suspend/kill a backgrounded app at any moment, so the queue
+///    is flushed the instant it leaves the foreground.
+///  - It ALSO watches `SIGTERM`/`SIGINT` so desktop (macOS/Windows/Linux)
+///    and server runs still flush on process termination. Signal
+///    registration is guarded so it is a safe no-op where signals are
+///    unsupported (mobile).
+///
+/// The core's public surface and the manager are unchanged; this stays behind
+/// the single [LifecycleHook] abstraction and is uniform across all targets.
 library;
 
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/widgets.dart';
+
 import 'lifecycle.dart';
 
+class _LifecycleObserver with WidgetsBindingObserver {
+  _LifecycleObserver(this._onExit);
+
+  final void Function() _onExit;
+  AppLifecycleState? _last;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Flush whenever we transition into a not-foreground state. Guard against
+    // repeated identical callbacks (inactive↔paused churn) so we don't spam
+    // flushes, while still flushing once per backgrounding.
+    final leavingForeground = state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.detached;
+    if (leavingForeground && _last != state) {
+      _onExit();
+    }
+    _last = state;
+  }
+}
+
 class _IoSubscription implements LifecycleSubscription {
-  _IoSubscription(this._subs);
+  _IoSubscription(this._subs, this._observer);
 
   final List<StreamSubscription<ProcessSignal>> _subs;
+  final _LifecycleObserver? _observer;
   bool _cancelled = false;
 
   @override
@@ -29,6 +61,12 @@ class _IoSubscription implements LifecycleSubscription {
       unawaited(s.cancel());
     }
     _subs.clear();
+    final obs = _observer;
+    if (obs != null) {
+      final binding = WidgetsBinding.instance;
+      // ignore: unnecessary_null_comparison
+      if (binding != null) binding.removeObserver(obs);
+    }
   }
 }
 
@@ -37,20 +75,35 @@ class _IoLifecycleHook implements LifecycleHook {
 
   @override
   LifecycleSubscription onExit(void Function() onExit) {
+    _LifecycleObserver? observer;
+    // App-lifecycle (mobile background = beacon equivalent). Only when a
+    // Flutter binding exists (it won't in a plain `dart test` VM — desktop
+    // signal handling below still covers process exit there).
+    try {
+      final binding = WidgetsBinding.instance;
+      // ignore: unnecessary_null_comparison
+      if (binding != null) {
+        observer = _LifecycleObserver(onExit);
+        binding.addObserver(observer);
+      }
+    } catch (_) {
+      // No binding (pure unit-test VM) — signals/explicit flush still work.
+    }
+
+    // Process-termination signals (desktop / server).
     final subs = <StreamSubscription<ProcessSignal>>[];
     void watch(ProcessSignal signal) {
       try {
         subs.add(signal.watch().listen((_) => onExit()));
       } catch (_) {
-        // Signal unsupported on this platform (e.g. mobile) — safe no-op.
-        // Mobile background flush is wired by the Wave 1 engine layer
-        // through this same surface.
+        // Signal unsupported on this platform (e.g. mobile) — safe no-op;
+        // the WidgetsBindingObserver above already covers mobile background.
       }
     }
 
     watch(ProcessSignal.sigterm);
     watch(ProcessSignal.sigint);
-    return _IoSubscription(subs);
+    return _IoSubscription(subs, observer);
   }
 }
 

--- a/packages/flutter/lib/src/telemetry/mobile.dart
+++ b/packages/flutter/lib/src/telemetry/mobile.dart
@@ -1,0 +1,88 @@
+/// Mobile (iOS/Android) + desktop telemetry integration — the single
+/// opt-in entry point that wires the Wave-1 internals together behind the
+/// existing surface:
+///
+///  - native device/app context auto-attach (a `device` sub-context on every
+///    record, via a [Telemetry.child]),
+///  - crash capture (`FlutterError` + `PlatformDispatcher` + isolate) with
+///    crash-on-next-launch persistence,
+///  - ATT/IDFA + consent sequencing (no IDs before consent).
+///
+/// The base [createTelemetry] already handles engine wiring, the durable
+/// queue (when a [createDurableSink] is registered) and lifecycle flush
+/// (`AppLifecycleState.paused/inactive/detached` via the conditional
+/// `lifecycle_io.dart`). This helper is additive and **does not change the
+/// public API**: it returns a `Telemetry` that is used exactly like the one
+/// from `createTelemetry`, identical across web / android / ios / desktop.
+library;
+
+import 'att_gate.dart';
+import 'crash_capture.dart';
+import 'durable_store.dart';
+import 'native_context.dart';
+import 'types.dart';
+
+/// Result of [installMobileTelemetry]: the context-enriched telemetry plus
+/// the crash guard and the ATT/consent gate the host drives.
+class MobileTelemetry {
+  /// Creates a [MobileTelemetry].
+  const MobileTelemetry({
+    required this.telemetry,
+    required this.crashGuard,
+    required this.consent,
+  });
+
+  /// Use exactly like the return of `createTelemetry` — every record carries
+  /// the native `device` context, crashes are captured, and the gate is
+  /// honored. Calling `child()` keeps all of that.
+  final Telemetry telemetry;
+
+  /// Installed crash guard (call `dispose()` to detach hooks; mostly tests).
+  final TelemetryCrashGuard crashGuard;
+
+  /// ATT / consent gate the host drives from its own ATT prompt result.
+  final TelemetryConsent consent;
+}
+
+/// Wire native context + crash capture + consent onto an existing [base]
+/// telemetry (from `createTelemetry`).
+///
+/// - [overrides] supplies app version/build (no plugin dependency).
+/// - [store] controls crash-on-next-launch persistence.
+/// - [consent] lets the host pass a pre-seeded gate (e.g. ATT already
+///   resolved); defaults to `notDetermined` (safe — no tracking id emitted).
+/// - [installIsolateListener] / [now] forwarded to crash capture (tests).
+MobileTelemetry installMobileTelemetry(
+  Telemetry base, {
+  NativeContextOverrides? overrides,
+  DurableStore? store,
+  TelemetryConsent? consent,
+  bool installIsolateListener = true,
+  DateTime Function()? now,
+}) {
+  final gate = consent ?? TelemetryConsent();
+
+  // Native context as a bound child — non-identifying, attached once. The
+  // tracking id (if any) is added ONLY via gate.trackingContext(), which is
+  // empty until ATT authorization, enforcing "no IDs before consent".
+  final native = NativeContext.resolve(overrides);
+  final boundCtx = <String, Object?>{
+    if (native.isNotEmpty) 'device': native.values,
+    ...gate.trackingContext(),
+  };
+  final enriched =
+      boundCtx.isEmpty ? base : base.child(boundCtx);
+
+  final guard = installCrashCapture(
+    enriched,
+    store: store,
+    installIsolateListener: installIsolateListener,
+    now: now,
+  );
+
+  return MobileTelemetry(
+    telemetry: enriched,
+    crashGuard: guard,
+    consent: gate,
+  );
+}

--- a/packages/flutter/lib/src/telemetry/native_context.dart
+++ b/packages/flutter/lib/src/telemetry/native_context.dart
@@ -1,0 +1,92 @@
+/// Native device/app context auto-attach.
+///
+/// Collects a small, fixed, **non-identifying** set of attributes — device
+/// model, OS name + version, app version/build, locale — and merges them once
+/// onto every record's context as a `device` sub-map. This is the same on
+/// web / android / ios / desktop: the public surface is a single
+/// [NativeContext] resolved behind a conditional import. No advertising ID,
+/// no IDFA/IDFV, no MAC, no persistent hardware identifier is ever read here
+/// (store-compliance: see `PrivacyInfo.xcprivacy` + DATA_SAFETY.md).
+///
+/// Dependency policy: this uses only `dart:io` (`Platform`) and Flutter SDK
+/// APIs (`PlatformDispatcher.locale`). It deliberately does NOT pull
+/// `device_info_plus` / `package_info_plus`; app version/build are read from
+/// the optional [NativeContextOverrides] the consumer can supply (or from
+/// `--dart-define`d values) so the package stays dependency-free while still
+/// shipping the attributes stores expect documented.
+library;
+
+import 'native_context_stub.dart'
+    if (dart.library.io) 'native_context_io.dart'
+    if (dart.library.js_interop) 'native_context_web.dart'
+    as platform;
+
+/// Consumer-supplied overrides. App version/build are not reliably available
+/// without a plugin; the consumer passes them (commonly from generated build
+/// config or `--dart-define`). Any field left null is simply omitted.
+class NativeContextOverrides {
+  /// Creates [NativeContextOverrides].
+  const NativeContextOverrides({
+    this.appVersion,
+    this.appBuild,
+    this.deviceModel,
+    this.osName,
+    this.osVersion,
+    this.locale,
+  });
+
+  /// Marketing version, e.g. `1.4.0` (iOS `CFBundleShortVersionString` /
+  /// Android `versionName`).
+  final String? appVersion;
+
+  /// Build number, e.g. `42` (iOS `CFBundleVersion` / Android `versionCode`).
+  final String? appBuild;
+
+  /// Override the auto-detected device model.
+  final String? deviceModel;
+
+  /// Override the auto-detected OS name (`ios`, `android`, ...).
+  final String? osName;
+
+  /// Override the auto-detected OS version string.
+  final String? osVersion;
+
+  /// Override the auto-detected locale (BCP-47-ish, e.g. `en-US`).
+  final String? locale;
+}
+
+/// Resolves the native device/app attributes for the current platform.
+class NativeContext {
+  NativeContext._(this._values);
+
+  final Map<String, Object?> _values;
+
+  /// Resolve the platform context once. Failures degrade to an empty map so
+  /// telemetry never breaks because a platform probe threw.
+  factory NativeContext.resolve([NativeContextOverrides? overrides]) {
+    Map<String, Object?> base;
+    try {
+      base = platform.collectNativeContext();
+    } catch (_) {
+      base = <String, Object?>{};
+    }
+    if (overrides != null) {
+      if (overrides.appVersion != null) base['appVersion'] = overrides.appVersion;
+      if (overrides.appBuild != null) base['appBuild'] = overrides.appBuild;
+      if (overrides.deviceModel != null) {
+        base['deviceModel'] = overrides.deviceModel;
+      }
+      if (overrides.osName != null) base['osName'] = overrides.osName;
+      if (overrides.osVersion != null) base['osVersion'] = overrides.osVersion;
+      if (overrides.locale != null) base['locale'] = overrides.locale;
+    }
+    base.removeWhere((_, v) => v == null);
+    return NativeContext._(base);
+  }
+
+  /// The collected attributes (a fresh copy; callers may mutate it).
+  Map<String, Object?> get values => Map<String, Object?>.from(_values);
+
+  /// `true` when at least one attribute was resolved.
+  bool get isNotEmpty => _values.isNotEmpty;
+}

--- a/packages/flutter/lib/src/telemetry/native_context_io.dart
+++ b/packages/flutter/lib/src/telemetry/native_context_io.dart
@@ -1,0 +1,84 @@
+/// Native-context collector for `dart:io` targets (Android, iOS, macOS,
+/// Windows, Linux).
+///
+/// Reads ONLY non-identifying, store-safe values:
+///  - `osName`      — `ios` / `android` / `macos` / `windows` / `linux`
+///  - `osVersion`   — `Platform.operatingSystemVersion` (kernel/OS string)
+///  - `deviceModel` — best-effort: `Platform.localHostname` on desktop;
+///                    on mobile this is a generic value (`iPhone`/`Android`)
+///                    because the precise model needs a plugin we deliberately
+///                    avoid. The consumer can override via
+///                    `NativeContextOverrides.deviceModel`.
+///  - `locale`      — `PlatformDispatcher.instance.locale` (BCP-47-ish)
+///  - `dartVersion` — `Platform.version` (diagnostic only)
+///
+/// No advertising ID, IDFA/IDFV, MAC, serial, or any persistent hardware
+/// identifier is read. Required-reason API note: the only "required reason"
+/// API potentially touched on iOS is file timestamps via the durable queue
+/// (declared `C617.1` in the privacy manifest) — nothing here reads one.
+library;
+
+import 'dart:io';
+import 'dart:ui' show PlatformDispatcher;
+
+Map<String, Object?> collectNativeContext() {
+  final out = <String, Object?>{};
+
+  String osName;
+  if (Platform.isIOS) {
+    osName = 'ios';
+  } else if (Platform.isAndroid) {
+    osName = 'android';
+  } else if (Platform.isMacOS) {
+    osName = 'macos';
+  } else if (Platform.isWindows) {
+    osName = 'windows';
+  } else if (Platform.isLinux) {
+    osName = 'linux';
+  } else {
+    osName = Platform.operatingSystem;
+  }
+  out['osName'] = osName;
+
+  try {
+    out['osVersion'] = Platform.operatingSystemVersion;
+  } catch (_) {
+    // Some sandboxes deny this — omit.
+  }
+
+  // Device model: precise model requires a platform plugin we intentionally
+  // do not depend on. Use a coarse, non-identifying value; consumers wanting
+  // the exact model pass NativeContextOverrides.deviceModel.
+  try {
+    if (Platform.isIOS) {
+      out['deviceModel'] = 'iPhone/iPad';
+    } else if (Platform.isAndroid) {
+      out['deviceModel'] = 'Android';
+    } else {
+      // Desktop hostname is a user-set, non-hardware label — fine to report.
+      out['deviceModel'] = Platform.localHostname;
+    }
+  } catch (_) {
+    // Hostname lookup can throw in locked-down sandboxes — omit.
+  }
+
+  try {
+    final l = PlatformDispatcher.instance.locale;
+    final tag = l.countryCode == null || l.countryCode!.isEmpty
+        ? l.languageCode
+        : '${l.languageCode}-${l.countryCode}';
+    if (tag.isNotEmpty) out['locale'] = tag;
+  } catch (_) {
+    // Locale unavailable before the engine binds — omit.
+  }
+
+  try {
+    // Major.minor only; the full version string is noisy.
+    final v = Platform.version.split(' ').first;
+    out['dartVersion'] = v;
+  } catch (_) {
+    // omit
+  }
+
+  return out;
+}

--- a/packages/flutter/lib/src/telemetry/native_context_stub.dart
+++ b/packages/flutter/lib/src/telemetry/native_context_stub.dart
@@ -1,0 +1,7 @@
+/// Native-context fallback for platforms with neither `dart:io` nor web
+/// interop (e.g. a bare unit-test VM). Returns an empty map — the overrides
+/// path still works.
+library;
+
+/// No platform probes available — empty context.
+Map<String, Object?> collectNativeContext() => <String, Object?>{};

--- a/packages/flutter/lib/src/telemetry/native_context_web.dart
+++ b/packages/flutter/lib/src/telemetry/native_context_web.dart
@@ -1,0 +1,25 @@
+/// Native-context collector for Flutter web.
+///
+/// Web has no device model / OS APIs that are store-safe and stable, so this
+/// reports only the engine locale. `navigator.userAgent` is intentionally NOT
+/// read (fingerprinting surface). The uniform surface is preserved — web just
+/// resolves a smaller map. Consumers can still inject app version/build via
+/// `NativeContextOverrides`.
+library;
+
+import 'dart:ui' show PlatformDispatcher;
+
+Map<String, Object?> collectNativeContext() {
+  final out = <String, Object?>{};
+  out['osName'] = 'web';
+  try {
+    final l = PlatformDispatcher.instance.locale;
+    final tag = l.countryCode == null || l.countryCode!.isEmpty
+        ? l.languageCode
+        : '${l.languageCode}-${l.countryCode}';
+    if (tag.isNotEmpty) out['locale'] = tag;
+  } catch (_) {
+    // omit
+  }
+  return out;
+}

--- a/packages/flutter/lib/src/telemetry/telemetry.dart
+++ b/packages/flutter/lib/src/telemetry/telemetry.dart
@@ -91,5 +91,43 @@ export 'redact.dart' show redact;
 // Mock sink (for testing).
 export 'mock_sink.dart' show createMockSink, MockSinkExtended;
 
-// App-exit flush hook (uniform surface; platform wiring is internal).
+// App-exit / app-background flush hook (uniform surface; platform wiring —
+// web pagehide / mobile AppLifecycleState.paused·inactive·detached / desktop
+// SIGTERM — is an internal conditional-import detail).
 export 'lifecycle.dart' show LifecycleHook, LifecycleSubscription;
+
+// ---- Wave-1 mobile/desktop layer (all internal behind the surface) -------
+// The public API/structure is unchanged and identical across every target;
+// these are additive helpers — platform differences stay behind conditional
+// imports.
+
+// Durable offline queue + retry/backoff sink (wraps any transport sink).
+export 'durable_sink.dart'
+    show
+        createDurableSink,
+        DurableSink,
+        DurableSinkOptions,
+        DurableSinkTransport,
+        RecordingDurableTransport,
+        durableSinkPending;
+
+// Pluggable durable store (platform-selected; injectable for tests).
+export 'durable_store.dart'
+    show DurableStore, MemoryDurableStore, resolveDurableStore;
+
+// Native device/app context auto-attach.
+export 'native_context.dart' show NativeContext, NativeContextOverrides;
+
+// Crash capture + crash-on-next-launch.
+export 'crash_capture.dart'
+    show installCrashCapture, TelemetryCrashGuard, debugWritePersistedCrash;
+
+// Isolate-aware ingestion (background-isolate logs aren't lost).
+export 'isolate_queue.dart' show TelemetryIsolateHost, createIsolateLogger;
+
+// ATT/IDFA gating + consent sequencing (no IDs before consent).
+export 'att_gate.dart' show TelemetryConsent, TrackingState;
+
+// One-call mobile/desktop integration (additive; same usage as
+// createTelemetry — context auto-attach + crash + consent).
+export 'mobile.dart' show installMobileTelemetry, MobileTelemetry;

--- a/packages/flutter/store_compliance/ATT_CONSENT.md
+++ b/packages/flutter/store_compliance/ATT_CONSENT.md
@@ -1,0 +1,65 @@
+# App Tracking Transparency (ATT) / IDFA + consent sequencing
+
+Release-blocking store-compliance artifact (epic #225 §3). Explains how the
+Flutter telemetry layer guarantees **no identifiers before consent** and how
+a consuming app must sequence the iOS ATT prompt.
+
+## What refraction_ui does and does NOT do
+
+- **Does NOT** read the IDFA / IDFV / advertising ID. No `AdSupport`, no
+  `app_tracking_transparency` dependency. The native context
+  (`native_context_io.dart`) is OS name/version + coarse model + locale +
+  app version/build only — **nothing identifying**.
+- **Does NOT** present the ATT prompt (that is the app's call, on the app's
+  schedule, with the app's `NSUserTrackingUsageDescription`).
+- **Does** provide `TelemetryConsent`, a gate that makes correct sequencing
+  the default and makes "an ID set before consent" structurally impossible.
+
+## Required sequence (iOS)
+
+```
+1. App launches.
+   createTelemetry(...) + installMobileTelemetry(...)         ← no tracking id
+   TelemetryConsent starts in `notDetermined`.
+   → telemetry flows with crash/diagnostics ONLY, no IDFA.
+
+2. App decides to ask (its own UX, after first frame, per Apple HIG).
+   App calls ATTrackingManager.requestTrackingAuthorization
+   (its own plugin/native code).
+
+3. App reports the result back:
+   consent.setTrackingAuthorized(TrackingState.authorized | .denied)
+
+4. ONLY if authorized:
+   final idfa = <app reads IDFA via its own plugin>;
+   consent.attachTrackingId(idfa);   // guarded: no-op unless authorized
+   → from now on consent.trackingContext() carries {'trackingId': idfa}
+     and the app can merge it into telemetry context.
+
+5. If the user later revokes (Settings):
+   consent.setTrackingAuthorized(TrackingState.denied)
+   → trackingId is cleared immediately; nothing further is emitted.
+```
+
+`attachTrackingId()` returns `false` and stores nothing while the state is
+`notDetermined`/`denied` — a programming mistake cannot leak an ID early.
+
+## Android / web / desktop
+
+There is no ATT prompt. Construct
+`TelemetryConsent(initial: TrackingState.notApplicable)`; tracking IDs remain
+disallowed until the app explicitly authorizes via category/marketing consent
+and calls `setTrackingAuthorized(authorized)`. The API is identical — no
+per-platform consumer branching (uniform surface, epic #225 §2).
+
+## Checklist for the consuming app
+
+- [ ] iOS `Info.plist` has `NSUserTrackingUsageDescription` **only if** the
+      app attaches an ad ID. If it does not, do not add it (and keep
+      `NSPrivacyTracking=false` in the merged `PrivacyInfo.xcprivacy`).
+- [ ] ATT prompt shown after first frame, never at the very first launch
+      instant, never before any value.
+- [ ] No call to `attachTrackingId` before `setTrackingAuthorized(authorized)`
+      (the gate enforces this; the check is a belt-and-braces).
+- [ ] If an ad ID is attached, the app's iOS privacy manifest +
+      Play Data Safety form are updated to declare it (see the sibling docs).

--- a/packages/flutter/store_compliance/PLAY_DATA_SAFETY.md
+++ b/packages/flutter/store_compliance/PLAY_DATA_SAFETY.md
@@ -1,0 +1,44 @@
+# Google Play — Data Safety mapping (refraction_ui telemetry, Wave 1)
+
+Release-blocking, MANDATORY store-compliance artifact (epic #225 DESIGN
+CLARIFICATION §3). This documents **exactly what the Flutter telemetry layer
+collects** so a consuming app can complete the Play Console **Data safety**
+form and pass review with **zero rejection risk**.
+
+> Data goes to the **consuming app's own collector endpoint** (configured via
+> `TelemetryConfig.endpoint`), never to a refraction-ui server. The package
+> only *captures and queues*; the consumer chooses the destination.
+
+## Does this layer collect or share data?
+
+| Question (Play form) | Answer for this layer |
+|---|---|
+| Does your app collect or share any of the required user data types? | **Yes** — diagnostics only (see table). |
+| Is all collected data encrypted in transit? | The consumer's collector endpoint **must** be HTTPS (the package does not downgrade). |
+| Do you provide a way to request deletion? | Consumer-owned (their collector / backend). |
+| Is data collection optional? | Yes — `enabled: false` disables it entirely (tree-shakeable no-op); production sampling/consent gating applies. |
+
+## Data types collected by THIS layer
+
+| Play data type | Collected? | What | Why | Linked to user? | Used for tracking? |
+|---|---|---|---|---|---|
+| **Crash logs** (App activity → Crash logs / Diagnostics) | Yes | Exception type, message, stack trace; persisted once for crash-on-next-launch | App functionality / diagnostics | No (no identifier attached by this layer) | No |
+| **Diagnostics** (Performance / Other) | Yes | Log records & span durations the app emits, post-redaction | App functionality / performance | No | No |
+| **Device or other IDs** (Advertising ID, etc.) | **No** | The package never reads the Advertising ID / GAID / IMEI / MAC / serial | — | — | — |
+| **App info & performance → Other app performance data** | Yes | OS name+version, coarse device model (`"Android"`), locale, app version/build (consumer-supplied) | Diagnostics: bucket telemetry by platform | No | No |
+| Personal info / Location / Contacts / Photos / Messages / Audio / Files | **No** | Not accessed by this layer | — | — | — |
+
+### Notes for the consuming app's submission
+
+1. **Redaction is on the app.** This layer ships `redact()` and honors
+   `redactKeys`, but if the *app* puts PII in log context that PII is
+   collected. Declare accordingly; prefer redacting it.
+2. **Advertising ID:** if the consuming app *separately* attaches an ad ID it
+   MUST go through `TelemetryConsent` (see `ATT_CONSENT.md`) and the app must
+   then add **Advertising ID** to its Data safety form. By default this layer
+   adds nothing.
+3. **No tracking.** Nothing here joins data across apps/sites or shares with
+   data brokers. Answer "Used for tracking? No" for every row above.
+4. **Storage:** the offline queue is a namespaced file under the app's
+   private temp dir (Android internal storage) — not user-accessible, not
+   shared, cleared once delivered.

--- a/packages/flutter/store_compliance/README.md
+++ b/packages/flutter/store_compliance/README.md
@@ -1,0 +1,27 @@
+# Store compliance — refraction_ui Flutter telemetry (Wave 1)
+
+App Store / Play Store compliance for the telemetry/analytics layer is a
+**MANDATORY, release-blocking deliverable** (epic #225 DESIGN CLARIFICATION
+§3). Zero store-rejection risk is acceptance criteria. These artifacts cover
+exactly the code added in Wave 1 (offline persistence, crash-on-next-launch,
+native device/app context, ATT/consent sequencing).
+
+| File | Purpose |
+|---|---|
+| `ios/PrivacyInfo.xcprivacy` | iOS **privacy-manifest fragment** + **required-reason API** declarations (file-timestamp `C617.1`, defensive UserDefaults `CA92.1`) covering the durable queue / crash store / native-context code. Pure-Dart packages can't embed a binary manifest, so the consuming app **merges** these arrays into its `ios/Runner/PrivacyInfo.xcprivacy`. |
+| `PLAY_DATA_SAFETY.md` | Exact Google **Play Data Safety** mapping — what is/ isn't collected, linkage, tracking flags. |
+| `ATT_CONSENT.md` | iOS **ATT/IDFA** handling + the **consent sequencing** the app must follow. The package never reads the IDFA and makes "ID before consent" structurally impossible via `TelemetryConsent`. |
+
+### Guarantees that make review safe
+
+- **No advertising / hardware identifiers** are ever read by this package
+  (no IDFA/IDFV/GAID/MAC/IMEI/serial). Native context = OS name+version,
+  coarse model, locale, consumer-supplied app version/build.
+- **No tracking.** `NSPrivacyTracking=false` for this layer; nothing is
+  joined across apps or shared with brokers.
+- **Consumer endpoint only.** Telemetry is delivered to the consuming app's
+  configured collector, never to a refraction-ui server.
+- **No new native dependency.** Persistence uses `dart:io` file APIs (the
+  same pattern Wave-0 analytics uses), so there is no transitive SDK whose
+  own privacy manifest the consumer must also reconcile.
+- **Off switch.** `enabled: false` ⇒ tree-shakeable no-op, zero collection.

--- a/packages/flutter/store_compliance/ios/PrivacyInfo.xcprivacy
+++ b/packages/flutter/store_compliance/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  refraction_ui telemetry — iOS Privacy Manifest FRAGMENT.
+
+  This is a release-blocking, MANDATORY store-compliance artifact (epic #225
+  DESIGN CLARIFICATION §3). It covers ONLY the code paths added by the Flutter
+  telemetry/analytics layer:
+
+    - Durable offline queue        (durable_store_io.dart — writes/reads a
+                                    namespaced JSON/NDJSON file under the OS
+                                    temp dir; reads file timestamps via the
+                                    standard File API)
+    - Crash-on-next-launch         (crash_capture.dart — persists a single
+                                    crash blob to the same file store)
+    - Native context auto-attach   (native_context_io.dart — reads OS
+                                    name/version, coarse model, locale ONLY)
+
+  refraction_ui is a pure-Dart package with NO native plugin, so it cannot
+  ship a binary-embedded manifest itself. The CONSUMING app must MERGE the
+  arrays below into its own `ios/Runner/PrivacyInfo.xcprivacy`
+  (`NSPrivacyAccessedAPITypes` + `NSPrivacyCollectedDataTypes`). Apple
+  requires the privacy manifest to live in the app/SDK bundle.
+
+  WHAT IS NOT DONE HERE (so consumers can attest accurately):
+    - NO IDFA / IDFV / advertising identifier is read or collected.
+    - NO device name, serial, MAC, IMEI, or any persistent HW identifier.
+    - NO ATTrackingManager / AdSupport usage (ATT is the consumer's; this
+      package only SEQUENCES it — see ../ATT_CONSENT.md).
+    - NO tracking. `NSPrivacyTracking` is false for this layer.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyTracking</key>
+  <false/>
+
+  <key>NSPrivacyTrackingDomains</key>
+  <array/>
+
+  <!--
+    Required-reason API declarations for the offline-persistence /
+    device-context code. Reason codes are from Apple's "Describing use of
+    required reason API" list.
+  -->
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <!--
+        File timestamp APIs: the durable queue / crash store create and
+        re-open files; reading their timestamps is implicit in File I/O and
+        in deciding queue freshness. C617.1 = "...timestamp of files inside
+        the app container, app group container, or the app's CloudKit
+        container." We never read timestamps of files outside our own
+        namespaced container directory.
+      -->
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>C617.1</string>
+      </array>
+    </dict>
+    <dict>
+      <!--
+        UserDefaults: declared defensively for the Flutter-web localStorage
+        equivalent / any plugin a consumer adds for app version. The Dart
+        durable store on iOS uses the file system (above), NOT UserDefaults,
+        so consumers who do not add such a plugin may drop this entry.
+        CA92.1 = "access info from same app, no tracking, not sent off
+        device in a way that identifies the user/device."
+      -->
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+  </array>
+
+  <!--
+    Collected data types. "Crash data", "Performance data", and "Other
+    diagnostic data" are sent to the CONSUMER's own collector endpoint
+    (never refraction-ui's). Not linked to identity, not used for tracking.
+    Add/adjust to match what the consuming app actually puts in log context.
+  -->
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypeCrashData</string>
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+      </array>
+    </dict>
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypePerformanceData</string>
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+      </array>
+    </dict>
+    <dict>
+      <key>NSPrivacyCollectedDataType</key>
+      <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+      <key>NSPrivacyCollectedDataTypeLinked</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypeTracking</key>
+      <false/>
+      <key>NSPrivacyCollectedDataTypePurposes</key>
+      <array>
+        <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/packages/flutter/test/telemetry_att_consent_test.dart
+++ b/packages/flutter/test/telemetry_att_consent_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('TelemetryConsent — ATT/IDFA gating + sequencing (no IDs before '
+      'consent)', () {
+    test('default is notDetermined: tracking disallowed, no id emitted', () {
+      final c = TelemetryConsent();
+      expect(c.state, TrackingState.notDetermined);
+      expect(c.allowsTracking, isFalse);
+      expect(c.trackingContext(), isEmpty);
+    });
+
+    test('attaching an id BEFORE authorization is rejected (guarded)', () {
+      final c = TelemetryConsent();
+      final accepted = c.attachTrackingId('idfa-123');
+      expect(accepted, isFalse);
+      expect(c.trackingId, isNull);
+      expect(c.trackingContext(), isEmpty);
+    });
+
+    test('after authorization: id may be attached and is then emitted', () {
+      final c = TelemetryConsent();
+      c.setTrackingAuthorized(TrackingState.authorized);
+      expect(c.allowsTracking, isTrue);
+      expect(c.attachTrackingId('idfa-xyz'), isTrue);
+      expect(c.trackingId, 'idfa-xyz');
+      expect(c.trackingContext(), <String, Object?>{'trackingId': 'idfa-xyz'});
+    });
+
+    test('denied / revoked clears any attached id', () {
+      final c = TelemetryConsent()
+        ..setTrackingAuthorized(TrackingState.authorized);
+      c.attachTrackingId('idfa-1');
+      c.setTrackingAuthorized(TrackingState.denied);
+      expect(c.allowsTracking, isFalse);
+      expect(c.trackingId, isNull);
+      expect(c.trackingContext(), isEmpty);
+    });
+
+    test('notApplicable (Android/web/desktop): still no id without authorize',
+        () {
+      final c = TelemetryConsent(initial: TrackingState.notApplicable);
+      expect(c.allowsTracking, isFalse);
+      expect(c.attachTrackingId('gaid'), isFalse);
+      expect(c.trackingContext(), isEmpty);
+    });
+
+    test('installMobileTelemetry never emits a tracking id pre-consent', () {
+      final base = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      base.addSink(mock);
+
+      final mt = installMobileTelemetry(
+        base,
+        store: MemoryDurableStore(),
+        installIsolateListener: false,
+      );
+      mt.telemetry.error('e');
+      // No trackingId anywhere in the bound device context.
+      final ctx = mock.logs.single.context;
+      expect(ctx.containsKey('trackingId'), isFalse);
+      expect(mt.consent.allowsTracking, isFalse);
+      mt.crashGuard.dispose();
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_crash_capture_test.dart
+++ b/packages/flutter/test/telemetry_crash_capture_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('installCrashCapture — hooks route to the sink pipeline', () {
+    test('FlutterError.onError -> error record (non-fatal); prior handler '
+        'preserved', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      var priorCalled = false;
+      final saved = FlutterError.onError;
+      FlutterError.onError = (d) => priorCalled = true;
+
+      final guard = installCrashCapture(
+        t,
+        store: MemoryDurableStore(),
+        installIsolateListener: false,
+      );
+
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: StateError('render boom'),
+          stack: StackTrace.current,
+          library: 'test',
+        ),
+      );
+
+      expect(mock.logs, hasLength(1));
+      expect(mock.logs.single.level, LogLevel.error);
+      expect(mock.logs.single.message, contains('render boom'));
+      expect(mock.logs.single.context['error.source'], 'FlutterError.onError');
+      expect(priorCalled, isTrue, reason: 'previous handler chained');
+
+      guard.dispose();
+      FlutterError.onError = saved;
+    });
+
+    test('PlatformDispatcher.onError -> fatal record AND persists '
+        'crash-on-next-launch', () {
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+      final store = MemoryDurableStore();
+
+      final guard = installCrashCapture(
+        t,
+        store: store,
+        installIsolateListener: false,
+      );
+
+      final handled = PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+
+      expect(handled, isTrue);
+      expect(mock.logs.single.level, LogLevel.fatal);
+      expect(mock.logs.single.message, contains('async boom'));
+      // Persisted for next launch BEFORE the live emit.
+      expect(store.read('telemetry.crash'), isNotNull);
+      expect(store.read('telemetry.crash'), contains('async boom'));
+
+      guard.dispose();
+    });
+
+    test('crash-on-next-launch: a crash persisted by a prior run is '
+        're-emitted as fatal on the next install, then cleared', () {
+      final store = MemoryDurableStore();
+      // Simulate: previous process died after persisting a fatal crash.
+      debugWritePersistedCrash(
+        store,
+        message: 'died last launch',
+        type: 'OutOfMemoryError',
+      );
+
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      final guard = installCrashCapture(
+        t,
+        store: store,
+        installIsolateListener: false,
+      );
+
+      // Replayed immediately on install.
+      expect(mock.logs, hasLength(1));
+      expect(mock.logs.single.level, LogLevel.fatal);
+      expect(mock.logs.single.message, contains('died last launch'));
+      expect(
+        mock.logs.single.context['error.source'],
+        'crash-on-next-launch',
+      );
+      // Cleared so it is not re-sent on the run after.
+      expect(store.read('telemetry.crash'), isNull);
+
+      guard.dispose();
+    });
+
+    test('dispose restores the previous handlers', () {
+      final before = FlutterError.onError;
+      final beforePd = PlatformDispatcher.instance.onError;
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final guard = installCrashCapture(
+        t,
+        store: MemoryDurableStore(),
+        installIsolateListener: false,
+      );
+      expect(identical(FlutterError.onError, before), isFalse);
+      guard.dispose();
+      expect(identical(FlutterError.onError, before), isTrue);
+      expect(identical(PlatformDispatcher.instance.onError, beforePd), isTrue);
+    });
+
+    test('crash record flows all the way through a durable sink', () async {
+      final transport = RecordingDurableTransport();
+      final t = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      t.addSink(createDurableSink(transport, store: MemoryDurableStore()));
+      final guard = installCrashCapture(
+        t,
+        store: MemoryDurableStore(),
+        installIsolateListener: false,
+      );
+
+      PlatformDispatcher.instance.onError!(
+        StateError('pipeline'),
+        StackTrace.current,
+      );
+      await t.flush();
+
+      expect(transport.delivered, hasLength(1));
+      expect(
+        (transport.delivered.single['record'] as Map)['message'],
+        contains('pipeline'),
+      );
+      guard.dispose();
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_durable_sink_test.dart
+++ b/packages/flutter/test/telemetry_durable_sink_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('createDurableSink — offline queue + retry/backoff (no network)', () {
+    test('online: records delivered immediately on flush', () async {
+      final t = RecordingDurableTransport();
+      final store = MemoryDurableStore();
+      final sink = createDurableSink(t, store: store);
+
+      sink.log(_log('a'));
+      sink.log(_log('b'));
+      expect(sink.pending, 2);
+      expect(t.delivered, isEmpty); // not delivered until flush
+
+      await sink.flush();
+      expect(sink.pending, 0);
+      expect(t.delivered, hasLength(2));
+      expect(t.delivered[0]['kind'], 'log');
+      expect((t.delivered[0]['record'] as Map)['message'], 'a');
+    });
+
+    test(
+      'offline window: nothing delivered, queue persists; replay on '
+      'reconnect (durable across a new sink instance = process restart)',
+      () async {
+        final store = MemoryDurableStore();
+        final offline = RecordingDurableTransport(failWhileOffline: true);
+        final s1 = createDurableSink(offline, store: store);
+
+        s1.log(_log('queued-1'));
+        s1.log(_log('queued-2'));
+        await s1.flush(); // offline -> stays queued + backoff armed
+        expect(offline.delivered, isEmpty);
+        expect(s1.pending, 2);
+
+        // Simulate process restart: brand-new sink, SAME durable store.
+        final online = RecordingDurableTransport();
+        final s2 = createDurableSink(online, store: store);
+        expect(s2.pending, 2, reason: 'queue survived restart');
+
+        await s2.flush();
+        expect(online.delivered, hasLength(2));
+        expect((online.delivered[0]['record'] as Map)['message'], 'queued-1');
+        expect((online.delivered[1]['record'] as Map)['message'], 'queued-2');
+        expect(s2.pending, 0);
+      },
+    );
+
+    test('backoff: a failed flush is not retried until backoff elapses',
+        () async {
+      final store = MemoryDurableStore();
+      final transport = RecordingDurableTransport(failWhileOffline: true);
+      final sink = createDurableSink(
+        transport,
+        store: store,
+        options: const DurableSinkOptions(
+          baseBackoff: Duration(milliseconds: 80),
+        ),
+      );
+
+      sink.log(_log('x'));
+      await sink.flush(); // fails, backoff armed (~80ms)
+      expect(sink.pending, 1);
+
+      // Immediately reconnect; flush should be SKIPPED (still backing off).
+      transport.failWhileOffline = false;
+      await sink.flush();
+      expect(transport.delivered, isEmpty, reason: 'still within backoff');
+      expect(sink.pending, 1);
+
+      await Future<void>.delayed(const Duration(milliseconds: 120));
+      await sink.flush(); // backoff elapsed -> delivers
+      expect(transport.delivered, hasLength(1));
+      expect(sink.pending, 0);
+    });
+
+    test('ordering preserved when a mid-batch delivery fails', () async {
+      final store = MemoryDurableStore();
+      // Transport that fails the 2nd envelope only.
+      final t = _FlakyTransport(failIndex: 1);
+      final sink = createDurableSink(
+        t,
+        store: store,
+        options: const DurableSinkOptions(
+          baseBackoff: Duration(milliseconds: 30),
+        ),
+      );
+      sink.log(_log('1'));
+      sink.log(_log('2'));
+      sink.log(_log('3'));
+
+      await sink.flush();
+      // 1 delivered; 2 failed so 2 & 3 stay queued IN ORDER.
+      expect(t.delivered.map((e) => (e['record'] as Map)['message']), ['1']);
+      expect(sink.pending, 2);
+
+      t.failIndex = -1; // recover
+      // Wait out the post-failure backoff before retrying.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await sink.flush();
+      expect(
+        t.delivered.map((e) => (e['record'] as Map)['message']),
+        ['1', '2', '3'],
+      );
+    });
+
+    test('queue is bounded (oldest dropped past maxQueue)', () {
+      final store = MemoryDurableStore();
+      final sink = createDurableSink(
+        RecordingDurableTransport(failWhileOffline: true),
+        store: store,
+        options: const DurableSinkOptions(maxQueue: 3),
+      );
+      for (var i = 0; i < 10; i++) {
+        sink.log(_log('m$i'));
+      }
+      expect(sink.pending, 3);
+    });
+
+    test('corrupt persisted queue is dropped, not crash-looped', () {
+      final store = MemoryDurableStore()
+        ..write('telemetry.queue', '{not json\nstill not json');
+      final sink = createDurableSink(
+        RecordingDurableTransport(),
+        store: store,
+      );
+      expect(sink.pending, 0);
+      expect(store.read('telemetry.queue'), isNull);
+    });
+
+    test('wires behind the uniform TelemetrySink surface via addSink',
+        () async {
+      final t = RecordingDurableTransport();
+      final telemetry = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      telemetry.addSink(
+        createDurableSink(t, store: MemoryDurableStore()),
+      );
+      expect(telemetry.sinks, contains('durable'));
+      telemetry.error('boom');
+      await telemetry.flush();
+      expect(t.delivered, hasLength(1));
+      expect((t.delivered.single['record'] as Map)['message'], 'boom');
+    });
+  });
+}
+
+LogRecord _log(String message) => LogRecord(
+      level: LogLevel.error,
+      message: message,
+      timestamp: 0,
+      app: 'svc',
+      env: TelemetryEnv.production,
+      context: const <String, Object?>{},
+    );
+
+class _FlakyTransport implements DurableSinkTransport {
+  _FlakyTransport({required this.failIndex});
+  int failIndex;
+  int _seen = 0;
+  final List<Map<String, Object?>> delivered = <Map<String, Object?>>[];
+
+  @override
+  bool deliver({required String kind, required Map<String, Object?> record}) {
+    final idx = _seen++;
+    if (idx == failIndex) return false;
+    delivered.add(<String, Object?>{'kind': kind, 'record': record});
+    return true;
+  }
+}

--- a/packages/flutter/test/telemetry_isolate_queue_test.dart
+++ b/packages/flutter/test/telemetry_isolate_queue_test.dart
@@ -1,0 +1,106 @@
+import 'dart:isolate';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('TelemetryIsolateHost — background-isolate logs are not lost', () {
+    test('worker logger -> host -> real telemetry pipeline (in-process port)',
+        () async {
+      final telemetry = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      telemetry.addSink(mock);
+
+      final host = TelemetryIsolateHost.attach(telemetry);
+      // The SendPort is what would be passed into Isolate.spawn.
+      final workerLogger = createIsolateLogger(host.sendPort);
+
+      workerLogger.info('from-worker', <String, Object?>{'wid': 7});
+      workerLogger
+          .child(<String, Object?>{'job': 'resize'}).error('worker-fail');
+
+      // Port delivery is async (microtask/event loop) — let it drain.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(mock.logs, hasLength(2));
+      final first = mock.logs.firstWhere((r) => r.message == 'from-worker');
+      expect(first.level, LogLevel.info);
+      expect(first.context['wid'], 7);
+
+      final second = mock.logs.firstWhere((r) => r.message == 'worker-fail');
+      expect(second.level, LogLevel.error);
+      expect(second.context['job'], 'resize');
+
+      host.close();
+    });
+
+    test('worker span crosses the boundary as a completed span', () async {
+      final telemetry = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      telemetry.addSink(mock);
+      final host = TelemetryIsolateHost.attach(telemetry);
+      final worker = createIsolateLogger(host.sendPort);
+
+      worker.startSpan('decode', <String, Object?>{'fmt': 'png'}).end();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(mock.spans, hasLength(1));
+      expect(mock.spans.single.name, 'decode');
+      expect(mock.spans.single.context['fmt'], 'png');
+      host.close();
+    });
+
+    test('closed host ignores further messages (no throw)', () async {
+      final telemetry = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      telemetry.addSink(mock);
+      final host = TelemetryIsolateHost.attach(telemetry);
+      final worker = createIsolateLogger(host.sendPort);
+      host.close();
+      worker.info('after-close');
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(mock.logs, isEmpty);
+    });
+
+    test('end-to-end across a real spawned isolate (SendPort handoff)',
+        () async {
+      final telemetry = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      telemetry.addSink(mock);
+      final host = TelemetryIsolateHost.attach(telemetry);
+
+      final done = ReceivePort();
+      await Isolate.spawn(_worker, [host.sendPort, done.sendPort]);
+      await done.first; // worker signals completion
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(
+        mock.logs.map((r) => r.message),
+        containsAll(<String>['bg-isolate-1', 'bg-isolate-2']),
+      );
+      final tagged =
+          mock.logs.firstWhere((r) => r.message == 'bg-isolate-2');
+      expect(tagged.context['isolate'], 'worker');
+      host.close();
+      done.close();
+    });
+  });
+}
+
+/// Runs in a spawned isolate: emits via the forwarded SendPort, then signals.
+void _worker(List<Object> args) {
+  final sendPort = args[0] as SendPort;
+  final done = args[1] as SendPort;
+  final logger = createIsolateLogger(sendPort);
+  logger.warn('bg-isolate-1');
+  logger.child(<String, Object?>{'isolate': 'worker'}).error('bg-isolate-2');
+  done.send('done');
+}

--- a/packages/flutter/test/telemetry_mobile_lifecycle_test.dart
+++ b/packages/flutter/test/telemetry_mobile_lifecycle_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+/// Test hook standing in for the platform `lifecycle_io.dart`
+/// `WidgetsBindingObserver`: lets the suite drive the same exit callback the
+/// real observer fires on `AppLifecycleState.paused/inactive/detached`.
+class _AppLifecycleHook implements LifecycleHook {
+  void Function()? _onExit;
+  AppLifecycleState? _last;
+
+  /// Mirror the real observer's transition logic exactly.
+  void drive(AppLifecycleState state) {
+    final leaving = state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.detached;
+    if (leaving && _last != state) _onExit?.call();
+    _last = state;
+  }
+
+  @override
+  LifecycleSubscription onExit(void Function() onExit) {
+    _onExit = onExit;
+    return _Sub();
+  }
+}
+
+class _Sub implements LifecycleSubscription {
+  @override
+  void cancel() {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('mobile lifecycle flush — paused/inactive/detached (web beacon '
+      'replacement)', () {
+    test('production: backgrounding flushes the buffered queue', () async {
+      final hook = _AppLifecycleHook();
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.production,
+          sampleRate: 1,
+        ),
+        lifecycleHook: hook,
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      t.error('pending-1');
+      t.error('pending-2');
+      expect(mock.logs, isEmpty, reason: 'prod batches');
+
+      hook.drive(AppLifecycleState.inactive); // leaving foreground
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.logs, hasLength(2));
+    });
+
+    test('paused and detached also flush; resumed does NOT', () async {
+      final hook = _AppLifecycleHook();
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.production,
+          sampleRate: 1,
+        ),
+        lifecycleHook: hook,
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      hook.drive(AppLifecycleState.resumed); // no-op
+      t.error('a');
+      hook.drive(AppLifecycleState.resumed); // still no flush
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.logs, isEmpty);
+
+      hook.drive(AppLifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.logs, hasLength(1));
+
+      t.error('b');
+      hook.drive(AppLifecycleState.detached);
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.logs, hasLength(2));
+    });
+
+    test('repeated identical background state flushes once per transition',
+        () async {
+      final hook = _AppLifecycleHook();
+      final t = createTelemetry(
+        const TelemetryConfig(
+          app: 'svc',
+          env: TelemetryEnv.production,
+          sampleRate: 1,
+        ),
+        lifecycleHook: hook,
+      );
+      final mock = createMockSink();
+      t.addSink(mock);
+
+      t.error('once');
+      hook.drive(AppLifecycleState.paused);
+      hook.drive(AppLifecycleState.paused); // same state -> no extra flush
+      await Future<void>.delayed(Duration.zero);
+      expect(mock.flushCalls, greaterThanOrEqualTo(1));
+      expect(mock.logs, hasLength(1));
+    });
+
+    test('the real platform LifecycleHook constructs without a binding crash',
+        () {
+      // On the dart:io path this builds the WidgetsBindingObserver-backed
+      // hook; in the test VM it must be a safe no-op (explicit flush still
+      // works), proving the uniform surface holds.
+      final hook = LifecycleHook();
+      final sub = hook.onExit(() {});
+      expect(sub, isNotNull);
+      sub.cancel(); // idempotent / no throw
+    });
+  });
+}

--- a/packages/flutter/test/telemetry_native_context_test.dart
+++ b/packages/flutter/test/telemetry_native_context_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NativeContext — non-identifying device/app auto-attach', () {
+    test('resolves a map; never contains an advertising/hardware id', () {
+      final ctx = NativeContext.resolve().values;
+      // On the dart:io test host osName is populated.
+      expect(ctx['osName'], isNotNull);
+      // Store-compliance: no ad/IDFA/IDFV/MAC/serial keys ever.
+      for (final forbidden in const [
+        'idfa',
+        'idfv',
+        'advertisingId',
+        'gaid',
+        'mac',
+        'serial',
+        'imei',
+      ]) {
+        expect(ctx.containsKey(forbidden), isFalse);
+      }
+    });
+
+    test('overrides supply app version/build and win over auto-detection',
+        () {
+      final ctx = NativeContext.resolve(
+        const NativeContextOverrides(
+          appVersion: '1.4.0',
+          appBuild: '42',
+          deviceModel: 'Pixel 8',
+          osName: 'android',
+          osVersion: '14',
+          locale: 'en-GB',
+        ),
+      ).values;
+      expect(ctx['appVersion'], '1.4.0');
+      expect(ctx['appBuild'], '42');
+      expect(ctx['deviceModel'], 'Pixel 8');
+      expect(ctx['osName'], 'android');
+      expect(ctx['osVersion'], '14');
+      expect(ctx['locale'], 'en-GB');
+    });
+
+    test('null override fields are omitted (no null values leak)', () {
+      final ctx = NativeContext.resolve(
+        const NativeContextOverrides(appVersion: '2.0.0'),
+      ).values;
+      expect(ctx['appVersion'], '2.0.0');
+      expect(ctx.values.contains(null), isFalse);
+    });
+  });
+
+  group('installMobileTelemetry — context attached on every record', () {
+    test('device sub-context rides on every emitted record', () {
+      final base = createTelemetry(
+        const TelemetryConfig(app: 'svc', env: TelemetryEnv.development),
+      );
+      final mock = createMockSink();
+      base.addSink(mock);
+
+      final mt = installMobileTelemetry(
+        base,
+        store: MemoryDurableStore(),
+        overrides: const NativeContextOverrides(
+          appVersion: '3.1.0',
+          appBuild: '99',
+        ),
+        installIsolateListener: false,
+      );
+
+      mt.telemetry.error('boom', <String, Object?>{'route': '/x'});
+      final ctx = mock.logs.single.context;
+      final device = ctx['device'] as Map<String, Object?>;
+      expect(device['appVersion'], '3.1.0');
+      expect(device['appBuild'], '99');
+      expect(ctx['route'], '/x'); // per-call context still merged
+
+      // child() keeps the device context.
+      mt.telemetry.child(<String, Object?>{'sessionId': 's1'}).warn('w');
+      final c2 = mock.logs.last.context;
+      expect((c2['device'] as Map)['appVersion'], '3.1.0');
+      expect(c2['sessionId'], 's1');
+
+      mt.crashGuard.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Epic #225 Wave 1. Mobile telemetry over Wave-0 core, **internal-only behind the unchanged uniform surface** (additive telemetry-barrel exports only — 0 removed/renamed). Offline durable queue + capped backoff (survives process restart), crash capture + **crash-on-next-launch**, app-lifecycle flush (mobile beacon replacement), non-identifying native context, background-isolate→main bridge, ATT/IDFA gating (no IDs pre-consent; package never reads IDFA). `store_compliance/` — iOS `PrivacyInfo.xcprivacy` + required-reason API decls + Play Data Safety + ATT docs (acceptance criteria). Zero new pub deps (coarse device model + consumer override, documented).

✅ analyze clean · flutter test **+239** (30 new, 0 regressions). No changeset (Dart pub; pub.dev separate). Closes #227.