### PR TITLE
fix(react-analytics): no-op instead of throw outside <AnalyticsProvider>

### DIFF
--- a/.changeset/react-analytics-noop-without-provider.md
+++ b/.changeset/react-analytics-noop-without-provider.md
@@ -1,0 +1,9 @@
+---
+"@refraction-ui/react": patch
+---
+
+react-analytics: `useAnalytics()` and `useTrackEvent()` no longer throw when
+used outside an `<AnalyticsProvider>`. They now return a shared no-op
+`Analytics` (via `createNoopAnalytics()`) and emit a dev-only warn-once hint,
+mirroring the `react-logger` behaviour shipped in 0.9.0. Instrumenting a
+component with analytics must never crash the host (including in tests).

--- a/docs/instrumentation/component-tiers.json
+++ b/docs/instrumentation/component-tiers.json
@@ -56,8 +56,8 @@
       "package": "react-analytics",
       "framework": "react",
       "tier": "footgun",
-      "footgunKind": "provider-context-throw",
-      "rationale": "useAnalytics throws outside <AnalyticsProvider>",
+      "footgunKind": "provider-context-noop",
+      "rationale": "useAnalytics/useTrackEvent no-op (createNoopAnalytics) outside <AnalyticsProvider> — instrumentation must not crash the host; devWarn only",
       "loc": 108,
       "files": [
         "analytics-provider.tsx",

--- a/docs/instrumentation/policy.md
+++ b/docs/instrumentation/policy.md
@@ -66,12 +66,14 @@ Treatment:
 - **Keep the existing `throw`.** `devWarn` augments, never replaces, the
   thrown error. For silent-default contexts, `devWarn` is the *only* signal —
   do not introduce a throw (would be a breaking change).
-- **Exception — `@refraction-ui/react-logger` (telemetry instrumentation
-  itself):** its hooks (`useTelemetry`/`useLogger`/`useSpan`) **must NOT
-  throw** outside `<TelemetryProvider>` — they return a shared
-  `createNoopTelemetry()` and emit only the `devWarn`. Rationale: adding
-  logging to a component must never crash the host (incl. in tests) — that
-  would defeat the purpose of instrumentation. Do not re-introduce the throw.
+- **Exception — instrumentation packages (`@refraction-ui/react-logger` and
+  `@refraction-ui/react-analytics`):** their hooks (`useTelemetry`/
+  `useLogger`/`useSpan`; `useAnalytics`/`useTrackEvent`) **must NOT throw**
+  outside their provider — they return a shared `createNoopTelemetry()` /
+  `createNoopAnalytics()` and emit only the `devWarn`. Rationale: adding
+  logging or analytics to a component must never crash the host (incl. in
+  tests) — that would defeat the purpose of instrumentation. Do not
+  re-introduce the throw for these.
 - `devWarn` is warn-once per message, env-guarded (`process.env.NODE_ENV !==
   'production'` / `import.meta.env.DEV`), and **must not import the telemetry
   library**. If a consumer wired the diagnostics sink (#247 W1), the error

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -23,6 +23,11 @@ export { SCHEMA_VERSION } from './types.js'
 // Manager
 export { createAnalytics } from './analytics-manager.js'
 
+// Headless no-op (symmetry with @refraction-ui/logger's createNoopTelemetry):
+// a full Analytics whose every method is an empty fn. Used by adapters to
+// degrade gracefully (no-op, never throw) when no provider/context is present.
+export { createNoopAnalytics } from './noop.js'
+
 // Built-in sinks
 export { createHttpSink } from './http-sink.js'
 export { createConsoleSink } from './console-sink.js'

--- a/packages/react-analytics/__tests__/analytics-provider.test.tsx
+++ b/packages/react-analytics/__tests__/analytics-provider.test.tsx
@@ -98,14 +98,14 @@ describe('useAnalytics (SSR)', () => {
     expect(typeof (scoped as { track: unknown }).track).toBe('function')
   })
 
-  it('throws when used outside AnalyticsProvider', () => {
+  it('no-ops (no throw) when used outside AnalyticsProvider', () => {
     function TestConsumer() {
       useAnalytics()
-      return React.createElement('span', null, 'never')
+      return React.createElement('span', null, 'ok')
     }
     expect(() => {
       renderToString(React.createElement(TestConsumer))
-    }).toThrow(/useAnalytics.*AnalyticsProvider/i)
+    }).not.toThrow()
   })
 })
 

--- a/packages/react-analytics/__tests__/devwarn.test.tsx
+++ b/packages/react-analytics/__tests__/devwarn.test.tsx
@@ -2,21 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
 import { resetDevFeedback } from '@refraction-ui/shared'
-import { useAnalytics } from '../src/analytics-provider.js'
+import { useAnalytics, useTrackEvent } from '../src/analytics-provider.js'
 
-// react-analytics is a footgun (provider-context-throw): useAnalytics throws
-// outside <AnalyticsProvider>. Per docs/instrumentation/policy.md the throw is
-// KEPT and a dev-only warn-once devWarn is added immediately before it.
+// react-analytics hooks degrade gracefully: when called outside an
+// <AnalyticsProvider> they DO NOT throw — they return a shared no-op
+// Analytics (createNoopAnalytics) so instrumented components/hooks render
+// fine without a provider (tests, standalone usage). A dev-only warn-once
+// devWarn (from @refraction-ui/shared, zero dependency on the analytics lib)
+// is emitted for discoverability and is stripped in production.
 
-function renderHook(hook: () => unknown): void {
-  function Probe() {
-    hook()
-    return null
-  }
-  renderToString(React.createElement(Probe))
+function render(el: React.ReactElement): void {
+  renderToString(el)
 }
 
-describe('react-analytics devWarn footgun (useAnalytics outside provider)', () => {
+describe('react-analytics hooks outside <AnalyticsProvider> (no-op, no throw)', () => {
   const originalEnv = process.env.NODE_ENV
   let warnSpy: ReturnType<typeof vi.spyOn>
 
@@ -31,22 +30,46 @@ describe('react-analytics devWarn footgun (useAnalytics outside provider)', () =
     resetDevFeedback()
   })
 
-  it('warns once in dev AND still throws', () => {
+  it('useAnalytics: no throw in dev, warns once, returns a usable no-op', () => {
     process.env.NODE_ENV = 'development'
-    expect(() => renderHook(useAnalytics)).toThrow(
-      'useAnalytics must be used within an <AnalyticsProvider>',
-    )
+    let a: ReturnType<typeof useAnalytics> | undefined
+    function Probe() {
+      a = useAnalytics()
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(warnSpy.mock.calls[0]?.[0]).toContain(
       'react-analytics/use-analytics-outside-provider',
     )
+    // The returned analytics is a working no-op (no throw on use).
+    expect(a).toBeTruthy()
+    expect(() => {
+      a!.track('evt', { k: 'v' })
+      a!.identify('u1')
+      a!.page()
+      const child = a!.with({ scope: 's' } as never)
+      child.track('evt2')
+    }).not.toThrow()
   })
 
-  it('does NOT warn in production but still throws', () => {
+  it('useAnalytics: no warn in production, still no-op (no throw)', () => {
     process.env.NODE_ENV = 'production'
-    expect(() => renderHook(useAnalytics)).toThrow(
-      'useAnalytics must be used within an <AnalyticsProvider>',
-    )
+    function Probe() {
+      useAnalytics()
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
     expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('useTrackEvent also no-ops outside provider (no throw)', () => {
+    process.env.NODE_ENV = 'production'
+    function Probe() {
+      const track = useTrackEvent()
+      track('evt', { a: 1 })
+      return null
+    }
+    expect(() => render(React.createElement(Probe))).not.toThrow()
   })
 })

--- a/packages/react-analytics/src/analytics-provider.tsx
+++ b/packages/react-analytics/src/analytics-provider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { devWarn } from '@refraction-ui/shared'
+import { createNoopAnalytics } from '@refraction-ui/analytics'
 import type {
   Analytics,
   AnalyticsContext as AnalyticsEventContext,
@@ -8,6 +9,18 @@ import type {
 } from '@refraction-ui/analytics'
 
 const AnalyticsContext = React.createContext<Analytics | null>(null)
+
+/**
+ * Shared no-op Analytics used when a hook is called outside an
+ * <AnalyticsProvider>. Lazily created once and reused so the reference stays
+ * stable. The hooks degrade gracefully (silent no-op) instead of throwing —
+ * components instrumented with useAnalytics/useTrackEvent render fine without
+ * a provider (tests, standalone); analytics activates when one is mounted.
+ */
+let noopAnalytics: Analytics | null = null
+function getNoopAnalytics(): Analytics {
+  return (noopAnalytics ??= createNoopAnalytics())
+}
 
 export interface AnalyticsProviderProps {
   children: React.ReactNode
@@ -50,21 +63,25 @@ export interface UseAnalyticsOptions {
  * useAnalytics — access the `Analytics` instance from context.
  *
  * Pass `{ scope }` to receive a `with(...)` child whose context is merged
- * into every event. Must be used within an `<AnalyticsProvider>`.
+ * into every event. If called outside an `<AnalyticsProvider>` it does NOT
+ * throw: it returns a shared no-op `Analytics` (a dev-only warn-once hint is
+ * emitted). Instrumenting a component with analytics must never crash the
+ * host (incl. in tests).
  */
 export function useAnalytics(options?: UseAnalyticsOptions): Analytics {
   const ctx = React.useContext(AnalyticsContext)
-  if (!ctx) {
+  let base = ctx
+  if (!base) {
     devWarn(
       'react-analytics/use-analytics-outside-provider',
-      'useAnalytics() was called outside an <AnalyticsProvider>. Wrap your app (or the consuming subtree) in <AnalyticsProvider> so the analytics context is available.',
+      'useAnalytics() (or useTrackEvent()) was called outside an <AnalyticsProvider>. Analytics is a no-op here; wrap your app (or the consuming subtree) in <AnalyticsProvider> to enable it.',
     )
-    throw new Error('useAnalytics must be used within an <AnalyticsProvider>')
+    base = getNoopAnalytics()
   }
   const scope = options?.scope
   return React.useMemo<Analytics>(
-    () => (scope ? ctx.with(scope) : ctx),
-    [ctx, scope],
+    () => (scope ? base.with(scope) : base),
+    [base, scope],
   )
 }
 


### PR DESCRIPTION
## Problem

`useAnalytics()` / `useTrackEvent()` **threw** when used outside an
`<AnalyticsProvider>` — identical to the `react-logger` problem already fixed
and shipped in `@refraction-ui/react@0.9.0`. Instrumenting a component with
analytics should never crash the host (including in tests / standalone usage).

## Fix (RUI-side, mirrors the logger fix)

- `useAnalytics()` no longer throws outside a provider: `devWarn` once
  (dev-only, stripped in prod) then fall back to a lazily-created shared
  `createNoopAnalytics()`. Hook order preserved (`useContext` + `useMemo`
  always run — no conditional hook). `useTrackEvent()` rides on
  `useAnalytics()`, so it's fixed transitively.
- `@refraction-ui/analytics` now **exports `createNoopAnalytics`** (it
  existed in `./noop.js` but wasn't re-exported — asymmetric vs logger's
  `createNoopTelemetry`).
- Tests: flipped the throw-asserting tests to `.not.toThrow()`; rewrote
  `devwarn.test.tsx` with warn-once-in-dev / no-warn-in-prod / positive
  no-op tests for both `useAnalytics` and `useTrackEvent`. **12 passed (2
  files).**
- Docs: `policy.md` no-throw exception now names `react-analytics`;
  `component-tiers.json` entry `provider-context-throw` →
  `provider-context-noop` (so a future agent doesn't "restore the throw").
- Changeset: **patch `@refraction-ui/react`** (0.9.1 → 0.9.2).

## Acceptance

A component calling `useTrackEvent()` / `useAnalytics()` with no
`<AnalyticsProvider>` renders fine; calls are silent no-ops. ✅

## Verification

`make ci` green by log content: `Tasks: 692 successful, 692 total`,
`@refraction-ui/react-analytics:test: Tests 12 passed (12)`, no hard
failures.