### PR TITLE
feat(conversation): group replies under originating root + reply counts

### DIFF
--- a/.changeset/threading-strategy.md
+++ b/.changeset/threading-strategy.md
@@ -1,0 +1,6 @@
+---
+"@refraction-ui/react": minor
+"@refraction-ui/astro": minor
+---
+
+Conversation — refine the reply-threading strategy. Replies to *any* message in a thread (the root or a mid-thread reply) now group under the originating root (one level deep) while remembering the specific message replied to via `replyToId` (used for the quote). The "💬 N replies" count now shows on the originating message in **both** inline and panel modes, and a new `replyTo(messageId)` action + `replyTarget` state lets a reply target a specific mid-thread message while still grouping under the root.

--- a/packages/astro-conversation/src/Chat.astro
+++ b/packages/astro-conversation/src/Chat.astro
@@ -88,7 +88,7 @@ function isOwn(m: ChatMessage): boolean {
       ) : (
         timeline.map((message) => {
           const parent = state.threadingMode === 'inline' && message.parentId
-            ? findMessage(state.messages, message.parentId)
+            ? findMessage(state.messages, message.replyToId ?? message.parentId)
             : undefined
           const replyCount = getReplyCount(state.messages, message.id)
           return (
@@ -137,7 +137,7 @@ function isOwn(m: ChatMessage): boolean {
                   </div>
                 )}
 
-                {state.threadingMode === 'panel' && replyCount > 0 && (
+                {replyCount > 0 && (
                   <button type="button" class="mt-1 text-xs font-medium text-primary hover:underline" data-rfr-open-thread data-root-id={message.id}>
                     💬 {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
                   </button>

--- a/packages/conversation/__tests__/conversation.test.ts
+++ b/packages/conversation/__tests__/conversation.test.ts
@@ -209,6 +209,47 @@ describe('thread panel', () => {
     c.deleteMessage(rootId)
     expect(c.getState().openThreadRootId).toBeNull()
   })
+
+  it('openThread defaults the reply target to the root', async () => {
+    const c = createConversation()
+    await c.sendMessage('root')
+    const rootId = c.getState().messages[0]!.id
+    c.openThread(rootId)
+    expect(c.getState().replyTarget).toBe(rootId)
+  })
+})
+
+describe('reply-target strategy (reply to a mid-thread message)', () => {
+  it('replyTo opens the originating thread and targets the specific message', async () => {
+    const c = createConversation()
+    await c.sendMessage('root')
+    const rootId = c.getState().messages[0]!.id
+    await c.sendMessage('mid reply', { replyTo: rootId })
+    const mid = c.getState().messages.find((m) => m.content === 'mid reply')!
+
+    c.replyTo(mid.id)
+    // panel opens on the originating root, but the next reply targets `mid`
+    expect(c.getState().openThreadRootId).toBe(rootId)
+    expect(c.getState().replyTarget).toBe(mid.id)
+  })
+
+  it('replying to a mid-thread message groups under the root, records replyToId', async () => {
+    const c = createConversation()
+    await c.sendMessage('root')
+    const rootId = c.getState().messages[0]!.id
+    await c.sendMessage('first reply', { replyTo: rootId })
+    const mid = c.getState().messages.find((m) => m.content === 'first reply')!
+
+    // reply to the mid-thread reply, not the root
+    await c.sendMessage('reply to the reply', { replyTo: mid.id })
+    const nested = c.getState().messages.find((m) => m.content === 'reply to the reply')!
+
+    expect(nested.parentId).toBe(rootId) // grouped under the originating root
+    expect(nested.replyToId).toBe(mid.id) // but quotes the specific message
+    // thread still flat: root + 2 replies
+    const thread = c.getState().messages.filter((m) => m.parentId === rootId)
+    expect(thread).toHaveLength(2)
+  })
 })
 
 describe('error + retry + stop', () => {

--- a/packages/conversation/src/conversation.ts
+++ b/packages/conversation/src/conversation.ts
@@ -40,6 +40,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
   const messagesByConv = new Map<string, ChatMessage[]>()
   let activeConversationId: string | null = config.activeConversationId ?? null
   let openThreadRootId: string | null = null
+  let replyTarget: string | null = null
   let status: ConversationState['status'] = 'idle'
   let error: string | null = null
   let abortController: AbortController | null = null
@@ -66,6 +67,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
       activeConversationId,
       messages: activeConversationId ? (messagesByConv.get(activeConversationId) ?? []) : [],
       openThreadRootId,
+      replyTarget,
       threadingMode,
       status,
       error,
@@ -187,6 +189,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
     newConversation(opts) {
       const conversation = createConversationInternal(opts ?? {})
       openThreadRootId = null
+      replyTarget = null
       emit()
       return conversation
     },
@@ -195,6 +198,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
       if (!conversations.has(conversationId) || activeConversationId === conversationId) return
       activeConversationId = conversationId
       openThreadRootId = null
+      replyTarget = null
       emit()
     },
 
@@ -205,6 +209,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
       if (activeConversationId === conversationId) {
         activeConversationId = orderedConversations()[0]?.id ?? null
         openThreadRootId = null
+        replyTarget = null
       }
       emit()
     },
@@ -245,6 +250,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
       const next = list.filter((m) => !removeIds.has(m.id))
       messagesByConv.set(activeConversationId, next)
       if (openThreadRootId && removeIds.has(openThreadRootId)) openThreadRootId = null
+      if (replyTarget && removeIds.has(replyTarget)) replyTarget = openThreadRootId
       emit()
     },
 
@@ -277,7 +283,9 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
 
       const conversationId = ensureActiveConversation(opts)
       const list = messagesByConv.get(conversationId)!
+      // Group under the originating root, but remember the specific message replied to.
       const parentId = opts?.replyTo ? rootIdOf(list, opts.replyTo) : undefined
+      const replyToId = opts?.replyTo
       const isFirstRoot = !parentId && selectRoots(list).length === 0
 
       const userMsg: ChatMessage = {
@@ -289,6 +297,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
         timestamp: new Date(),
         status: 'sent',
         parentId,
+        replyToId,
         attachments: opts?.attachments,
         metadata: opts?.metadata,
       }
@@ -355,12 +364,23 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
 
     openThread(rootId) {
       openThreadRootId = rootId
+      replyTarget = rootId // reply to the root by default
+      emit()
+    },
+
+    replyTo(messageId) {
+      if (!activeConversationId) return
+      const list = messagesByConv.get(activeConversationId)!
+      // Open the originating thread, but target the specific message replied to.
+      openThreadRootId = rootIdOf(list, messageId)
+      replyTarget = messageId
       emit()
     },
 
     closeThread() {
-      if (openThreadRootId === null) return
+      if (openThreadRootId === null && replyTarget === null) return
       openThreadRootId = null
+      replyTarget = null
       emit()
     },
 

--- a/packages/conversation/src/types.ts
+++ b/packages/conversation/src/types.ts
@@ -68,9 +68,15 @@ export interface ChatMessage {
   error?: string
   /**
    * Root message id of the reply-thread this message belongs to. Absent on
-   * root/main-timeline messages. Threads are one level deep.
+   * root/main-timeline messages. Threads are one level deep — a reply to any
+   * message in a thread groups under the same originating root.
    */
   parentId?: string
+  /**
+   * The specific message this is "in reply to" (for the quote), which may be a
+   * mid-thread reply even though `parentId` is always the originating root.
+   */
+  replyToId?: string
   /** Emoji reactions */
   reactions?: MessageReaction[]
   /** Attachments (images/gifs/files) */
@@ -136,6 +142,8 @@ export interface ConversationState {
   messages: ChatMessage[]
   /** Root id of the thread shown in the side panel, or null when closed */
   openThreadRootId: string | null
+  /** The specific message a reply in the open thread will target (default: the root) */
+  replyTarget: string | null
   /** Current threading mode */
   threadingMode: ThreadingMode
   /** Coarse store status */
@@ -210,8 +218,10 @@ export interface ConversationAPI {
   stop(): void
 
   // — threads / view —
-  /** Open the side panel focused on a message's thread */
+  /** Open the side panel focused on a message's thread (reply target = root) */
   openThread(rootId: string): void
+  /** Open the originating thread and target a specific message for the next reply */
+  replyTo(messageId: string): void
   /** Close the thread side panel */
   closeThread(): void
   /** Switch threading mode */

--- a/packages/react-conversation/src/chat.tsx
+++ b/packages/react-conversation/src/chat.tsx
@@ -166,7 +166,7 @@ function HoverActions({
   onToggleEmojis: () => void
   align: 'start' | 'end'
 }) {
-  const { state, openThread, deleteMessage } = conversation
+  const { replyTo, deleteMessage } = conversation
   return h(
     'div',
     {
@@ -175,7 +175,8 @@ function HoverActions({
         align === 'end' && 'justify-end',
       ),
     },
-    h('button', { type: 'button', className: 'hover:text-foreground', onClick: () => openThread(rootIdOf(state.messages, message.id)) }, 'Reply'),
+    // Reply targets this specific message but groups under the originating root.
+    h('button', { type: 'button', className: 'hover:text-foreground', onClick: () => replyTo(message.id) }, 'Reply'),
     h('button', { type: 'button', className: 'hover:text-foreground', onClick: onToggleEmojis }, 'React'),
     isOwn ? h('button', { type: 'button', className: 'hover:text-foreground', onClick: onEdit }, 'Edit') : null,
     isOwn ? h('button', { type: 'button', className: 'hover:text-destructive', onClick: () => deleteMessage(message.id) }, 'Delete') : null,
@@ -248,7 +249,7 @@ function MessageRow({
   const inner = h(
     React.Fragment,
     null,
-    quotedParent ? h(QuotedParent, { parent: quotedParent, onClick: () => openThread(quotedParent.id) }) : null,
+    quotedParent ? h(QuotedParent, { parent: quotedParent, onClick: () => openThread(rootIdOf(state.messages, quotedParent.id)) }) : null,
     editing
       ? h(EditField, { message, conversation, onDone: () => setEditing(false) })
       : isUser
@@ -362,13 +363,15 @@ function ThreadPanel({ conversation, currentUserId, composer }: { conversation: 
   const rootId = state.openThreadRootId
   if (!rootId) return null
   const messages = selectThreadMessages(state.messages, rootId)
+  // Hint when the next reply targets a specific mid-thread message rather than the root.
+  const target = state.replyTarget && state.replyTarget !== rootId ? findMessage(state.messages, state.replyTarget) : undefined
   return h(
     'aside',
     { className: 'flex w-80 flex-col border-l border-border', 'aria-label': 'Thread' },
     h(
       'div',
       { className: 'flex items-center justify-between border-b border-border px-3 py-2' },
-      h('span', { className: 'text-sm font-semibold' }, 'Thread'),
+      h('span', { className: 'text-sm font-semibold' }, `Thread · ${messages.length - 1} ${messages.length - 1 === 1 ? 'reply' : 'replies'}`),
       h('button', { type: 'button', className: 'text-muted-foreground hover:text-foreground', 'aria-label': 'Close thread', onClick: () => conversation.closeThread() }, '✕'),
     ),
     h(
@@ -376,6 +379,14 @@ function ThreadPanel({ conversation, currentUserId, composer }: { conversation: 
       { className: 'flex-1 overflow-y-auto p-1' },
       ...messages.map((m) => h(MessageRow, { key: m.id, message: m, conversation, currentUserId, showThreadAffordance: false })),
     ),
+    target
+      ? h(
+          'div',
+          { className: 'flex items-center justify-between gap-2 border-t border-border bg-muted/40 px-3 py-1 text-xs text-muted-foreground' },
+          h('span', { className: 'truncate' }, `↳ Replying to ${target.author.name}`),
+          h('button', { type: 'button', className: 'hover:text-foreground', onClick: () => conversation.openThread(rootId) }, 'Reply to thread instead'),
+        )
+      : null,
     composer,
   )
 }
@@ -445,7 +456,7 @@ export function Chat({
         onSlashCommand,
         toolbar: composerToolbar,
         onSubmit: (content: string, atts?: MessageAttachment[]) =>
-          void sendMessage(content, { replyTo: state.openThreadRootId!, attachments: atts }),
+          void sendMessage(content, { replyTo: state.replyTarget ?? state.openThreadRootId!, attachments: atts }),
         onStop: () => conversation.stop(),
       })
     : null
@@ -462,8 +473,10 @@ export function Chat({
               message: m,
               conversation,
               currentUserId,
-              showThreadAffordance: state.threadingMode === 'panel',
-              quotedParent: state.threadingMode === 'inline' && m.parentId ? findMessage(state.messages, m.parentId) : undefined,
+              // Show the "N replies" count on originating messages in BOTH modes.
+              showThreadAffordance: true,
+              // Inline: quote the specific message replied to (falls back to the root).
+              quotedParent: state.threadingMode === 'inline' && m.parentId ? findMessage(state.messages, m.replyToId ?? m.parentId) : undefined,
             }),
           ),
         )

--- a/packages/react-conversation/src/use-conversation.ts
+++ b/packages/react-conversation/src/use-conversation.ts
@@ -23,6 +23,7 @@ export interface UseConversationResult {
   retryLast: ConversationAPI['retryLast']
   stop: ConversationAPI['stop']
   openThread: ConversationAPI['openThread']
+  replyTo: ConversationAPI['replyTo']
   closeThread: ConversationAPI['closeThread']
   setThreadingMode: ConversationAPI['setThreadingMode']
 }
@@ -60,6 +61,7 @@ export function useConversation(config?: ConversationConfig): UseConversationRes
     retryLast: api.retryLast,
     stop: api.stop,
     openThread: api.openThread,
+    replyTo: api.replyTo,
     closeThread: api.closeThread,
     setThreadingMode: api.setThreadingMode,
   }


### PR DESCRIPTION
Refines the reply-threading strategy:

- **Grouping:** replying to *any* message in a thread (root or a mid-thread reply) groups under the **originating root** (one level deep) — no deep nesting.
- **`replyToId`:** the specific message replied-to is remembered (distinct from `parentId`/root) and used for the inline quote.
- **Counts:** the "💬 N replies" indicator now shows on the originating message in **both** inline and panel modes.
- **`replyTo(messageId)`** action + `replyTarget` state let a reply target a specific mid-thread message while still grouping under the root (with a "↳ Replying to X" hint in the panel).

Core: 21 tests. Both metas (minor).