### PR TITLE
feat(conversation,cookie-consent): redesign composer + consent banner

### DIFF
--- a/.changeset/chat-cookie-redesign.md
+++ b/.changeset/chat-cookie-redesign.md
@@ -1,0 +1,6 @@
+---
+"@refraction-ui/react": minor
+"@refraction-ui/astro": minor
+---
+
+Visual redesign of the Chat composer and the CookieConsent banner. The Chat composer is now a unified rounded input card (textarea + bottom bar with attach / formatting toolbar / send), with the inline error + retry banner restored (new optional `error`/`onRetry` props on `Composer`). The CookieConsent banner gets a cookie-icon header, a clearer button hierarchy (Customize / Reject all / Accept all), and switch-style category toggles in the settings view; the Astro `CookieConsent` mirrors the new look.

--- a/packages/astro-cookie-consent/src/CookieConsent.astro
+++ b/packages/astro-cookie-consent/src/CookieConsent.astro
@@ -37,40 +37,45 @@ const {
   aria-label="Cookie consent"
   class={cn('fixed inset-x-0 z-50 p-4', position === 'bottom' ? 'bottom-0' : 'top-0', className)}
 >
-  <div class="mx-auto max-w-3xl rounded-xl border border-border bg-background p-4 shadow-lg">
-    <h2 class="text-base font-semibold">{title}</h2>
-    <p class="mt-1 text-sm text-muted-foreground">{description}</p>
-    {policyUrl && (
-      <a href={policyUrl} target="_blank" rel="noreferrer" class="mt-1 inline-block text-sm text-muted-foreground underline hover:text-foreground">{policyLabel}</a>
-    )}
-
-    <div data-rfr-cc-prompt class="mt-3 flex flex-wrap items-center gap-2">
-      <button type="button" data-rfr-cc-accept class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground">Accept all</button>
-      <button type="button" data-rfr-cc-reject class="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">Reject all</button>
-      <button type="button" data-rfr-cc-manage class="ml-auto rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">Manage preferences</button>
+  <div class="mx-auto max-w-2xl overflow-hidden rounded-2xl border border-border bg-background shadow-lg">
+    <div data-rfr-cc-prompt class="flex flex-col gap-4 p-5 sm:flex-row sm:items-center">
+      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent text-xl" aria-hidden="true">🍪</div>
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-semibold">{title}</p>
+        <p class="mt-0.5 text-sm leading-relaxed text-muted-foreground">
+          {description}
+          {policyUrl && (
+            <a href={policyUrl} target="_blank" rel="noreferrer" class="font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"> {policyLabel}</a>
+          )}
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 sm:shrink-0">
+        <button type="button" data-rfr-cc-manage class="text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">Customize</button>
+        <button type="button" data-rfr-cc-reject class="inline-flex items-center rounded-lg border border-border px-3.5 py-2 text-sm font-medium hover:bg-accent">Reject all</button>
+        <button type="button" data-rfr-cc-accept class="inline-flex items-center rounded-lg bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground hover:opacity-90">Accept all</button>
+      </div>
     </div>
 
-    <div data-rfr-cc-settings hidden class="mt-3 space-y-2">
+    <div data-rfr-cc-settings hidden class="space-y-2 p-5">
+      <p class="text-sm font-semibold">Cookie preferences</p>
       {categories.map((cat) => (
-        <label class="flex items-start justify-between gap-3 rounded-md border border-border p-3">
+        <label class="flex items-center justify-between gap-4 rounded-xl border border-border p-3">
           <span class="min-w-0">
-            <span class="block text-sm font-medium">{cat.label}{cat.required ? ' (required)' : ''}</span>
-            {cat.description && <span class="block text-xs text-muted-foreground">{cat.description}</span>}
+            <span class="block text-sm font-medium">{cat.label}</span>
+            {cat.description && <span class="mt-0.5 block text-xs text-muted-foreground">{cat.description}</span>}
           </span>
-          <input
-            type="checkbox"
-            data-rfr-cc-cat={cat.id}
-            checked={cat.required}
-            disabled={cat.required}
-            aria-label={cat.label}
-            class="mt-0.5 h-4 w-4"
-          />
+          {cat.required ? (
+            <span class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">Always on</span>
+          ) : (
+            <input type="checkbox" data-rfr-cc-cat={cat.id} aria-label={cat.label} class="h-5 w-5 accent-[hsl(var(--primary))]" />
+          )}
+          {cat.required && <input type="checkbox" data-rfr-cc-cat={cat.id} checked disabled hidden />}
         </label>
       ))}
       <div class="flex flex-wrap items-center gap-2 pt-1">
-        <button type="button" data-rfr-cc-save class="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground">Save preferences</button>
-        <button type="button" data-rfr-cc-accept class="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent">Accept all</button>
-        <button type="button" data-rfr-cc-back class="ml-auto text-sm text-muted-foreground underline hover:text-foreground">Back</button>
+        <button type="button" data-rfr-cc-back class="text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">← Back</button>
+        <button type="button" data-rfr-cc-accept class="inline-flex items-center rounded-lg border border-border px-3.5 py-2 text-sm font-medium hover:bg-accent sm:ml-auto">Accept all</button>
+        <button type="button" data-rfr-cc-save class="inline-flex items-center rounded-lg bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground hover:opacity-90">Save preferences</button>
       </div>
     </div>
   </div>

--- a/packages/react-conversation/src/chat.tsx
+++ b/packages/react-conversation/src/chat.tsx
@@ -435,10 +435,14 @@ export function Chat({
   const timeline = selectMainTimeline(state.messages, state.threadingMode)
   const activeConv = state.conversations.find((c) => c.id === state.activeConversationId)
   const busy = state.status === 'sending' || state.status === 'streaming'
+  const error = state.status === 'error' ? state.error : null
+  const onRetry = () => void conversation.retryLast()
 
   const mainComposer = h(Composer, {
     placeholder,
     busy,
+    error,
+    onRetry,
     slashCommands,
     mentions,
     onSlashCommand,
@@ -451,6 +455,8 @@ export function Chat({
     ? h(Composer, {
         placeholder: 'Reply…',
         busy,
+        error,
+        onRetry,
         slashCommands,
         mentions,
         onSlashCommand,

--- a/packages/react-conversation/src/composer.tsx
+++ b/packages/react-conversation/src/composer.tsx
@@ -34,6 +34,9 @@ export interface ComposerProps {
   emoji?: boolean
   /** Enable the attach button (default true) */
   attachments?: boolean
+  /** Error to surface above the input (with a Retry button) */
+  error?: string | null
+  onRetry?: () => void
   onSubmit: (content: string, attachments?: MessageAttachment[]) => void
   onStop?: () => void
   /** Called when a `/` command without `insertText` is chosen */
@@ -81,6 +84,8 @@ export function Composer({
   toolbar = true,
   emoji = true,
   attachments = true,
+  error,
+  onRetry,
   onSubmit,
   onStop,
   onSlashCommand,
@@ -240,6 +245,7 @@ export function Composer({
     }
   }
 
+  const iconBtn = 'flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground'
   const toolbarBtn = (label: string, title: string, kind: Parameters<typeof format>[0]) =>
     h(
       'button',
@@ -247,156 +253,163 @@ export function Composer({
         key: kind,
         type: 'button',
         title,
-        className: 'rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground',
+        className: cn(iconBtn, 'text-xs font-medium'),
         onMouseDown: (e: React.MouseEvent) => e.preventDefault(), // keep textarea selection
         onClick: () => format(kind),
       },
       label,
     )
 
+  const menu = menuOpen
+    ? h(
+        'div',
+        {
+          className:
+            'absolute bottom-full left-0 z-20 mb-2 w-72 overflow-hidden rounded-xl border border-border bg-popover shadow-lg',
+          role: 'listbox',
+        },
+        h(
+          'div',
+          { className: 'border-b border-border px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground' },
+          trigger?.type === '/' ? 'Commands' : trigger?.type === '@' ? 'Mentions' : 'Emoji',
+        ),
+        ...items.map((it, i) =>
+          h(
+            'button',
+            {
+              key: it.key,
+              type: 'button',
+              role: 'option',
+              'aria-selected': i === active,
+              className: cn(
+                'flex w-full items-center gap-2 px-3 py-2 text-left text-sm',
+                i === active ? 'bg-accent' : 'hover:bg-accent/50',
+              ),
+              onMouseEnter: () => setActive(i),
+              onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+              onClick: () => selectItem(i),
+            },
+            it.icon ? h('span', { className: 'w-4 text-center text-muted-foreground' }, it.icon) : null,
+            h('span', { className: 'flex-1 truncate' }, it.primary),
+            it.secondary ? h('span', { className: 'truncate text-xs text-muted-foreground' }, it.secondary) : null,
+          ),
+        ),
+      )
+    : null
+
   return h(
     'div',
-    { className: 'border-t border-border' },
-    // attachment chips
-    pending.length > 0
-      ? h(
-          'div',
-          { className: 'flex flex-wrap gap-2 px-3 pt-2' },
-          ...pending.map((a) =>
-            h(
-              'span',
-              { key: a.id, className: 'inline-flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs' },
-              a.name,
-              h(
-                'button',
-                {
-                  type: 'button',
-                  className: 'text-muted-foreground hover:text-destructive',
-                  onClick: () => setPending((p) => p.filter((x) => x.id !== a.id)),
-                },
-                '✕',
-              ),
-            ),
-          ),
-        )
-      : null,
-    // toolbar
-    toolbar
-      ? h(
-          'div',
-          { className: 'flex items-center gap-0.5 px-2 pt-2' },
-          toolbarBtn('B', 'Bold (⌘B)', 'bold'),
-          toolbarBtn('𝑖', 'Italic (⌘I)', 'italic'),
-          toolbarBtn('</>', 'Code (⌘E)', 'code'),
-          toolbarBtn('🔗', 'Link (⌘K)', 'link'),
-          toolbarBtn('❝', 'Quote', 'quote'),
-          toolbarBtn('•', 'Bulleted list', 'ul'),
-          toolbarBtn('1.', 'Numbered list', 'ol'),
-        )
-      : null,
-    // input row (relative for the popup menu)
+    { className: 'p-3' },
     h(
       'div',
-      { className: 'relative flex items-end gap-2 p-3' },
-      menuOpen
-        ? h(
-            'div',
-            {
-              className:
-                'absolute bottom-full left-3 z-20 mb-1 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg',
-              role: 'listbox',
-            },
-            h(
+      { className: 'relative' },
+      menu,
+      // unified input card
+      h(
+        'div',
+        {
+          className:
+            'overflow-hidden rounded-2xl border border-border bg-background transition focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
+        },
+        // error banner
+        error
+          ? h(
               'div',
-              { className: 'border-b border-border px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground' },
-              trigger?.type === '/' ? 'Commands' : trigger?.type === '@' ? 'Mentions' : 'Emoji',
-            ),
-            ...items.map((it, i) =>
-              h(
+              { className: 'flex items-center gap-2 border-b border-border bg-destructive/5 px-3 py-2 text-xs text-destructive', role: 'alert' },
+              h('span', { className: 'flex-1 truncate' }, error),
+              onRetry ? h('button', { type: 'button', className: 'font-medium underline', onClick: () => onRetry() }, 'Retry') : null,
+            )
+          : null,
+        // attachment chips
+        pending.length > 0
+          ? h(
+              'div',
+              { className: 'flex flex-wrap gap-2 px-3 pt-3' },
+              ...pending.map((a) =>
+                h(
+                  'span',
+                  { key: a.id, className: 'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs' },
+                  a.name,
+                  h(
+                    'button',
+                    { type: 'button', className: 'text-muted-foreground hover:text-destructive', onClick: () => setPending((p) => p.filter((x) => x.id !== a.id)) },
+                    '✕',
+                  ),
+                ),
+              ),
+            )
+          : null,
+        // textarea (borderless)
+        h('textarea', {
+          ref,
+          className: 'block max-h-40 w-full resize-none bg-transparent px-3.5 py-3 text-sm placeholder:text-muted-foreground focus:outline-none',
+          rows: 1,
+          value,
+          placeholder,
+          autoFocus,
+          'aria-label': 'Message',
+          onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => syncFromTextarea(e.target),
+          onClick: (e: React.MouseEvent<HTMLTextAreaElement>) => syncFromTextarea(e.currentTarget),
+          onKeyUp: (e: React.KeyboardEvent<HTMLTextAreaElement>) => syncFromTextarea(e.currentTarget),
+          onKeyDown,
+          onBlur: () => setTimeout(() => setTrigger(null), 120),
+        }),
+        // bottom action bar
+        h(
+          'div',
+          { className: 'flex items-center gap-0.5 px-2 pb-2' },
+          attachments
+            ? h(
+                React.Fragment,
+                null,
+                h('input', {
+                  ref: fileRef,
+                  type: 'file',
+                  accept: 'image/*',
+                  multiple: true,
+                  className: 'hidden',
+                  onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+                    onFiles(e.target.files)
+                    e.target.value = ''
+                  },
+                }),
+                h('button', { type: 'button', className: iconBtn, 'aria-label': 'Attach image or GIF', onClick: () => fileRef.current?.click() }, '📎'),
+              )
+            : null,
+          attachments && toolbar ? h('span', { className: 'mx-1 h-5 w-px bg-border' }) : null,
+          toolbar
+            ? h(
+                React.Fragment,
+                null,
+                toolbarBtn('B', 'Bold (⌘B)', 'bold'),
+                toolbarBtn('𝑖', 'Italic (⌘I)', 'italic'),
+                toolbarBtn('</>', 'Code (⌘E)', 'code'),
+                toolbarBtn('🔗', 'Link (⌘K)', 'link'),
+                toolbarBtn('❝', 'Quote', 'quote'),
+                toolbarBtn('•', 'Bulleted list', 'ul'),
+                toolbarBtn('1.', 'Numbered list', 'ol'),
+              )
+            : null,
+          h('div', { className: 'flex-1' }),
+          busy
+            ? h(
+                'button',
+                { type: 'button', 'aria-label': 'Stop', className: 'flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground', onClick: () => onStop?.() },
+                '■',
+              )
+            : h(
                 'button',
                 {
-                  key: it.key,
                   type: 'button',
-                  role: 'option',
-                  'aria-selected': i === active,
-                  className: cn(
-                    'flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm',
-                    i === active ? 'bg-accent' : 'hover:bg-accent/50',
-                  ),
-                  onMouseEnter: () => setActive(i),
-                  onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
-                  onClick: () => selectItem(i),
+                  'aria-label': 'Send',
+                  className: 'flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-base font-semibold text-primary-foreground transition disabled:opacity-40',
+                  disabled: !value.trim() && pending.length === 0,
+                  onClick: submit,
                 },
-                it.icon ? h('span', { className: 'w-4 text-center text-muted-foreground' }, it.icon) : null,
-                h('span', { className: 'flex-1 truncate' }, it.primary),
-                it.secondary ? h('span', { className: 'truncate text-xs text-muted-foreground' }, it.secondary) : null,
+                '↑',
               ),
-            ),
-          )
-        : null,
-      attachments
-        ? h(
-            React.Fragment,
-            null,
-            h('input', {
-              ref: fileRef,
-              type: 'file',
-              accept: 'image/*',
-              multiple: true,
-              className: 'hidden',
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                onFiles(e.target.files)
-                e.target.value = ''
-              },
-            }),
-            h(
-              'button',
-              {
-                type: 'button',
-                className: 'rounded-md border border-border px-2 py-2 text-sm hover:bg-accent',
-                'aria-label': 'Attach image or GIF',
-                onClick: () => fileRef.current?.click(),
-              },
-              '📎',
-            ),
-          )
-        : null,
-      h('textarea', {
-        ref,
-        className:
-          'max-h-40 flex-1 resize-none rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary',
-        rows: 1,
-        value,
-        placeholder,
-        autoFocus,
-        'aria-label': 'Message',
-        onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => syncFromTextarea(e.target),
-        onClick: (e: React.MouseEvent<HTMLTextAreaElement>) => syncFromTextarea(e.currentTarget),
-        onKeyUp: (e: React.KeyboardEvent<HTMLTextAreaElement>) => syncFromTextarea(e.currentTarget),
-        onKeyDown,
-        onBlur: () => setTimeout(() => setTrigger(null), 120),
-      }),
-      busy
-        ? h(
-            'button',
-            {
-              type: 'button',
-              className: 'rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground',
-              onClick: () => onStop?.(),
-            },
-            'Stop',
-          )
-        : h(
-            'button',
-            {
-              type: 'button',
-              className:
-                'rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50',
-              disabled: !value.trim() && pending.length === 0,
-              onClick: submit,
-            },
-            'Send',
-          ),
+        ),
+      ),
     ),
   )
 }

--- a/packages/react-cookie-consent/src/cookie-consent.tsx
+++ b/packages/react-cookie-consent/src/cookie-consent.tsx
@@ -17,20 +17,69 @@ export interface CookieConsentProps {
   className?: string
 }
 
-const btnPrimary = 'rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90'
-const btnGhost = 'rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent'
-const btnLink = 'text-sm text-muted-foreground underline hover:text-foreground'
+const btnBase = 'inline-flex items-center justify-center rounded-lg px-3.5 py-2 text-sm font-medium transition-colors'
+const btnPrimary = cn(btnBase, 'bg-primary text-primary-foreground hover:opacity-90')
+const btnGhost = cn(btnBase, 'border border-border hover:bg-accent')
+const btnLink = 'text-sm font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline'
+
+/** A compact switch toggle. Required categories render a static "Always on". */
+function Toggle({
+  checked,
+  disabled,
+  onChange,
+  label,
+}: {
+  checked: boolean
+  disabled?: boolean
+  onChange: (v: boolean) => void
+  label: string
+}) {
+  if (disabled) {
+    return h(
+      'span',
+      { className: 'rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground' },
+      'Always on',
+    )
+  }
+  return h(
+    'button',
+    {
+      type: 'button',
+      role: 'switch',
+      'aria-checked': checked,
+      'aria-label': label,
+      onClick: () => onChange(!checked),
+      className: cn(
+        'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors',
+        checked ? 'bg-primary' : 'bg-muted',
+      ),
+    },
+    h('span', {
+      className: cn(
+        'inline-block h-4 w-4 transform rounded-full bg-background shadow transition-transform',
+        checked ? 'translate-x-[1.125rem]' : 'translate-x-0.5',
+      ),
+    }),
+  )
+}
+
+function CookieIcon() {
+  return h(
+    'div',
+    { className: 'flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-accent text-xl', 'aria-hidden': true },
+    '🍪',
+  )
+}
 
 /**
  * CookieConsent — batteries-included consent banner over `useCookieConsent()`.
- * Shows a prompt (Accept all / Reject all / Manage), with a settings view of
- * per-category toggles. Renders nothing once the user has consented.
+ * Renders nothing once the user has consented.
  */
 export function CookieConsent({
   consent,
   position = 'bottom',
   title = 'We use cookies',
-  description = 'We use cookies to run the site, remember your preferences, and measure traffic. Choose which categories to allow.',
+  description = 'We use cookies to run the site, remember your preferences, and measure traffic. Choose which to allow.',
   policyUrl,
   policyLabel = 'Cookie policy',
   className,
@@ -40,69 +89,87 @@ export function CookieConsent({
 
   if (!state.open) return null
 
-  const wrapper = cn(
-    'fixed inset-x-0 z-50 p-4',
-    position === 'bottom' ? 'bottom-0' : 'top-0',
-    className,
-  )
-  const panel = 'mx-auto max-w-3xl rounded-xl border border-border bg-background p-4 shadow-lg'
+  const wrapper = cn('fixed inset-x-0 z-50 p-4', position === 'bottom' ? 'bottom-0' : 'top-0', className)
+  const panel = 'mx-auto max-w-2xl overflow-hidden rounded-2xl border border-border bg-background shadow-lg'
 
-  const header = h(
-    'div',
-    null,
-    h('h2', { className: 'text-base font-semibold' }, title),
-    h('p', { className: 'mt-1 text-sm text-muted-foreground' }, description),
-    policyUrl
-      ? h('a', { href: policyUrl, target: '_blank', rel: 'noreferrer', className: cn(btnLink, 'mt-1 inline-block') }, policyLabel)
-      : null,
-  )
+  const policy = policyUrl
+    ? h('a', { href: policyUrl, target: '_blank', rel: 'noreferrer', className: cn(btnLink, 'whitespace-nowrap') }, policyLabel)
+    : null
 
-  const promptActions = h(
+  // — compact prompt —
+  const promptView = h(
     'div',
-    { className: 'mt-3 flex flex-wrap items-center gap-2' },
-    h('button', { type: 'button', className: btnPrimary, onClick: () => acceptAll() }, 'Accept all'),
-    h('button', { type: 'button', className: btnGhost, onClick: () => rejectAll() }, 'Reject all'),
-    h('button', { type: 'button', className: cn(btnGhost, 'ml-auto'), onClick: () => setSettings(true) }, 'Manage preferences'),
-  )
-
-  const settingsView = h(
-    'div',
-    { className: 'mt-3 space-y-2' },
-    ...state.categories.map((cat) =>
+    { className: 'flex flex-col gap-4 p-5 sm:flex-row sm:items-center' },
+    h(CookieIcon),
+    h(
+      'div',
+      { className: 'min-w-0 flex-1' },
+      h('p', { className: 'text-sm font-semibold' }, title),
       h(
-        'label',
-        {
-          key: cat.id,
-          className: 'flex items-start justify-between gap-3 rounded-md border border-border p-3',
-        },
-        h(
-          'span',
-          { className: 'min-w-0' },
-          h('span', { className: 'block text-sm font-medium' }, cat.label, cat.required ? ' (required)' : ''),
-          cat.description ? h('span', { className: 'block text-xs text-muted-foreground' }, cat.description) : null,
-        ),
-        h('input', {
-          type: 'checkbox',
-          className: 'mt-0.5 h-4 w-4 accent-[hsl(var(--primary))]',
-          checked: !!state.preferences[cat.id],
-          disabled: cat.required,
-          'aria-label': cat.label,
-          onChange: (e: React.ChangeEvent<HTMLInputElement>) => setPreference(cat.id, e.target.checked),
-        }),
+        'p',
+        { className: 'mt-0.5 text-sm leading-relaxed text-muted-foreground' },
+        description,
+        policy ? h(React.Fragment, null, ' ', policy) : null,
       ),
     ),
     h(
       'div',
-      { className: 'flex flex-wrap items-center gap-2 pt-1' },
+      { className: 'flex flex-wrap items-center gap-2 sm:shrink-0' },
+      h('button', { type: 'button', className: btnLink, onClick: () => setSettings(true) }, 'Customize'),
+      h('button', { type: 'button', className: btnGhost, onClick: () => rejectAll() }, 'Reject all'),
+      h('button', { type: 'button', className: btnPrimary, onClick: () => acceptAll() }, 'Accept all'),
+    ),
+  )
+
+  // — settings —
+  const settingsView = h(
+    'div',
+    { className: 'p-5' },
+    h(
+      'div',
+      { className: 'flex items-center gap-3' },
+      h(CookieIcon),
+      h(
+        'div',
+        null,
+        h('p', { className: 'text-sm font-semibold' }, 'Cookie preferences'),
+        h('p', { className: 'text-xs text-muted-foreground' }, 'Toggle the categories you want to allow.'),
+      ),
+    ),
+    h(
+      'div',
+      { className: 'mt-4 space-y-2' },
+      ...state.categories.map((cat) =>
+        h(
+          'div',
+          { key: cat.id, className: 'flex items-center justify-between gap-4 rounded-xl border border-border p-3' },
+          h(
+            'div',
+            { className: 'min-w-0' },
+            h('p', { className: 'text-sm font-medium' }, cat.label),
+            cat.description ? h('p', { className: 'mt-0.5 text-xs text-muted-foreground' }, cat.description) : null,
+          ),
+          h(Toggle, {
+            checked: !!state.preferences[cat.id],
+            disabled: cat.required,
+            label: cat.label,
+            onChange: (v: boolean) => setPreference(cat.id, v),
+          }),
+        ),
+      ),
+    ),
+    h(
+      'div',
+      { className: 'mt-4 flex flex-wrap items-center gap-2' },
+      h('button', { type: 'button', className: btnLink, onClick: () => setSettings(false) }, '← Back'),
+      h('button', { type: 'button', className: cn(btnGhost, 'sm:ml-auto'), onClick: () => acceptAll() }, 'Accept all'),
       h('button', { type: 'button', className: btnPrimary, onClick: () => savePreferences(state.preferences) }, 'Save preferences'),
-      h('button', { type: 'button', className: btnGhost, onClick: () => acceptAll() }, 'Accept all'),
-      h('button', { type: 'button', className: cn(btnLink, 'ml-auto'), onClick: () => setSettings(false) }, 'Back'),
     ),
   )
 
   return h(
     'div',
     { className: wrapper, role: 'dialog', 'aria-label': 'Cookie consent', 'aria-modal': false },
-    h('div', { className: panel }, header, settings ? settingsView : promptActions),
+    h('div', { className: panel }, settings ? settingsView : promptView),
   )
 }


### PR DESCRIPTION
Visual redesign of two components (verified via Storybook screenshots).

**Chat composer** → a unified rounded input card: textarea on top, bottom bar with attach · formatting toolbar (B/i/code/link/quote/lists) · circular send (↑). The inline **error + retry** banner is restored (new optional `error`/`onRetry` props on `Composer`).

**CookieConsent banner** → cookie-icon header, clearer button hierarchy (Customize / Reject all / Accept all), and switch-style category toggles with an "Always on" badge for required categories in the settings view. The Astro `CookieConsent` mirrors the new look.

Changeset bumps both metas (minor).