### PR TITLE
fix(react-logger): hooks no-op (not throw) without <TelemetryProvider>

### DIFF
--- a/.changeset/react-logger-noop-without-provider.md
+++ b/.changeset/react-logger-noop-without-provider.md
@@ -1,0 +1,10 @@
+---
+"@refraction-ui/react": minor
+---
+
+react-logger: `useTelemetry`/`useLogger`/`useSpan` no longer throw when used
+outside a `<TelemetryProvider>` — they return a shared `createNoopTelemetry()`
+(a dev-only warn-once hint is still emitted). Components/hooks instrumented
+with logging render safely without a provider (tests, standalone usage);
+telemetry activates when a provider is mounted. Instrumentation must never
+crash the host.

--- a/docs/instrumentation/component-tiers.json
+++ b/docs/instrumentation/component-tiers.json
@@ -229,7 +229,7 @@
       "framework": "react",
       "tier": "footgun",
       "footgunKind": "silent-default-context",
-      "rationale": "Sub-charts read ChartContext default (zero dimensions) when used outside <Chart> \u2014 silent misuse, no throw",
+      "rationale": "Sub-charts read ChartContext default (zero dimensions) when used outside <Chart> — silent misuse, no throw",
       "loc": 568,
       "files": [
         "gradient.tsx",
@@ -579,8 +579,8 @@
       "package": "react-logger",
       "framework": "react",
       "tier": "footgun",
-      "footgunKind": "provider-context-throw",
-      "rationale": "useTelemetry/useSpan throw outside <TelemetryProvider> (instrumentation infra itself)",
+      "footgunKind": "provider-context-noop",
+      "rationale": "useTelemetry/useLogger/useSpan no-op (createNoopTelemetry) outside <TelemetryProvider> — instrumentation must not crash the host; devWarn only",
       "loc": 256,
       "files": [
         "error-boundary.tsx",
@@ -764,7 +764,7 @@
       "framework": "react",
       "tier": "footgun",
       "footgunKind": "silent-default-context",
-      "rationale": "Select parts read SelectContext default when used outside <Select> \u2014 silent misuse, no throw",
+      "rationale": "Select parts read SelectContext default when used outside <Select> — silent misuse, no throw",
       "loc": 311,
       "files": [
         "index.ts",
@@ -983,7 +983,7 @@
       "framework": "react",
       "tier": "async-heavy",
       "asyncKind": "voice",
-      "rationale": "Voice/speaker activity pill \u2014 voice-session surface; intensity/mute lifecycle",
+      "rationale": "Voice/speaker activity pill — voice-session surface; intensity/mute lifecycle",
       "loc": 189,
       "files": [
         "index.ts",

--- a/docs/instrumentation/policy.md
+++ b/docs/instrumentation/policy.md
@@ -66,6 +66,12 @@ Treatment:
 - **Keep the existing `throw`.** `devWarn` augments, never replaces, the
   thrown error. For silent-default contexts, `devWarn` is the *only* signal —
   do not introduce a throw (would be a breaking change).
+- **Exception — `@refraction-ui/react-logger` (telemetry instrumentation
+  itself):** its hooks (`useTelemetry`/`useLogger`/`useSpan`) **must NOT
+  throw** outside `<TelemetryProvider>` — they return a shared
+  `createNoopTelemetry()` and emit only the `devWarn`. Rationale: adding
+  logging to a component must never crash the host (incl. in tests) — that
+  would defeat the purpose of instrumentation. Do not re-introduce the throw.
 - `devWarn` is warn-once per message, env-guarded (`process.env.NODE_ENV !==
   'production'` / `import.meta.env.DEV`), and **must not import the telemetry
   library**. If a consumer wired the diagnostics sink (#247 W1), the error

--- a/packages/react-logger/__tests__/devwarn.test.tsx
+++ b/packages/react-logger/__tests__/devwarn.test.tsx
@@ -2,23 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
 import { resetDevFeedback } from '@refraction-ui/shared'
-import { useTelemetry } from '../src/telemetry-provider.js'
+import { useTelemetry, useLogger } from '../src/telemetry-provider.js'
+import { useSpan } from '../src/use-span.js'
 
-// react-logger is a footgun (provider-context-throw): useTelemetry/useSpan
-// throw outside <TelemetryProvider>. Per docs/instrumentation/policy.md the
-// throw is KEPT and a dev-only warn-once devWarn is added immediately before
-// it. devWarn comes from @refraction-ui/shared, which has zero dependency on
-// the telemetry library (no hard-dep / no cycle).
+// react-logger hooks degrade gracefully: when called outside a
+// <TelemetryProvider> they DO NOT throw — they return a shared no-op
+// telemetry so instrumented components/hooks render fine without a provider
+// (tests, standalone usage). A dev-only warn-once devWarn (from
+// @refraction-ui/shared, zero dependency on the telemetry lib) is emitted for
+// discoverability and is stripped in production.
 
-function renderHook(hook: () => unknown): void {
-  function Probe() {
-    hook()
-    return null
-  }
-  renderToString(React.createElement(Probe))
+function render(el: React.ReactElement): void {
+  renderToString(el)
 }
 
-describe('react-logger devWarn footgun (useTelemetry outside provider)', () => {
+describe('react-logger hooks outside <TelemetryProvider> (no-op, no throw)', () => {
   const originalEnv = process.env.NODE_ENV
   let warnSpy: ReturnType<typeof vi.spyOn>
 
@@ -33,22 +31,47 @@ describe('react-logger devWarn footgun (useTelemetry outside provider)', () => {
     resetDevFeedback()
   })
 
-  it('warns once in dev AND still throws', () => {
+  it('useTelemetry: no throw in dev, warns once, returns a usable no-op', () => {
     process.env.NODE_ENV = 'development'
-    expect(() => renderHook(useTelemetry)).toThrow(
-      'useTelemetry must be used within a <TelemetryProvider>',
-    )
+    let t: ReturnType<typeof useTelemetry> | undefined
+    function Probe() {
+      t = useTelemetry()
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy.mock.calls[0]?.[0]).toContain(
       'react-logger/use-telemetry-outside-provider',
     )
+    // The returned telemetry is a working no-op (no throw on use).
+    expect(t).toBeTruthy()
+    expect(() => {
+      t!.info('noop')
+      const child = t!.child({ k: 'v' })
+      child.warn('noop')
+      const span = t!.startSpan('s')
+      span.end()
+    }).not.toThrow()
   })
 
-  it('does NOT warn in production but still throws', () => {
+  it('useTelemetry: no warn in production, still no-op (no throw)', () => {
     process.env.NODE_ENV = 'production'
-    expect(() => renderHook(useTelemetry)).toThrow(
-      'useTelemetry must be used within a <TelemetryProvider>',
-    )
+    function Probe() {
+      useTelemetry()
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('useLogger and useSpan also no-op outside provider (no throw)', () => {
+    process.env.NODE_ENV = 'production'
+    function Probe() {
+      const log = useLogger({ a: 1 })
+      useSpan()
+      log.info('noop')
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
   })
 })

--- a/packages/react-logger/__tests__/telemetry-provider.test.tsx
+++ b/packages/react-logger/__tests__/telemetry-provider.test.tsx
@@ -104,10 +104,10 @@ describe('useTelemetry (SSR)', () => {
     expect(html).toContain('console')
   })
 
-  it('throws when used outside TelemetryProvider', () => {
+  it('no-ops (no throw) when used outside TelemetryProvider', () => {
     expect(() => {
       renderToString(React.createElement(TestConsumer))
-    }).toThrow(/useTelemetry.*TelemetryProvider/i)
+    }).not.toThrow()
   })
 })
 
@@ -153,9 +153,9 @@ describe('useLogger (SSR)', () => {
     expect(html).toContain('data-is-root="false"')
   })
 
-  it('throws when used outside TelemetryProvider', () => {
+  it('no-ops (no throw) when used outside TelemetryProvider', () => {
     expect(() => {
       renderToString(React.createElement(ScopedConsumer))
-    }).toThrow(/useTelemetry.*TelemetryProvider/i)
+    }).not.toThrow()
   })
 })

--- a/packages/react-logger/src/telemetry-provider.tsx
+++ b/packages/react-logger/src/telemetry-provider.tsx
@@ -2,11 +2,24 @@ import * as React from 'react'
 import { devWarn } from '@refraction-ui/shared'
 import {
   createTelemetry,
+  createNoopTelemetry,
   type TelemetryConfig,
   type Telemetry,
   type Logger,
   type LogContext,
 } from '@refraction-ui/logger'
+
+/**
+ * Shared no-op telemetry used when a hook is called outside a
+ * <TelemetryProvider>. Lazily created once and reused so the reference is
+ * stable across renders. The hooks degrade gracefully (no-op) instead of
+ * throwing, so components instrumented with useLogger/useSpan/useTelemetry
+ * render fine without a provider (e.g. in tests, or standalone usage).
+ */
+let noopTelemetry: Telemetry | null = null
+function getNoopTelemetry(): Telemetry {
+  return (noopTelemetry ??= createNoopTelemetry())
+}
 
 export interface TelemetryContextValue {
   /** The root telemetry instance (a logger bound to the empty root context). */
@@ -45,16 +58,20 @@ export function TelemetryProvider({ children, ...config }: TelemetryProviderProp
 
 /**
  * useTelemetry — access the root telemetry instance.
- * Must be used within <TelemetryProvider>.
+ *
+ * If called outside a <TelemetryProvider> it does NOT throw: it returns a
+ * shared no-op telemetry (a dev-only warn-once hint is emitted so the missing
+ * provider is discoverable). This lets components instrumented with
+ * useLogger/useSpan/useTelemetry render safely without a provider.
  */
 export function useTelemetry(): Telemetry {
   const ctx = React.useContext(TelemetryContext)
   if (!ctx) {
     devWarn(
       'react-logger/use-telemetry-outside-provider',
-      'useTelemetry() (or useSpan(), which depends on it) was called outside a <TelemetryProvider>. Wrap your app (or the consuming subtree) in <TelemetryProvider> so the telemetry context is available.',
+      'useTelemetry() (or useLogger()/useSpan(), which depend on it) was called outside a <TelemetryProvider>. Telemetry is a no-op here; wrap your app (or the consuming subtree) in <TelemetryProvider> to enable it.',
     )
-    throw new Error('useTelemetry must be used within a <TelemetryProvider>')
+    return getNoopTelemetry()
   }
   return ctx.telemetry
 }


### PR DESCRIPTION
`useTelemetry`/`useLogger`/`useSpan` return a shared `createNoopTelemetry()` instead of throwing outside `<TelemetryProvider>` (dev-only warn-once `devWarn` retained). Instrumentation must never crash the host — so React components/hooks instrumented with logging render fine without a provider (tests, standalone); telemetry activates when a provider is mounted. Pre-existing throw-asserting tests flipped to assert no-op; `policy.md` exception + tier-map updated so it isn't reverted.

**Locally `make ci`-verified**: 704/704 tasks, react-logger 41/41, meta.test.ts react 22 / astro 5 / angular 5. Changeset bumps `@refraction-ui/react` minor.