### PR TITLE
fix(react-meta): ship RSC 'use client' directive on every published entry

### DIFF
--- a/.changeset/react-meta-rsc-use-client.md
+++ b/.changeset/react-meta-rsc-use-client.md
@@ -1,0 +1,16 @@
+---
+"@refraction-ui/react": patch
+---
+
+RSC: every published `@refraction-ui/react` JS entry (`.`, `./theme`,
+`./form`, ESM + CJS) now ships the `'use client'` directive as its module
+prologue. Previously the package shipped the directive nowhere, so importing
+it from a Next.js App Router **Server Component** — e.g. mounting
+`<AnalyticsProvider>` / `<TelemetryProvider>` / `<ThemeProvider>` in
+`app/layout.tsx` — broke `next build` with the "`createContext` only works
+in a Client Component" error. The directive is restored deterministically
+post-build (tsup's bundling + `treeshake` strip both a source directive and
+an esbuild banner), and a regression test locks it in. Server-safe headless
+factories also re-exported here (`createAnalytics`/`createTelemetry`/
+`createAI`/`cn`/`cva`) are now part of this client module — instantiate them
+inside the client/provider boundary.

--- a/packages/react-meta/__tests__/meta.test.ts
+++ b/packages/react-meta/__tests__/meta.test.ts
@@ -164,4 +164,32 @@ describe('@refraction-ui/react (meta package)', () => {
     expect(declarationText).not.toMatch(/from ['"]@refraction-ui\//)
     expect(declarationText).not.toMatch(/import\(['"]@refraction-ui\//)
   })
+
+  // RSC regression guard. Every published JS entry re-exports React
+  // providers/hooks (createContext, useContext, …); without a leading
+  // `"use client"` directive, importing `@refraction-ui/react` from a
+  // Next.js App Router Server Component (e.g. a Provider in app/layout.tsx)
+  // fails `next build`. tsup strips both a source directive and an esbuild
+  // banner here (esbuild drops it when bundling; `treeshake` removes a
+  // banner expression) — scripts/ensure-use-client.mjs restores it
+  // post-build. This locks that in.
+  it.each([
+    'index.js',
+    'index.cjs',
+    'theme.js',
+    'theme.cjs',
+    'form.js',
+    'form.cjs',
+  ])('built entry %s starts with the RSC "use client" directive', (entry) => {
+    const code = readFileSync(join(testDir, '..', 'dist', entry), 'utf8')
+    // Must be the module's directive prologue: the very first statement,
+    // before any import/expression. Allow either quote style + optional ;.
+    expect(code).toMatch(/^﻿?\s*(['"])use client\1\s*;?/)
+    // Not double-prepended (post-build step must be idempotent). Checked at
+    // the prologue only — a "use client" string literal may legitimately
+    // appear elsewhere inside the ~1.5 MB bundled code.
+    expect(code).not.toMatch(
+      /^﻿?\s*(['"])use client\1\s*;?\s*(['"])use client\2\s*;?/,
+    )
+  })
 })

--- a/packages/react-meta/package.json
+++ b/packages/react-meta/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && cp src/styles.css dist/styles.css && node ./scripts/embed-internal-types.mjs",
+    "build": "tsup && cp src/styles.css dist/styles.css && node ./scripts/embed-internal-types.mjs && node ./scripts/ensure-use-client.mjs",
     "dev": "tsup --watch",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",

--- a/packages/react-meta/scripts/ensure-use-client.mjs
+++ b/packages/react-meta/scripts/ensure-use-client.mjs
@@ -1,0 +1,56 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Post-build: guarantee the RSC `'use client'` directive is the module's
+// directive prologue in every published JS entry of @refraction-ui/react.
+//
+// Why a post-build step and not a source directive / esbuild `banner`:
+// every entry (`.`, `./theme`, `./form`) re-exports React providers / hooks
+// (createContext, useContext, …). Without a leading `"use client"`,
+// importing `@refraction-ui/react` from a Next.js App Router Server
+// Component (e.g. mounting a Provider in `app/layout.tsx`) fails
+// `next build` with the "createContext only works in a Client Component"
+// RSC error. tsup's pipeline strips both a source-level directive and an
+// esbuild `banner` here: esbuild drops non-standard directives when
+// bundling, and the `treeshake: true` (Rollup) pass removes a banner string
+// as a side-effect-free expression. Rewriting the emitted files last is the
+// only deterministic place. Mirrors scripts/embed-internal-types.mjs.
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'dist')
+
+// All published JS entries (see package.json `exports`). Shared chunks are
+// imported by these so the boundary on the entry is sufficient.
+const entries = [
+  'index.js',
+  'index.cjs',
+  'theme.js',
+  'theme.cjs',
+  'form.js',
+  'form.cjs',
+]
+
+// Already-present directive (any quote style, optional semicolon), allowing
+// a leading BOM / whitespace / blank lines before it — idempotent.
+const alreadyDirective = /^﻿?\s*(['"])use client\1\s*;?/
+
+let patched = 0
+for (const name of entries) {
+  const file = resolve(distDir, name)
+  let code
+  try {
+    code = await readFile(file, 'utf8')
+  } catch (err) {
+    if (err.code === 'ENOENT') continue // entry not emitted (e.g. format off)
+    throw err
+  }
+  if (alreadyDirective.test(code)) continue
+  await writeFile(file, `'use client';\n${code}`, 'utf8')
+  patched += 1
+}
+
+console.log(
+  `[ensure-use-client] prepended 'use client' to ${patched} entr${
+    patched === 1 ? 'y' : 'ies'
+  }`,
+)

--- a/packages/react-meta/src/form.ts
+++ b/packages/react-meta/src/form.ts
@@ -1,6 +1,11 @@
 /**
  * @refraction-ui/react/form
  *
+ * RSC client boundary (RHF-backed primitives use React context + hooks).
+ * Do NOT add a `'use client'` directive here — it is injected post-build by
+ * scripts/ensure-use-client.mjs (bundling strips a source/banner directive).
+ * This subpath is safe to import from a Next.js App Router Server Component.
+ *
  * Opt-in subpath for React Hook Form-backed primitives. Keeping these exports
  * out of the root entry prevents ordinary component consumers from having to
  * install or resolve react-hook-form.

--- a/packages/react-meta/src/index.ts
+++ b/packages/react-meta/src/index.ts
@@ -1,6 +1,20 @@
 /**
  * @refraction-ui/react
  *
+ * RSC client boundary: this meta re-exports React providers / hooks /
+ * interactive components (createContext, useRef, useContext, …), so the
+ * published bundle must carry a leading `'use client'` directive — otherwise
+ * importing `@refraction-ui/react` from a Next.js App Router Server
+ * Component (e.g. mounting a Provider in `app/layout.tsx`) fails
+ * `next build` with the "createContext only works in a Client Component"
+ * RSC error. Do NOT add a `'use client'` directive here: tsup/esbuild drop
+ * it when bundling and the `treeshake` (Rollup) pass only emits a
+ * "module level directives ... ignored" warning. The directive is injected
+ * deterministically post-build by scripts/ensure-use-client.mjs (guarded by
+ * a meta.test.ts regression test). The server-safe headless factories also
+ * re-exported here (createAnalytics/createTelemetry/createAI/cn/cva/…) are
+ * part of this client module — instantiate them inside the client boundary.
+ *
  * Meta package that re-exports all @refraction-ui/react-* component packages.
  * Allows consumers to install everything from a single package:
  *

--- a/packages/react-meta/src/theme.ts
+++ b/packages/react-meta/src/theme.ts
@@ -1,6 +1,12 @@
 /**
  * @refraction-ui/react/theme
  *
+ * RSC client boundary (ThemeProvider / useTheme / ThemeToggle use React
+ * context + hooks). Do NOT add a `'use client'` directive here — it is
+ * injected post-build by scripts/ensure-use-client.mjs (bundling strips a
+ * source/banner directive). This subpath is safe to import from a Next.js
+ * App Router Server Component.
+ *
  * Opt-in subpath that re-exports the @refraction-ui/react-theme package.
  * Kept separate from the main entry so that consumers who already use
  * their own theme system (e.g. next-themes) don't accidentally pull in

--- a/packages/react-meta/tsup.config.ts
+++ b/packages/react-meta/tsup.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   treeshake: true,
+  // RSC: the `'use client'` directive lives at the top of each source entry
+  // (src/index.ts, src/theme.ts, src/form.ts), NOT here as an esbuild
+  // `banner`. A banner string is injected post-bundle and then dropped by
+  // this `treeshake` (Rollup) pass as a side-effect-free expression; a real
+  // source-level directive is recognised and hoisted to the bundle top so
+  // `@refraction-ui/react` is safe to import from a Next.js Server Component.
   // Bundle all @refraction-ui/* workspace packages into the output.
   // Only external deps (React and RHF for the form subpath) remain as peer deps.
   noExternal: [/@refraction-ui\//],


### PR DESCRIPTION
## Problem

`@refraction-ui/react` re-exports React providers/hooks (`createContext`,
`useContext`, …) from **every** entry (`.`, `./theme`, `./form`) but shipped
the `'use client'` directive **nowhere** — verified across 0.7.0 → 0.9.2
(not a regression; never existed). Importing it from a Next.js App Router
**Server Component** — the canonical place to mount `<AnalyticsProvider>` /
`<TelemetryProvider>` / `<ThemeProvider>`, i.e. `app/layout.tsx` — breaks
`next build` with *"`createContext` only works in a Client Component"*.

Surfaced by easyloops feedback (P2b deploy off `main`). The original note
assumed RUI shipped the banner on `./theme`; it does not — no subpath had it.

## Why post-build (not a source directive / esbuild banner)

tsup's pipeline strips both: esbuild drops the non-standard directive when
bundling, and the `treeshake: true` (Rollup) pass only emits *"module level
directives cause errors when bundled, 'use client' … was ignored"* and
removes it. A banner string is likewise tree-shaken as a side-effect-free
expression.

## Fix

- **`scripts/ensure-use-client.mjs`** — idempotent post-build step that
  prepends `'use client';` as the module prologue to all 6 published JS
  entries (`index/theme/form` × `.js/.cjs`). Dependency-free, mirrors
  `embed-internal-types.mjs`; wired as the final `build` step.
- **`meta.test.ts`** — regression guard: each built entry must start with
  the directive and must not be double-prepended (6 new cases).
- **`src/{index,theme,form}.ts`** — comments warning against re-adding a
  source-level directive (it only produces Rollup noise).
- **changeset** — patch `@refraction-ui/react` (0.9.2 → 0.9.3).

Server-safe headless factories also re-exported here (`createAnalytics`/
`createTelemetry`/`createAI`/`cn`/`cva`) are now part of this client module —
instantiate them inside the client/provider boundary (chosen approach:
blanket client boundary on the meta).

## Verification

`make ci` green by log content: `Tasks: 692 successful, 692 total`,
`@refraction-ui/react:test: Tests 28 passed (28)` (incl. the new RSC
guards), **0** Rollup directive warnings. Locally confirmed all 6 entries
start with exactly one `'use client';`, idempotent across rebuilds, `.d.ts`
self-containment invariant intact.