### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/react-analytics-noop-without-provider.md
+++ b/.changeset/react-analytics-noop-without-provider.md
@@ -1,9 +1,0 @@
----
-"@refraction-ui/react": patch
----
-
-react-analytics: `useAnalytics()` and `useTrackEvent()` no longer throw when
-used outside an `<AnalyticsProvider>`. They now return a shared no-op
-`Analytics` (via `createNoopAnalytics()`) and emit a dev-only warn-once hint,
-mirroring the `react-logger` behaviour shipped in 0.9.0. Instrumenting a
-component with analytics must never crash the host (including in tests).

--- a/packages/react-meta/CHANGELOG.md
+++ b/packages/react-meta/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @refraction-ui/react
 
+## 0.9.2
+
+### Patch Changes
+
+- 817d8f2: react-analytics: `useAnalytics()` and `useTrackEvent()` no longer throw when
+  used outside an `<AnalyticsProvider>`. They now return a shared no-op
+  `Analytics` (via `createNoopAnalytics()`) and emit a dev-only warn-once hint,
+  mirroring the `react-logger` behaviour shipped in 0.9.0. Instrumenting a
+  component with analytics must never crash the host (including in tests).
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/react-meta/package.json
+++ b/packages/react-meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refraction-ui/react",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "All Refraction UI React components in one package — headless, accessible, zero-dependency",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version PR — consumes the react-analytics no-op changeset.

Bumps **`@refraction-ui/react` 0.9.1 → 0.9.2** (patch). On merge, the Release workflow publishes 0.9.2 to npm `@latest` via OIDC trusted publishing (provenance).

Carries: react-analytics `useAnalytics()`/`useTrackEvent()` no longer throw outside `<AnalyticsProvider>` (PR #293).