### PR TITLE
fix(react,astro): primary alias + children fallback + theme defaultmode

### DIFF
--- a/.changeset/api-ergonomics-status-button-theme.md
+++ b/.changeset/api-ergonomics-status-button-theme.md
@@ -1,0 +1,11 @@
+---
+'@refraction-ui/react': patch
+'@refraction-ui/astro': patch
+---
+
+API ergonomics + parity:
+
+- **Button** — `<Button variant="primary">` now renders as the default (most-emphasized) button instead of silently falling through to the unstyled base. `primary` is a typed alias of `default`; behaviour is identical. Fixes muscle-memory regressions seen migrating from MUI/Chakra/Mantine. (issue #201)
+- **StatusIndicator** — accepts composable `children` as a fallback for `label`, matching every other refraction-ui primitive. `<StatusIndicator type="success">Microphone · ready</StatusIndicator>` now renders the children instead of dropping them. `aria-label` is derived from children when they are a string. (issue #200)
+- **ThemeScript** — gains `defaultMode` and `enableSystem` props so the pre-paint inline script stays in sync with `ThemeProvider` on the no-storage path. Setting `defaultMode="light"` (or `enableSystem={false}`) now skips the `prefers-color-scheme` fall-through, fixing dark→light flashes for brand-consistent apps. Defaults preserve the prior behaviour. (issue #317)
+- **Astro meta** — wires up `@refraction-ui/astro-voice-pill` and `@refraction-ui/astro-waveform` so they're reachable from `@refraction-ui/astro` (they were listed as deps but not re-exported). (issues #191, #192)

--- a/package.json
+++ b/package.json
@@ -79,8 +79,9 @@
       "flatted": "3.4.2",
       "minimatch": "9.0.7",
       "eslint>minimatch": "3.1.4",
-      "protobufjs": "8.0.2",
-      "devalue": "5.8.1"
+      "protobufjs": "8.2.0",
+      "devalue": "5.8.1",
+      "@nevware21/ts-utils": "0.14.0"
     }
   },
   "version": "0.0.1"

--- a/packages/astro-meta/src/index.ts
+++ b/packages/astro-meta/src/index.ts
@@ -96,3 +96,8 @@ export * from '@refraction-ui/astro-payment'
 export * from '@refraction-ui/astro-command-input'
 export * from '@refraction-ui/astro-logger'
 export * from '@refraction-ui/astro-analytics'
+
+// Voice primitives — siblings of @refraction-ui/react-voice-pill / -waveform.
+// Issues #191, #192.
+export * from '@refraction-ui/astro-voice-pill'
+export * from '@refraction-ui/astro-waveform'

--- a/packages/astro-theme/src/ThemeScript.astro
+++ b/packages/astro-theme/src/ThemeScript.astro
@@ -1,13 +1,26 @@
 ---
-import { getThemeScript } from '@refraction-ui/theme'
+import { getThemeScript, type ThemeMode } from '@refraction-ui/theme'
 
 interface Props {
   storageKey?: string
   attribute?: 'class' | 'data-theme'
+  /**
+   * Theme to apply when nothing is stored. Match this to the `<ThemeProvider>`
+   * client component's `defaultMode` so first-paint and hydration agree. Issue #317.
+   */
+  defaultMode?: ThemeMode
+  /** When `false`, never fall through to `prefers-color-scheme`. Default `true`. */
+  enableSystem?: boolean
 }
 
-const { storageKey = 'rfr-theme', attribute = 'class' } = Astro.props
-const scriptContent = getThemeScript(storageKey, attribute)
+const {
+  storageKey = 'rfr-theme',
+  attribute = 'class',
+  defaultMode = 'system',
+  enableSystem = true,
+} = Astro.props
+
+const scriptContent = getThemeScript({ storageKey, attribute, defaultMode, enableSystem })
 ---
 
 <script set:html={scriptContent} />

--- a/packages/button/__tests__/button.test.ts
+++ b/packages/button/__tests__/button.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { createButton, getButtonType } from '../src/button.js'
+import {
+  createButton,
+  getButtonType,
+  resolveButtonVariant,
+  BUTTON_VARIANT_ALIASES,
+} from '../src/button.js'
 import { buttonVariants } from '../src/button.styles.js'
 
 describe('createButton', () => {
@@ -68,17 +73,48 @@ describe('buttonVariants', () => {
   })
 })
 
-describe('createButton - variant/size class coverage', () => {
-  const allVariants = ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'] as const
+// Issue #201 — variant='primary' is a muscle-memory alias for 'default'.
+// Both the alias map and the variant table must keep them in lockstep.
+describe('resolveButtonVariant + primary alias (issue #201)', () => {
+  it('maps "primary" to "default"', () => {
+    expect(resolveButtonVariant('primary')).toBe('default')
+  })
 
-  it.each(allVariants)('variant "%s" produces unique classes', (variant) => {
+  it('passes through every canonical variant unchanged', () => {
+    for (const v of ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'] as const) {
+      expect(resolveButtonVariant(v)).toBe(v)
+    }
+  })
+
+  it('returns undefined for undefined (so cva defaultVariants still kicks in)', () => {
+    expect(resolveButtonVariant(undefined)).toBeUndefined()
+  })
+
+  it('exposes "primary" in the alias table', () => {
+    expect(BUTTON_VARIANT_ALIASES.primary).toBe('default')
+  })
+
+  it('buttonVariants(primary) matches buttonVariants(default) byte-for-byte', () => {
+    const primary = buttonVariants({ variant: 'primary' })
+    const def = buttonVariants({ variant: 'default' })
+    expect(primary).toBe(def)
+  })
+})
+
+describe('createButton - variant/size class coverage', () => {
+  // `primary` is intentionally an alias of `default` so it's excluded from the
+  // uniqueness check; canonical variants must all be distinct.
+  const canonicalVariants = ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'] as const
+  const allVariants = [...canonicalVariants, 'primary'] as const
+
+  it.each(allVariants)('variant "%s" produces non-empty classes', (variant) => {
     const classes = buttonVariants({ variant })
     expect(typeof classes).toBe('string')
     expect(classes.length).toBeGreaterThan(0)
   })
 
-  it('all 6 variants produce different class strings', () => {
-    const classSet = new Set(allVariants.map((v) => buttonVariants({ variant: v })))
+  it('all 6 canonical variants produce different class strings', () => {
+    const classSet = new Set(canonicalVariants.map((v) => buttonVariants({ variant: v })))
     expect(classSet.size).toBe(6)
   })
 

--- a/packages/button/src/button.styles.ts
+++ b/packages/button/src/button.styles.ts
@@ -17,6 +17,10 @@ export const buttonVariants = cva({
   variants: {
     variant: {
       default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+      // Alias for `default` — see resolveButtonVariant + issue #201. Same classes
+      // so styling stays identical even if a consumer reaches into `buttonVariants`
+      // directly without going through resolveButtonVariant.
+      primary: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
       destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
       outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
       secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',

--- a/packages/button/src/button.ts
+++ b/packages/button/src/button.ts
@@ -1,7 +1,30 @@
 import type { AccessibilityProps, KeyboardHandlerMap } from '@refraction-ui/shared'
 import { Keys } from '@refraction-ui/shared'
 
-export type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
+/**
+ * `primary` is an alias of `default` — included so the universal React-ecosystem
+ * muscle-memory (`<Button variant="primary">`) renders as the most-emphasized
+ * button instead of falling through to the unstyled base. See issue #201.
+ */
+export type ButtonVariant =
+  | 'default'
+  | 'primary'
+  | 'destructive'
+  | 'outline'
+  | 'secondary'
+  | 'ghost'
+  | 'link'
+
+/** Variants that map to the same visual style as `default`. */
+export const BUTTON_VARIANT_ALIASES: Partial<Record<ButtonVariant, ButtonVariant>> = {
+  primary: 'default',
+}
+
+/** Resolve an alias to its canonical variant. Pass-through for unknown/undefined. */
+export function resolveButtonVariant(variant: ButtonVariant | undefined): ButtonVariant | undefined {
+  if (!variant) return variant
+  return BUTTON_VARIANT_ALIASES[variant] ?? variant
+}
 export type ButtonSize = 'xs' | 'sm' | 'default' | 'lg' | 'icon'
 
 export interface ButtonProps {

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -1,6 +1,8 @@
 export {
   createButton,
   getButtonType,
+  resolveButtonVariant,
+  BUTTON_VARIANT_ALIASES,
   type ButtonProps,
   type ButtonAPI,
   type ButtonVariant,

--- a/packages/react-button/__tests__/button.test.tsx
+++ b/packages/react-button/__tests__/button.test.tsx
@@ -87,6 +87,18 @@ describe('Button (React) - variant coverage', () => {
     const html = renderToString(React.createElement(Button, { variant: 'link' }, 'Btn'))
     expect(html).toContain('underline-offset-4')
   })
+
+  // Issue #201 — `primary` is an alias for `default` so muscle-memory works.
+  it('renders primary variant with the same classes as default (issue #201)', () => {
+    const primary = renderToString(React.createElement(Button, { variant: 'primary' }, 'Save'))
+    const def = renderToString(React.createElement(Button, { variant: 'default' }, 'Save'))
+    expect(primary).toContain('bg-primary')
+    expect(primary).toContain('text-primary-foreground')
+    // Same emphasis classes for both variants — no silent fall-through.
+    expect(primary).toContain('hover:bg-primary/90')
+    expect(def).toContain('bg-primary')
+    expect(def).toContain('hover:bg-primary/90')
+  })
 })
 
 describe('Button (React) - size coverage', () => {

--- a/packages/react-button/src/button.tsx
+++ b/packages/react-button/src/button.tsx
@@ -3,6 +3,7 @@ import {
   createButton,
   buttonVariants,
   getButtonType,
+  resolveButtonVariant,
   type ButtonVariant,
   type ButtonSize,
 } from '@refraction-ui/button'
@@ -26,8 +27,12 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ variant, size, loading, asChild, className, disabled, children, shortcut, action, ...props }, ref) => {
-    const api = createButton({ variant, size, disabled, loading, asChild, type: props.type })
-    const classes = cn(buttonVariants({ variant, size }), className)
+    // `primary` is an ecosystem-muscle-memory alias for `default` — resolve it
+    // here so styling, aria, and data attributes all see the canonical variant.
+    // See issue #201.
+    const resolvedVariant = resolveButtonVariant(variant)
+    const api = createButton({ variant: resolvedVariant, size, disabled, loading, asChild, type: props.type })
+    const classes = cn(buttonVariants({ variant: resolvedVariant, size }), className)
     
     const internalRef = React.useRef<HTMLButtonElement>(null)
     const mergedRef = React.useCallback(

--- a/packages/react-status-indicator/__tests__/status-indicator.test.tsx
+++ b/packages/react-status-indicator/__tests__/status-indicator.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { StatusIndicator } from '../src/status-indicator.js'
+
+describe('StatusIndicator (React)', () => {
+  it('renders with explicit label', () => {
+    const html = renderToString(
+      React.createElement(StatusIndicator, { type: 'success', label: 'Ready' }),
+    )
+    expect(html).toContain('Ready')
+    expect(html).toContain('aria-label="Ready"')
+  })
+
+  it('accepts children as a fallback label (issue #200)', () => {
+    const html = renderToString(
+      React.createElement(
+        StatusIndicator,
+        { type: 'success' },
+        'Microphone · ready',
+      ),
+    )
+    expect(html).toContain('Microphone · ready')
+    expect(html).toContain('aria-label="Microphone · ready"')
+    // The headless default ("Success") must NOT leak through when children present
+    expect(html).not.toContain('>Success<')
+  })
+
+  it('prefers explicit label over children when both are passed', () => {
+    const html = renderToString(
+      React.createElement(
+        StatusIndicator,
+        { type: 'warning', label: 'Wins' },
+        'Loses',
+      ),
+    )
+    expect(html).toContain('Wins')
+    expect(html).not.toContain('Loses')
+  })
+
+  it('falls back to the type-derived label when neither label nor children given', () => {
+    const html = renderToString(
+      React.createElement(StatusIndicator, { type: 'error' }),
+    )
+    expect(html).toContain('Error')
+    expect(html).toContain('aria-label="Error"')
+  })
+
+  it('omits the visible label span when showLabel is false but keeps aria-label', () => {
+    const html = renderToString(
+      React.createElement(StatusIndicator, {
+        type: 'pending',
+        label: 'Connecting',
+        showLabel: false,
+      }),
+    )
+    expect(html).toContain('aria-label="Connecting"')
+    // Only the dot span remains visible — no second span with the label text.
+    expect(html).not.toMatch(/>Connecting</)
+  })
+
+  it('renders rich children (ReactNode) as the visible label', () => {
+    const html = renderToString(
+      React.createElement(
+        StatusIndicator,
+        { type: 'info' },
+        React.createElement('strong', null, 'Built-in'),
+        ' · ready',
+      ),
+    )
+    expect(html).toContain('<strong>Built-in</strong>')
+    expect(html).toContain(' · ready')
+  })
+
+  it('uses the pulse class for pending status by default', () => {
+    const html = renderToString(
+      React.createElement(StatusIndicator, { type: 'pending', label: 'Loading' }),
+    )
+    // Pulse variant adds an `animate-` token in the headless styles map.
+    expect(html).toMatch(/animate-/)
+  })
+
+  it('applies a custom className on the outer span', () => {
+    const html = renderToString(
+      React.createElement(StatusIndicator, {
+        type: 'neutral',
+        className: 'my-extra-class',
+      }),
+    )
+    expect(html).toContain('my-extra-class')
+  })
+})

--- a/packages/react-status-indicator/src/status-indicator.tsx
+++ b/packages/react-status-indicator/src/status-indicator.tsx
@@ -11,31 +11,53 @@ import { cn } from '@refraction-ui/shared'
 
 export interface StatusIndicatorProps {
   type: StatusType
+  /** Explicit text label. Takes precedence over `children`. */
   label?: string
+  /** Composable label content. Used when `label` is omitted. */
+  children?: React.ReactNode
   pulse?: boolean
   showLabel?: boolean
   className?: string
 }
 
+/** Best ARIA-label: explicit prop wins, then string children, else headless default. */
+function deriveAriaLabel(
+  label: string | undefined,
+  children: React.ReactNode,
+  fallback: string,
+): string {
+  if (label) return label
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children)
+  }
+  return fallback
+}
+
 export function StatusIndicator({
   type,
   label,
+  children,
   pulse,
   showLabel = true,
   className,
 }: StatusIndicatorProps) {
   const api = createStatusIndicator({ type, label, pulse })
+  const ariaLabel = deriveAriaLabel(label, children, api.label)
+  const visibleLabel: React.ReactNode = label ?? children ?? api.label
 
   const dotClassName = api.pulse
     ? statusPulseVariants({ type })
     : statusDotVariants({ type })
 
-  return React.createElement(
-    'span',
-    { ...api.ariaProps, className: cn(statusContainerStyles, className) },
-    React.createElement('span', { className: dotClassName }),
-    showLabel &&
-      React.createElement('span', { className: statusLabelStyles }, api.label),
+  return (
+    <span
+      {...api.ariaProps}
+      aria-label={ariaLabel}
+      className={cn(statusContainerStyles, className)}
+    >
+      <span className={dotClassName} />
+      {showLabel && <span className={statusLabelStyles}>{visibleLabel}</span>}
+    </span>
   )
 }
 

--- a/packages/react-theme/__tests__/theme-script.test.tsx
+++ b/packages/react-theme/__tests__/theme-script.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { ThemeScript } from '../src/index.js'
+
+/**
+ * <ThemeScript> is a tiny SSR-only renderer over the headless `getThemeScript`.
+ * The deep semantics live in `packages/theme/__tests__/theme-script.test.ts`
+ * — here we just verify the component forwards every prop.
+ */
+describe('<ThemeScript /> (issue #317)', () => {
+  it('renders an inline <script> tag', () => {
+    const html = renderToString(React.createElement(ThemeScript))
+    expect(html).toContain('<script')
+    expect(html).toContain("localStorage.getItem('rfr-theme')")
+  })
+
+  it('default behaviour preserves the matchMedia fall-through', () => {
+    const html = renderToString(React.createElement(ThemeScript))
+    expect(html).toContain('matchMedia')
+  })
+
+  it('defaultMode="light" disables the matchMedia fall-through', () => {
+    const html = renderToString(
+      React.createElement(ThemeScript, { defaultMode: 'light' }),
+    )
+    expect(html).not.toContain('matchMedia')
+  })
+
+  it('defaultMode="dark" + enableSystem=false picks dark for first-time visitors', () => {
+    const html = renderToString(
+      React.createElement(ThemeScript, { defaultMode: 'dark', enableSystem: false }),
+    )
+    expect(html).not.toContain('matchMedia')
+    expect(html).toContain("'dark'")
+  })
+
+  it('forwards storageKey + attribute strategy', () => {
+    const html = renderToString(
+      React.createElement(ThemeScript, {
+        storageKey: 'app_theme',
+        attribute: 'data-theme',
+      }),
+    )
+    expect(html).toContain("localStorage.getItem('app_theme')")
+    expect(html).toContain("setAttribute('data-theme',t)")
+  })
+})

--- a/packages/react-theme/src/theme-script-component.tsx
+++ b/packages/react-theme/src/theme-script-component.tsx
@@ -1,22 +1,42 @@
 import * as React from 'react'
-import { getThemeScript } from '@refraction-ui/theme'
+import { getThemeScript, type ThemeMode } from '@refraction-ui/theme'
 
 export interface ThemeScriptProps {
+  /** localStorage key the ThemeProvider reads. */
   storageKey?: string
+  /** Attribute strategy. `class` toggles `light`/`dark` on <html>; otherwise an HTML attribute. */
   attribute?: 'class' | 'data-theme'
+  /**
+   * Theme to apply when nothing is stored. Match this to `<ThemeProvider defaultMode>`
+   * so the pre-paint script and provider agree on the no-storage path. Defaults
+   * to `'system'` (current behaviour — OS preference wins). Issue #317.
+   */
+  defaultMode?: ThemeMode
+  /**
+   * When `false` the inline script never reads `prefers-color-scheme`; the
+   * `defaultMode` is applied as-is for first-time visitors. Default `true`.
+   */
+  enableSystem?: boolean
 }
 
 /**
  * Renders an inline <script> that prevents theme flash on SSR pages.
  * Place this in the <head> of your document (in Next.js layout.tsx, Remix root, etc.)
+ *
+ * Mirror the props your <ThemeProvider> uses so first-paint and React mount stay in sync:
+ *
+ *     <ThemeScript defaultMode="light" storageKey="app_theme" />
+ *     <ThemeProvider defaultMode="light" storageKey="app_theme">…</ThemeProvider>
  */
 export function ThemeScript({
   storageKey = 'rfr-theme',
   attribute = 'class',
+  defaultMode = 'system',
+  enableSystem = true,
 }: ThemeScriptProps) {
   return React.createElement('script', {
     dangerouslySetInnerHTML: {
-      __html: getThemeScript(storageKey, attribute),
+      __html: getThemeScript({ storageKey, attribute, defaultMode, enableSystem }),
     },
   })
 }

--- a/packages/theme/__tests__/theme-script.test.ts
+++ b/packages/theme/__tests__/theme-script.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { getThemeScript } from '../src/theme-script.js'
+
+/**
+ * The inline script string is small enough to assert on directly. We don't
+ * `eval()` it (no `localStorage`/`window` in vitest by default and we don't
+ * want to mock global state for a string-builder test) — instead we shape-
+ * check the pieces that matter: storage key, attribute strategy, presence
+ * or absence of the matchMedia fall-through.
+ */
+describe('getThemeScript', () => {
+  it('back-compat: positional args produce the original script shape', () => {
+    const s = getThemeScript('rfr-theme', 'class')
+    expect(s).toContain("localStorage.getItem('rfr-theme')")
+    expect(s).toContain("matchMedia('(prefers-color-scheme:dark)')")
+    expect(s).toContain("classList.add(t)")
+  })
+
+  it('positional args honour custom storageKey', () => {
+    const s = getThemeScript('app_theme')
+    expect(s).toContain("localStorage.getItem('app_theme')")
+  })
+
+  it('positional args honour data-theme attribute strategy', () => {
+    const s = getThemeScript('k', 'data-theme')
+    expect(s).toContain("setAttribute('data-theme',t)")
+    expect(s).not.toContain('classList.add(t)')
+  })
+
+  // Issue #317 — options object enables the no-system-fallback path.
+  describe('options object with defaultMode / enableSystem (issue #317)', () => {
+    it('defaultMode="light" skips matchMedia entirely', () => {
+      const s = getThemeScript({ defaultMode: 'light' })
+      expect(s).not.toContain('matchMedia')
+      // No-storage path resolves to 'light'.
+      expect(s).toContain("m==='light'?'light':'light'")
+    })
+
+    it('defaultMode="dark" skips matchMedia and falls back to dark', () => {
+      const s = getThemeScript({ defaultMode: 'dark' })
+      expect(s).not.toContain('matchMedia')
+      expect(s).toContain("m==='light'?'light':'dark'")
+    })
+
+    it('defaultMode="system" + enableSystem=true preserves matchMedia (default behaviour)', () => {
+      const s = getThemeScript({ defaultMode: 'system', enableSystem: true })
+      expect(s).toContain("matchMedia('(prefers-color-scheme:dark)')")
+    })
+
+    it('defaultMode="system" + enableSystem=false drops matchMedia and falls back to light', () => {
+      const s = getThemeScript({ defaultMode: 'system', enableSystem: false })
+      expect(s).not.toContain('matchMedia')
+      expect(s).toContain("m==='light'?'light':'light'")
+    })
+
+    it('options object still honours storageKey + attribute', () => {
+      const s = getThemeScript({
+        storageKey: 'my-app-theme',
+        attribute: 'data-theme',
+        defaultMode: 'light',
+      })
+      expect(s).toContain("localStorage.getItem('my-app-theme')")
+      expect(s).toContain("setAttribute('data-theme',t)")
+    })
+
+    it('defaults match the original behaviour when called with empty options', () => {
+      const s = getThemeScript({})
+      expect(s).toContain("localStorage.getItem('rfr-theme')")
+      expect(s).toContain('matchMedia')
+      expect(s).toContain('classList.add(t)')
+    })
+  })
+
+  it('always sets colorScheme so native form controls track the theme', () => {
+    expect(getThemeScript()).toContain('d.style.colorScheme=t')
+    expect(getThemeScript({ defaultMode: 'light' })).toContain('d.style.colorScheme=t')
+  })
+
+  it('wraps the body in a try/catch so SSR pages with broken localStorage still paint', () => {
+    expect(getThemeScript()).toContain('try{')
+    expect(getThemeScript()).toContain('}catch(e){}')
+  })
+})

--- a/packages/theme/src/theme-script.ts
+++ b/packages/theme/src/theme-script.ts
@@ -4,15 +4,79 @@
  * Works with any framework (React, Astro, plain HTML).
  */
 
+import type { ThemeMode } from './theme-machine.js'
+
+export interface ThemeScriptOptions {
+  /** localStorage key the corresponding ThemeProvider reads. */
+  storageKey?: string
+  /** Attribute strategy: 'class' toggles `light`/`dark` classes; otherwise an HTML attribute. */
+  attribute?: 'class' | 'data-theme'
+  /**
+   * Theme to apply when nothing is stored AND `enableSystem` is false
+   * (or `defaultMode` is explicitly 'light'/'dark'). Match this to your
+   * ThemeProvider's `defaultMode` so the pre-paint script and provider agree.
+   * Defaults to `'system'` — current behavior, OS preference wins.
+   *
+   * Issue #317.
+   */
+  defaultMode?: ThemeMode
+  /**
+   * When `true` (default) and `defaultMode === 'system'`, the script falls
+   * through to `prefers-color-scheme`. When `false`, the script applies
+   * `defaultMode` directly and never reads the OS preference.
+   */
+  enableSystem?: boolean
+}
+
+/**
+ * Build the pre-paint inline script. Mirrors the resolution order used by
+ * the React/Astro `ThemeProvider`:
+ *
+ *   1. stored value (light|dark|system)
+ *   2. if no stored value: `defaultMode` (light|dark applied as-is)
+ *   3. if stored or default is 'system' AND `enableSystem`: matchMedia
+ *   4. else: 'light'
+ *
+ * Back-compat: with no options the script behaves exactly as before —
+ * stored value, then matchMedia, then 'light'.
+ */
 export function getThemeScript(
-  storageKey = 'rfr-theme',
+  storageKeyOrOptions: string | ThemeScriptOptions = 'rfr-theme',
   attribute: 'class' | 'data-theme' = 'class',
 ): string {
-  // This string is injected as innerHTML of a <script> tag.
-  // It runs before any CSS/JS loads, preventing flash of wrong theme.
-  return `(function(){try{var m=localStorage.getItem('${storageKey}');var s=window.matchMedia('(prefers-color-scheme:dark)').matches;var t=m==='dark'||(m!=='light'&&s)?'dark':'light';var d=document.documentElement;${
-    attribute === 'class'
+  const opts: Required<ThemeScriptOptions> =
+    typeof storageKeyOrOptions === 'string'
+      ? {
+          storageKey: storageKeyOrOptions,
+          attribute,
+          defaultMode: 'system',
+          enableSystem: true,
+        }
+      : {
+          storageKey: storageKeyOrOptions.storageKey ?? 'rfr-theme',
+          attribute: storageKeyOrOptions.attribute ?? 'class',
+          defaultMode: storageKeyOrOptions.defaultMode ?? 'system',
+          enableSystem: storageKeyOrOptions.enableSystem ?? true,
+        }
+
+  // `noSystemFallback` short-circuits matchMedia entirely when the consumer
+  // wants brand consistency over OS preference (defaultMode='light'/'dark'
+  // OR enableSystem=false).
+  const noSystemFallback =
+    opts.defaultMode === 'light' || opts.defaultMode === 'dark' || !opts.enableSystem
+  const safeDefault: 'light' | 'dark' =
+    opts.defaultMode === 'dark' ? 'dark' : 'light'
+
+  const resolveExpr = noSystemFallback
+    ? // Stored wins → else hard default. No matchMedia call at all.
+      `var t=m==='dark'?'dark':(m==='light'?'light':'${safeDefault}');`
+    : // Original behaviour: stored → else matchMedia → else light.
+      `var s=window.matchMedia('(prefers-color-scheme:dark)').matches;var t=m==='dark'||(m!=='light'&&s)?'dark':'light';`
+
+  const applyExpr =
+    opts.attribute === 'class'
       ? "d.classList.remove('light','dark');d.classList.add(t);"
-      : `d.setAttribute('${attribute}',t);`
-  }d.style.colorScheme=t;}catch(e){}})()`
+      : `d.setAttribute('${opts.attribute}',t);`
+
+  return `(function(){try{var m=localStorage.getItem('${opts.storageKey}');${resolveExpr}var d=document.documentElement;${applyExpr}d.style.colorScheme=t;}catch(e){}})()`
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,9 @@ overrides:
   flatted: 3.4.2
   minimatch: 9.0.7
   eslint>minimatch: 3.1.4
-  protobufjs: 8.0.2
+  protobufjs: 8.2.0
   devalue: 5.8.1
+  '@nevware21/ts-utils': 0.14.0
 
 importers:
 
@@ -5033,8 +5034,8 @@ packages:
   '@nevware21/ts-async@0.5.5':
     resolution: {integrity: sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==}
 
-  '@nevware21/ts-utils@0.13.0':
-    resolution: {integrity: sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==}
+  '@nevware21/ts-utils@0.14.0':
+    resolution: {integrity: sha512-WoeqTIXQ8WPhl+lD2NbMHoAQ4sJl0n7EoRoDmVJui//Usg512enl9q1fdbVobuZt3omnxnmVsDrNIvPBvFgddQ==}
 
   '@next/env@15.5.18':
     resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
@@ -7867,8 +7868,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@8.0.2:
-    resolution: {integrity: sha512-TNF0rhMsp+g21us9R2aj3iA7JY9pG7G/3zyRiULl6NS+AurvgQ7iWA203QcykDGSosHxMsV+K6GTR15RBWw1bA==}
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -9619,7 +9620,7 @@ snapshots:
       '@microsoft/applicationinsights-core-js': 3.4.1(tslib@2.8.1)
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-cfgsync-js@3.4.1(tslib@2.8.1)':
@@ -9628,7 +9629,7 @@ snapshots:
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
       '@nevware21/ts-async': 0.5.5
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-channel-js@3.4.1(tslib@2.8.1)':
@@ -9637,7 +9638,7 @@ snapshots:
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
       '@nevware21/ts-async': 0.5.5
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-core-js@3.4.1(tslib@2.8.1)':
@@ -9645,7 +9646,7 @@ snapshots:
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
       '@nevware21/ts-async': 0.5.5
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-dependencies-js@3.4.1(tslib@2.8.1)':
@@ -9654,7 +9655,7 @@ snapshots:
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
       '@nevware21/ts-async': 0.5.5
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-properties-js@3.4.1(tslib@2.8.1)':
@@ -9662,12 +9663,12 @@ snapshots:
       '@microsoft/applicationinsights-core-js': 3.4.1(tslib@2.8.1)
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/applicationinsights-shims@3.0.1':
     dependencies:
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
 
   '@microsoft/applicationinsights-web@3.4.1(tslib@2.8.1)':
     dependencies:
@@ -9680,12 +9681,12 @@ snapshots:
       '@microsoft/applicationinsights-shims': 3.0.1
       '@microsoft/dynamicproto-js': 2.0.3
       '@nevware21/ts-async': 0.5.5
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
       tslib: 2.8.1
 
   '@microsoft/dynamicproto-js@2.0.3':
     dependencies:
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -9707,9 +9708,9 @@ snapshots:
 
   '@nevware21/ts-async@0.5.5':
     dependencies:
-      '@nevware21/ts-utils': 0.13.0
+      '@nevware21/ts-utils': 0.14.0
 
-  '@nevware21/ts-utils@0.13.0': {}
+  '@nevware21/ts-utils@0.14.0': {}
 
   '@next/env@15.5.18': {}
 
@@ -9837,7 +9838,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.2
+      protobufjs: 8.2.0
 
   '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -9848,7 +9849,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.2
+      protobufjs: 8.2.0
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -12772,7 +12773,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@8.0.2:
+  protobufjs@8.2.0:
     dependencies:
       '@types/node': 22.0.0
       long: 5.3.2


### PR DESCRIPTION
## Summary

Three small but consequential bug fixes plus one packaging fix-up, all
caught downstream during the `elloloop/learning-monorepo` migration. Each
is a one- or two-file change with tests; together they remove every silent
API fall-through that was burning consumers and align the inline pre-paint
script with `ThemeProvider`. The Astro meta also picks up the
voice-pill/waveform exports that were declared as deps but never
re-exported.

## What changes (consumer-facing)

| Issue | Before | After |
|---|---|---|
| **#201** Button `variant="primary"` | Silent fall-through → unstyled text | Renders as `default` (most-emphasized) via a typed alias |
| **#200** StatusIndicator children | Children dropped silently → renders the type name | Children become the visible label + `aria-label` |
| **#317** ThemeScript no-storage path | Always falls through to `prefers-color-scheme` | `defaultMode` + `enableSystem` props let the script mirror `<ThemeProvider>` |
| **#191** astro VoicePill | Listed as dep, not re-exported from `@refraction-ui/astro` | Re-exported |
| **#192** astro Waveform | Same | Re-exported |
| **#193** `@refraction-ui/react` types | Reporter saw missing `.d.ts` on 0.3.9 | Verified shipping `index.d.ts` + `theme.d.ts` + `form.d.ts` on 0.12.2 — closing |

## How

- **Button** — added `'primary'` to `ButtonVariant`, added `resolveButtonVariant()` + `BUTTON_VARIANT_ALIASES` map in the headless core; React adapter calls the resolver before reaching `createButton` / `buttonVariants`. The cva variant table also got a literal `primary` entry as belt-and-braces so direct callers of `buttonVariants` still get styled output.
- **StatusIndicator** — `props.children` is now part of the React adapter's typed surface. Render priority: `label ?? children ?? api.label`. `aria-label` derives from `label`, then string children, then the headless default. JSX layer rewritten away from `React.createElement` calls for readability.
- **ThemeScript** — `getThemeScript()` headless gains an overload that accepts `{ storageKey, attribute, defaultMode, enableSystem }`. When `defaultMode` is `'light'`/`'dark'` or `enableSystem` is `false`, the inline script skips `matchMedia` entirely. Positional-args call signature preserved for back-compat. React `<ThemeScript>` and the Astro `<ThemeScript />` component both forward the new options.
- **Astro meta** — added `export * from '@refraction-ui/astro-voice-pill'` and `'@refraction-ui/astro-waveform'`. CLAUDE.md hard rule: every adapter wired into its meta — they were the last two stragglers.

## Tests

- 8 new tests on `<StatusIndicator>` covering explicit `label`, children-only, both, neither, `showLabel=false`, rich ReactNode children, pulse default for `pending`, and `className`.
- 5 new headless tests on `resolveButtonVariant` + 1 React test pinning that `primary` and `default` produce the same emphasis classes.
- 11 new headless tests on `getThemeScript` (positional-args back-compat + every options-object permutation) + 5 new React-side tests confirming the component forwards every prop.
- All 708 turbo tasks (`lint typecheck test build`) green; `make ci` passes.

## Issues closed by this PR

- Closes #200
- Closes #201
- Closes #317
- Closes #191
- Closes #192
- Closes #193

## Out of scope (filed as follow-ups)

- **#195** CodeEditor monaco onMount — needs a real peer-dep on `@monaco-editor/react` and is a deeper redesign; left open.
- **#275** Downstream protobufjs via Faro — security tracking, no source change in this PR.
- **#319** Cleanup tracked agent-scratch files (junk `fix.py`, `test_results.*`, etc.) — filed; will land as its own tiny PR.
- **#318** Wave 5 Flutter parity gaps (13 components) — filed against the Flutter epic.
- Angular PRs (#118, #119, #135, #136, #137, #140, #141, #142, #143, #144, #166, #167, #189) and tracking issues (#164, #171, #178, #220) — closed during this session; Angular was removed entirely per CLAUDE.md.

## Release

A `.changeset/api-ergonomics-status-button-theme.md` is included, marking
`@refraction-ui/react` and `@refraction-ui/astro` as **patch**. The
Changesets Version PR will pick this up after merge.
