### PR TITLE
ci(flutter): configure pub.dev OIDC publishing

### DIFF
--- a/.github/workflows/flutter-publish.yml
+++ b/.github/workflows/flutter-publish.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Dart pub.dev credentials
+        uses: dart-lang/setup-dart@v1
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.16.0
         with:
@@ -61,4 +64,5 @@ jobs:
 
       - name: Publish to pub.dev
         working-directory: packages/flutter
+        timeout-minutes: 10
         run: dart pub publish --force


### PR DESCRIPTION
## Summary
- add `dart-lang/setup-dart@v1` to the Flutter publish workflow so `dart pub publish --force` gets pub.dev GitHub OIDC credentials
- cap the final publish step at 10 minutes so missing auth fails closed instead of waiting for browser OAuth

## Verification
- Observed canceled tag run `26002857732`: tag/version check, dependency install, analysis, tests, and dry-run publish passed, then `dart pub publish --force` printed browser OAuth authorization text and waited
- Pub.dev API still reports only `refraction_ui` 0.1.0, so 0.2.0 was not published before cancellation
- Change follows Dart automated publishing docs: GitHub Actions OIDC publishing uses `id-token: write` plus `dart-lang/setup-dart` before `dart pub publish --force`