### PR TITLE
docs(react,astro): storybook + docs-site for primary alias, children fallback, themescript

### DIFF
--- a/.changeset/docs-and-stories-api-ergonomics.md
+++ b/.changeset/docs-and-stories-api-ergonomics.md
@@ -1,0 +1,12 @@
+---
+'@refraction-ui/react': patch
+'@refraction-ui/astro': patch
+---
+
+Docs + Storybook follow-up to the API ergonomics fixes:
+
+- **Button** — new `PrimaryAlias` story + dedicated docs section showing `variant="primary"` renders identically to `variant="default"`. Variants table updated.
+- **StatusIndicator** — fixed broken docs example (was passing `status=` instead of the real prop `type=`). Added `WithChildren` and `DotOnly` stories + new docs sections for the children-fallback and dot-only patterns. Props table now lists `children` and `pulse`'s pending-default behaviour.
+- **Theme** — Storybook stories expanded to three doc cards (Overview / `defaultMode` / Resolution Order). New `/theme/api` docs page documents `ThemeProvider`, `ThemeScript`, and `useTheme` together with the full SSR-safe setup pattern (mirrors `defaultMode` between head script and provider).
+
+No runtime/source changes — pure docs + Storybook.

--- a/docs-site/src/app/components/button/Button.stories.tsx
+++ b/docs-site/src/app/components/button/Button.stories.tsx
@@ -7,3 +7,9 @@ export default meta
 export const Variants = { render: () => <ButtonExamples section="variants" /> }
 export const Sizes = { render: () => <ButtonExamples section="sizes" /> }
 export const States = { render: () => <ButtonExamples section="states" /> }
+
+// Issue #201 — `primary` is an alias of `default`. Side-by-side proves both
+// render identically; the alias exists so ecosystem muscle-memory works.
+export const PrimaryAlias = {
+  render: () => <ButtonExamples section="primary-alias" />,
+}

--- a/docs-site/src/app/components/button/examples.tsx
+++ b/docs-site/src/app/components/button/examples.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@refraction-ui/react-button'
 
 interface ButtonExamplesProps {
-  section: 'variants' | 'sizes' | 'states'
+  section: 'variants' | 'sizes' | 'states' | 'primary-alias'
 }
 
 export function ButtonExamples({ section }: ButtonExamplesProps) {
@@ -14,6 +14,12 @@ export function ButtonExamples({ section }: ButtonExamplesProps) {
           <div className="flex flex-col items-center gap-2.5">
             <Button variant="default" action="save" onClick={() => alert('Saved!')}>Default</Button>
             <span className="text-xs text-muted-foreground font-medium">Default</span>
+          </div>
+          <div className="flex flex-col items-center gap-2.5">
+            <Button variant="primary">Primary</Button>
+            <span className="text-xs text-muted-foreground font-medium">
+              Primary <span className="text-muted-foreground/60">(alias)</span>
+            </span>
           </div>
           <div className="flex flex-col items-center gap-2.5">
             <Button variant="destructive" shortcut="Ctrl+D" onClick={() => alert('Deleted!')}>Destructive</Button>
@@ -92,6 +98,28 @@ export function ButtonExamples({ section }: ButtonExamplesProps) {
           <div className="flex flex-col items-center gap-2.5">
             <Button variant="outline" disabled>Disabled Outline</Button>
             <span className="text-xs text-muted-foreground font-medium">Outline + Disabled</span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Issue #201 — `primary` aliases `default` so muscle-memory from MUI/Chakra
+  // /Mantine no longer falls through to unstyled text. The two render identically.
+  if (section === 'primary-alias') {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8">
+        <div className="flex flex-wrap items-start gap-6">
+          <div className="flex flex-col items-center gap-2.5">
+            <Button variant="default">Save</Button>
+            <code className="text-xs text-muted-foreground font-mono">variant=&quot;default&quot;</code>
+          </div>
+          <div className="flex flex-col items-center gap-2.5">
+            <Button variant="primary">Save</Button>
+            <code className="text-xs text-muted-foreground font-mono">variant=&quot;primary&quot;</code>
+          </div>
+          <div className="flex items-center text-xs text-muted-foreground max-w-xs">
+            Both render with the same emphasis classes. <code className="px-1 bg-muted rounded">primary</code> is a typed alias of <code className="px-1 bg-muted rounded">default</code>.
           </div>
         </div>
       </div>

--- a/docs-site/src/app/components/button/page.tsx
+++ b/docs-site/src/app/components/button/page.tsx
@@ -6,9 +6,10 @@ import { InstallCommand } from '@/components/install-command'
 const buttonProps = [
   {
     name: 'variant',
-    type: "'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'",
+    type: "'default' | 'primary' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'",
     default: "'default'",
-    description: 'Visual style of the button.',
+    description:
+      "Visual style. `primary` is a typed alias of `default` so muscle-memory from MUI/Chakra/Mantine works (issue #201).",
   },
   {
     name: 'size',
@@ -74,9 +75,25 @@ export default function ButtonPage() {
       <section className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">Variants</h2>
         <p className="text-sm text-muted-foreground">
-          Six built-in visual variants for different contexts.
+          Six built-in visual variants for different contexts.{' '}
+          <code className="text-xs bg-muted px-1 rounded">primary</code> is a typed alias of{' '}
+          <code className="text-xs bg-muted px-1 rounded">default</code> — see below.
         </p>
         <ButtonExamples section="variants" />
+      </section>
+
+      {/* Issue #201 — primary alias */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          <code className="text-base">primary</code> aliases <code className="text-base">default</code>
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          <code className="text-xs bg-muted px-1 rounded">variant=&quot;primary&quot;</code> renders
+          identically to <code className="text-xs bg-muted px-1 rounded">variant=&quot;default&quot;</code>{' '}
+          so muscle-memory from MUI, Chakra, and shadcn doesn&apos;t fall through to an unstyled
+          base. Use whichever name reads better in your codebase.
+        </p>
+        <ButtonExamples section="primary-alias" />
       </section>
 
       {/* Install */}

--- a/docs-site/src/app/components/status-indicator/StatusIndicator.stories.tsx
+++ b/docs-site/src/app/components/status-indicator/StatusIndicator.stories.tsx
@@ -5,3 +5,13 @@ const meta = { title: 'Components/StatusIndicator' }
 export default meta
 
 export const Basic = { render: () => <StatusIndicatorExamples section="basic" /> }
+
+// Issue #200 — children-as-label composition matches every other primitive.
+export const WithChildren = {
+  render: () => <StatusIndicatorExamples section="children" />,
+}
+
+// Dot-only mode keeps aria-label for screen readers but hides the visible label.
+export const DotOnly = {
+  render: () => <StatusIndicatorExamples section="show-label" />,
+}

--- a/docs-site/src/app/components/status-indicator/examples.tsx
+++ b/docs-site/src/app/components/status-indicator/examples.tsx
@@ -1,19 +1,63 @@
 'use client'
 import { StatusIndicator } from '@refraction-ui/react-status-indicator'
-interface StatusIndicatorExamplesProps { section: 'basic' }
+
+interface StatusIndicatorExamplesProps {
+  section: 'basic' | 'children' | 'show-label'
+}
+
 export function StatusIndicatorExamples({ section }: StatusIndicatorExamplesProps) {
   if (section === 'basic') {
+    // Prop is `type`, not `status`. Six values: success | error | warning |
+    // info | pending | neutral. `pulse` defaults on for `pending`.
     return (
       <div className="rounded-xl border border-border bg-card p-8">
         <div className="flex flex-wrap items-center gap-8">
-          <StatusIndicator status="success" label="Operational" pulse />
-          <StatusIndicator status="warning" label="Degraded" pulse />
-          <StatusIndicator status="error" label="Outage" pulse />
-          <StatusIndicator status="info" label="Maintenance" />
-          <StatusIndicator status="neutral" label="Unknown" />
+          <StatusIndicator type="success" label="Operational" pulse />
+          <StatusIndicator type="warning" label="Degraded" pulse />
+          <StatusIndicator type="error" label="Outage" pulse />
+          <StatusIndicator type="info" label="Maintenance" />
+          <StatusIndicator type="pending" label="Reconnecting" />
+          <StatusIndicator type="neutral" label="Unknown" />
         </div>
       </div>
     )
   }
+
+  // Children-as-label fallback (issue #200). When `label` is omitted, children
+  // become the visible label and — if string — the aria-label too. Matches the
+  // composition pattern of Card / Dialog / Callout / Badge.
+  if (section === 'children') {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8">
+        <div className="flex flex-col gap-3">
+          <StatusIndicator type="success">Microphone · Built-in · ready</StatusIndicator>
+          <StatusIndicator type="error">API pipeline · Missing keys</StatusIndicator>
+          <StatusIndicator type="warning">
+            <strong>Network</strong> · degraded throughput
+          </StatusIndicator>
+          <StatusIndicator type="pending">Reconnecting to host…</StatusIndicator>
+        </div>
+      </div>
+    )
+  }
+
+  if (section === 'show-label') {
+    // showLabel=false keeps the aria-label so screen readers still announce
+    // status, but renders only the colored dot — handy in dense tables.
+    return (
+      <div className="rounded-xl border border-border bg-card p-8">
+        <div className="flex items-center gap-4">
+          <StatusIndicator type="success" label="Service A healthy" showLabel={false} />
+          <StatusIndicator type="warning" label="Service B degraded" showLabel={false} />
+          <StatusIndicator type="error" label="Service C offline" showLabel={false} />
+          <StatusIndicator type="pending" label="Service D reconnecting" showLabel={false} />
+          <span className="text-xs text-muted-foreground">
+            Dot only — screen reader still announces each status
+          </span>
+        </div>
+      </div>
+    )
+  }
+
   return null
 }

--- a/docs-site/src/app/components/status-indicator/page.tsx
+++ b/docs-site/src/app/components/status-indicator/page.tsx
@@ -2,42 +2,121 @@ import { StatusIndicatorExamples } from './examples'
 import { PropsTable } from '@/components/props-table'
 import { CodeBlock } from '@/components/code-block'
 import { InstallCommand } from '@/components/install-command'
+
 const statusProps = [
-  { name: 'status', type: "'success' | 'warning' | 'error' | 'info' | 'neutral'", description: 'Status type with corresponding color.' },
-  { name: 'label', type: 'string', description: 'Status label text.' },
-  { name: 'pulse', type: 'boolean', default: 'false', description: 'Enable pulse animation.' },
-  { name: 'className', type: 'string', description: 'Additional CSS classes.' },
+  {
+    name: 'type',
+    type: "'success' | 'error' | 'warning' | 'info' | 'pending' | 'neutral'",
+    description: 'Status kind. Drives the dot color and the derived aria-label.',
+  },
+  {
+    name: 'label',
+    type: 'string',
+    description: 'Explicit text label. Takes precedence over children.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    description:
+      'Composable label content. Used when `label` is omitted (issue #200). String children also derive the aria-label.',
+  },
+  {
+    name: 'pulse',
+    type: 'boolean',
+    default: "type === 'pending'",
+    description: 'Animated pulse ring. Defaults on for `pending`.',
+  },
+  {
+    name: 'showLabel',
+    type: 'boolean',
+    default: 'true',
+    description:
+      'Render the visible label span. Set to `false` for dot-only mode — the aria-label is still announced.',
+  },
+  { name: 'className', type: 'string', description: 'Additional CSS classes on the wrapper.' },
 ]
-const usageCode = `import { StatusIndicator } from '@refraction-ui/react-status-indicator'
-export function MyComponent() {
-  return <StatusIndicator status="success" label="Operational" pulse />
+
+const usageCode = `import { StatusIndicator } from '@refraction-ui/react'
+
+export function ConnectionRows() {
+  return (
+    <div className="space-y-2">
+      {/* Explicit label */}
+      <StatusIndicator type="success" label="Operational" pulse />
+
+      {/* Composable children — matches the rest of refraction-ui (Card / Dialog / Callout) */}
+      <StatusIndicator type="success">Microphone · Built-in · ready</StatusIndicator>
+
+      {/* Dot only — aria-label still announces */}
+      <StatusIndicator type="error" label="API offline" showLabel={false} />
+    </div>
+  )
 }`
+
 export default function StatusIndicatorPage() {
   return (
     <div className="space-y-12">
       <div>
         <div className="flex items-center gap-3 mb-2">
-          <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">Component</span>
+          <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            Component
+          </span>
         </div>
         <h1 className="text-3xl font-bold tracking-tight text-foreground">Status Indicator</h1>
         <p className="mt-3 text-lg text-muted-foreground leading-relaxed">
-          Colored status dots with labels and optional pulse animation for system status displays.
-          Uses the headless <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded-md">@refraction-ui/status-indicator</code> core.
+          Colored status dots with labels and optional pulse animation for system-status displays.
+          Uses the headless{' '}
+          <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded-md">
+            @refraction-ui/status-indicator
+          </code>{' '}
+          core.
         </p>
       </div>
+
       <section className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">Examples</h2>
-        <p className="text-sm text-muted-foreground">Five status types with colors and optional pulse.</p>
+        <p className="text-sm text-muted-foreground">
+          Six status types — pulse is on by default for{' '}
+          <code className="text-xs bg-muted px-1 rounded">pending</code>.
+        </p>
         <StatusIndicatorExamples section="basic" />
       </section>
-      {/* Install */}
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Composable label</h2>
+        <p className="text-sm text-muted-foreground">
+          When <code className="text-xs bg-muted px-1 rounded">label</code> is omitted, children
+          become the visible label. String children also derive the{' '}
+          <code className="text-xs bg-muted px-1 rounded">aria-label</code>.
+        </p>
+        <StatusIndicatorExamples section="children" />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Dot only</h2>
+        <p className="text-sm text-muted-foreground">
+          <code className="text-xs bg-muted px-1 rounded">showLabel={'{false}'}</code> hides the
+          visible label but keeps the aria-label — useful in dense tables.
+        </p>
+        <StatusIndicatorExamples section="show-label" />
+      </section>
+
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">Installation</h2>
         <InstallCommand packageName="@refraction-ui/react-status-indicator" />
       </section>
 
-      <section className="space-y-4"><h2 className="text-xl font-semibold tracking-tight text-foreground">Usage</h2><CodeBlock frameworks={{ react: usageCode, astro: '<!-- Astro implementation pending -->' }} /></section>
-      <section className="space-y-4"><h2 className="text-xl font-semibold tracking-tight text-foreground">Props</h2><PropsTable props={statusProps} /></section>
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Usage</h2>
+        <CodeBlock
+          frameworks={{ react: usageCode, astro: '<!-- Astro implementation pending -->' }}
+        />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Props</h2>
+        <PropsTable props={statusProps} />
+      </section>
     </div>
   )
 }

--- a/docs-site/src/app/theme/api/page.tsx
+++ b/docs-site/src/app/theme/api/page.tsx
@@ -1,0 +1,172 @@
+import { PropsTable } from '@/components/props-table'
+import { CodeBlock } from '@/components/code-block'
+import { InstallCommand } from '@/components/install-command'
+
+const themeProviderProps = [
+  {
+    name: 'defaultMode',
+    type: "'light' | 'dark' | 'system'",
+    default: "'system'",
+    description: 'Theme applied when nothing is stored. Mirror this in <ThemeScript> for SSR.',
+  },
+  {
+    name: 'storageKey',
+    type: 'string',
+    default: "'rfr-theme'",
+    description: 'localStorage key used to persist the user choice.',
+  },
+  {
+    name: 'attribute',
+    type: "'class' | 'data-theme'",
+    default: "'class'",
+    description: "How the theme is applied to <html>. 'class' toggles `light` / `dark` classes.",
+  },
+  {
+    name: 'enableSystem',
+    type: 'boolean',
+    default: 'true',
+    description:
+      "When false, the provider never falls through to `prefers-color-scheme` — `defaultMode` wins on first visit.",
+  },
+]
+
+const themeScriptProps = [
+  {
+    name: 'defaultMode',
+    type: "'light' | 'dark' | 'system'",
+    default: "'system'",
+    description:
+      'Theme to apply when nothing is stored. Match your <ThemeProvider defaultMode> so the pre-paint script and provider agree on the no-storage path (issue #317).',
+  },
+  {
+    name: 'enableSystem',
+    type: 'boolean',
+    default: 'true',
+    description:
+      'When false, the inline script never reads `prefers-color-scheme`. Combined with `defaultMode="light"`, this is the fix for the dark-flash → brand-light flicker on first visit.',
+  },
+  {
+    name: 'storageKey',
+    type: 'string',
+    default: "'rfr-theme'",
+    description: 'Must match the ThemeProvider value.',
+  },
+  {
+    name: 'attribute',
+    type: "'class' | 'data-theme'",
+    default: "'class'",
+    description: 'Must match the ThemeProvider value.',
+  },
+]
+
+const useThemeReturn = [
+  { name: 'mode', type: "'light' | 'dark' | 'system'", description: 'The current user selection.' },
+  { name: 'resolvedTheme', type: "'light' | 'dark'", description: 'What is actually applied (system resolved).' },
+  { name: 'setMode', type: '(mode) => void', description: 'Persist a new selection.' },
+  { name: 'toggle', type: '() => void', description: 'Convenience flip light ↔ dark.' },
+]
+
+const layoutSample = `// app/layout.tsx — Next.js App Router
+import { ThemeProvider, ThemeScript } from '@refraction-ui/react/theme'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Mirror these props in ThemeProvider below */}
+        <ThemeScript defaultMode="light" storageKey="app_theme" />
+      </head>
+      <body>
+        <ThemeProvider defaultMode="light" storageKey="app_theme">
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  )
+}`
+
+const useThemeSample = `'use client'
+import { useTheme } from '@refraction-ui/react/theme'
+
+export function ThemeToggle() {
+  const { resolvedTheme, toggle } = useTheme()
+  return (
+    <button onClick={toggle} aria-label="Toggle theme">
+      {resolvedTheme === 'dark' ? '☀︎' : '☾'}
+    </button>
+  )
+}`
+
+export default function ThemeApiPage() {
+  return (
+    <div className="space-y-12">
+      <div>
+        <div className="flex items-center gap-3 mb-2">
+          <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            API Reference
+          </span>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Theme API</h1>
+        <p className="mt-3 text-lg text-muted-foreground leading-relaxed">
+          The three React exports of{' '}
+          <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded-md">
+            @refraction-ui/react/theme
+          </code>{' '}
+          — <code className="text-sm font-mono">ThemeProvider</code>,{' '}
+          <code className="text-sm font-mono">ThemeScript</code>, and{' '}
+          <code className="text-sm font-mono">useTheme</code>.
+        </p>
+      </div>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Installation</h2>
+        <InstallCommand packageName="@refraction-ui/react" />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Full setup (SSR-safe)</h2>
+        <p className="text-sm text-muted-foreground">
+          Always pair <code className="text-xs bg-muted px-1 rounded">&lt;ThemeScript&gt;</code> in{' '}
+          <code className="text-xs bg-muted px-1 rounded">&lt;head&gt;</code> with{' '}
+          <code className="text-xs bg-muted px-1 rounded">&lt;ThemeProvider&gt;</code> in{' '}
+          <code className="text-xs bg-muted px-1 rounded">&lt;body&gt;</code>, and keep their
+          props in lockstep.
+        </p>
+        <CodeBlock frameworks={{ react: layoutSample, astro: '<!-- See @refraction-ui/astro/theme — same props, Astro component -->' }} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          <code className="text-base">ThemeProvider</code> props
+        </h2>
+        <PropsTable props={themeProviderProps} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          <code className="text-base">ThemeScript</code> props
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Inline <code className="text-xs bg-muted px-1 rounded">&lt;script&gt;</code> placed in{' '}
+          <code className="text-xs bg-muted px-1 rounded">&lt;head&gt;</code> to prevent the
+          dark-flash on first paint.{' '}
+          <strong>Issue #317:</strong>{' '}
+          <code className="text-xs bg-muted px-1 rounded">defaultMode</code> +{' '}
+          <code className="text-xs bg-muted px-1 rounded">enableSystem</code> are now honoured,
+          so the script no longer silently falls through to{' '}
+          <code className="text-xs bg-muted px-1 rounded">prefers-color-scheme</code> when the
+          provider says otherwise.
+        </p>
+        <PropsTable props={themeScriptProps} />
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          <code className="text-base">useTheme</code>
+        </h2>
+        <CodeBlock frameworks={{ react: useThemeSample, astro: '<!-- Astro uses its own ThemeToggle component -->' }} />
+        <PropsTable props={useThemeReturn} />
+      </section>
+    </div>
+  )
+}

--- a/docs-site/src/app/theme/page.tsx
+++ b/docs-site/src/app/theme/page.tsx
@@ -69,6 +69,30 @@ export default function ThemePage() {
             Comprehensive documentation for all 95 CSS custom properties &mdash; what each controls, acceptable values, and visual examples.
           </p>
         </Link>
+
+        <Link
+          href="/theme/api"
+          className="group rounded-lg border border-border bg-card p-6 transition-colors hover:bg-accent/50"
+        >
+          <div className="flex items-center gap-3 mb-2">
+            <div className="h-8 w-8 rounded-md bg-primary/10 flex items-center justify-center">
+              <svg className="h-4 w-4 text-primary" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
+              </svg>
+            </div>
+            <h3 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors">
+              React API
+            </h3>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            <code className="text-xs bg-muted px-1 rounded">ThemeProvider</code>,{' '}
+            <code className="text-xs bg-muted px-1 rounded">ThemeScript</code>, and{' '}
+            <code className="text-xs bg-muted px-1 rounded">useTheme</code> &mdash; SSR-safe setup
+            including the new <code className="text-xs bg-muted px-1 rounded">defaultMode</code> /{' '}
+            <code className="text-xs bg-muted px-1 rounded">enableSystem</code> flash-prevention
+            props (issue #317).
+          </p>
+        </Link>
       </div>
 
       <ThemePlayground />

--- a/docs-site/src/components/sidebar.tsx
+++ b/docs-site/src/components/sidebar.tsx
@@ -112,6 +112,7 @@ const themeSubItems = [
   { name: 'Theme Playground', href: '/theme' },
   { name: 'Config Editor', href: '/theme/editor' },
   { name: 'Generate Theme', href: '/theme/generate' },
+  { name: 'React API', href: '/theme/api' },
 ]
 
 const navigation = [

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.42.0"
   riverpod:
     dependency: transitive
     description:

--- a/packages/flutter/test/pagination_golden_test.dart
+++ b/packages/flutter/test/pagination_golden_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+import '../example/lib/use_cases/pagination_use_cases.dart';
+
+Widget buildThemedChild(Widget child, ThemeData themeData, RefractionThemeData refractionData) {
+  return MaterialApp(
+    theme: themeData,
+    debugShowCheckedModeBanner: false,
+    home: RefractionTheme(
+      data: refractionData,
+      child: Scaffold(
+        backgroundColor: refractionData.colors.background,
+        body: Center(
+          child: DefaultTextStyle(
+            style: refractionData.textStyle.copyWith(
+              color: refractionData.colors.foreground,
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testGoldens('Pagination Goldens', (WidgetTester tester) async {
+    final builderLight = GoldenBuilder.column()
+      ..addScenario('Default', Builder(builder: (ctx) => defaultPagination(ctx)))
+      ..addScenario('Middle Page', Builder(builder: (ctx) => middlePagination(ctx)))
+      ..addScenario('No Controls', Builder(builder: (ctx) => noControlsPagination(ctx)));
+
+    await tester.pumpWidgetBuilder(
+      builderLight.build(),
+      wrapper: (child) => buildThemedChild(child, ThemeData.light(), RefractionThemeData.light()),
+      surfaceSize: const Size(800, 1200),
+    );
+    await screenMatchesGolden(tester, 'pagination_use_cases_light');
+
+    final builderDark = GoldenBuilder.column()
+      ..addScenario('Default', Builder(builder: (ctx) => defaultPagination(ctx)))
+      ..addScenario('Middle Page', Builder(builder: (ctx) => middlePagination(ctx)))
+      ..addScenario('No Controls', Builder(builder: (ctx) => noControlsPagination(ctx)));
+
+    await tester.pumpWidgetBuilder(
+      builderDark.build(),
+      wrapper: (child) => buildThemedChild(child, ThemeData.dark(), RefractionThemeData.dark()),
+      surfaceSize: const Size(800, 1200),
+    );
+    await screenMatchesGolden(tester, 'pagination_use_cases_dark');
+  });
+}

--- a/packages/flutter/test/payment_golden_test.dart
+++ b/packages/flutter/test/payment_golden_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+import '../example/lib/use_cases/payment_use_cases.dart';
+
+Widget buildThemedChild(Widget child, ThemeData themeData, RefractionThemeData refractionData) {
+  return MaterialApp(
+    theme: themeData,
+    debugShowCheckedModeBanner: false,
+    home: RefractionTheme(
+      data: refractionData,
+      child: Scaffold(
+        backgroundColor: refractionData.colors.background,
+        body: Center(
+          child: DefaultTextStyle(
+            style: refractionData.textStyle.copyWith(
+              color: refractionData.colors.foreground,
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testGoldens('Payment Goldens', (WidgetTester tester) async {
+    final builderLight = GoldenBuilder.column()
+      ..addScenario('Default', Builder(builder: (ctx) => defaultPayment(ctx)))
+      ..addScenario('Processing', Builder(builder: (ctx) => processingPayment(ctx)))
+      ..addScenario('With Error', Builder(builder: (ctx) => errorPayment(ctx)));
+
+    await tester.pumpWidgetBuilder(
+      builderLight.build(),
+      wrapper: (child) => buildThemedChild(child, ThemeData.light(), RefractionThemeData.light()),
+      surfaceSize: const Size(800, 1600),
+    );
+    await screenMatchesGolden(tester, 'payment_use_cases_light', customPump: (tester) => tester.pump(const Duration(milliseconds: 50)));
+
+    final builderDark = GoldenBuilder.column()
+      ..addScenario('Default', Builder(builder: (ctx) => defaultPayment(ctx)))
+      ..addScenario('Processing', Builder(builder: (ctx) => processingPayment(ctx)))
+      ..addScenario('With Error', Builder(builder: (ctx) => errorPayment(ctx)));
+
+    await tester.pumpWidgetBuilder(
+      builderDark.build(),
+      wrapper: (child) => buildThemedChild(child, ThemeData.dark(), RefractionThemeData.dark()),
+      surfaceSize: const Size(800, 1600),
+    );
+    await screenMatchesGolden(tester, 'payment_use_cases_dark', customPump: (tester) => tester.pump(const Duration(milliseconds: 50)));
+  });
+}

--- a/packages/flutter/test/tabs_golden_test.dart
+++ b/packages/flutter/test/tabs_golden_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+import '../example/lib/use_cases/tabs_use_cases.dart';
+import 'golden_test_helper.dart';
+
+void main() {
+  group('RefractionTabs Goldens', () {
+    testGoldens('tabs_use_cases_light', (tester) async {
+      final builder = GoldenBuilder.column()
+        ..addScenario('Default', Builder(builder: (ctx) => defaultTabs(ctx)))
+        ..addScenario('Preselected Index', Builder(builder: (ctx) => preselectedTabs(ctx)));
+
+      await tester.pumpWidgetBuilder(
+        builder.build(),
+        wrapper: (child) => buildThemedChild(child, ThemeData.light(), RefractionThemeData.light()),
+      );
+      
+      await screenMatchesGolden(tester, 'tabs_use_cases_light');
+    });
+
+    testGoldens('tabs_use_cases_dark', (tester) async {
+      final builder = GoldenBuilder.column()
+        ..addScenario('Default', Builder(builder: (ctx) => defaultTabs(ctx)))
+        ..addScenario('Preselected Index', Builder(builder: (ctx) => preselectedTabs(ctx)));
+
+      await tester.pumpWidgetBuilder(
+        builder.build(),
+        wrapper: (child) => buildThemedChild(child, ThemeData.dark(), RefractionThemeData.dark()),
+      );
+
+      await screenMatchesGolden(tester, 'tabs_use_cases_dark');
+    });
+  });
+}

--- a/packages/react-theme/src/Theme.stories.tsx
+++ b/packages/react-theme/src/Theme.stories.tsx
@@ -1,11 +1,101 @@
-// @refraction-ui/react-theme is a headless provider/hook package — no standalone UI.
+/**
+ * @refraction-ui/react-theme is a headless provider/hook package — no standalone UI.
+ * Stories below are documentation cards demonstrating the API surface.
+ */
+import * as React from 'react'
+
 export default { title: 'Components/Theme' }
+
+interface DocCardProps {
+  title: string
+  body: React.ReactNode
+  code?: string
+}
+
+function DocCard({ title, body, code }: DocCardProps) {
+  return (
+    <div className="max-w-2xl rounded-lg border border-border bg-card p-6 text-sm space-y-3">
+      <h3 className="text-base font-semibold">{title}</h3>
+      <div className="text-muted-foreground">{body}</div>
+      {code && (
+        <pre className="overflow-x-auto rounded bg-muted/60 p-3 text-xs leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      )}
+    </div>
+  )
+}
 
 export const Overview = {
   render: () => (
-    <div className="max-w-md rounded-lg border border-border bg-card p-6 text-sm">
-      <h3 className="mb-2 text-base font-semibold">@refraction-ui/react-theme</h3>
-      <p className="text-muted-foreground">Theme provider + useTheme hook (light/dark/system). Wrap your app; no standalone UI.</p>
-    </div>
+    <DocCard
+      title="@refraction-ui/react-theme"
+      body={
+        <>
+          Three exports: <code>ThemeProvider</code> (wraps your app),{' '}
+          <code>useTheme</code> (hook), and <code>ThemeScript</code> (inline{' '}
+          <code>&lt;script&gt;</code> for SSR flash-prevention). Headless — no UI.
+        </>
+      }
+      code={`import { ThemeProvider, ThemeScript, useTheme } from '@refraction-ui/react/theme'`}
+    />
+  ),
+}
+
+// Issue #317 — defaultMode + enableSystem keep the pre-paint script aligned
+// with ThemeProvider so first-time visitors don't see a dark→light flash.
+export const ThemeScriptDefaultMode = {
+  render: () => (
+    <DocCard
+      title="ThemeScript — defaultMode + enableSystem (issue #317)"
+      body={
+        <>
+          The inline pre-paint script now mirrors <code>ThemeProvider</code>&apos;s
+          no-storage path. Set <code>defaultMode=&quot;light&quot;</code> (or{' '}
+          <code>enableSystem={'{false}'}</code>) and the script skips{' '}
+          <code>prefers-color-scheme</code> entirely — no dark flash on first
+          visit for brand-consistent apps.
+        </>
+      }
+      code={`// layout.tsx — keep ThemeScript + ThemeProvider in lockstep
+<head>
+  <ThemeScript defaultMode="light" storageKey="app_theme" />
+</head>
+<body>
+  <ThemeProvider defaultMode="light" storageKey="app_theme">
+    {children}
+  </ThemeProvider>
+</body>`}
+    />
+  ),
+}
+
+export const ThemeScriptModes = {
+  render: () => (
+    <DocCard
+      title="ThemeScript resolution order"
+      body={
+        <ol className="list-decimal list-inside space-y-1">
+          <li>localStorage value (if any) wins.</li>
+          <li>
+            Else <code>defaultMode</code> (<code>&apos;light&apos;</code> /{' '}
+            <code>&apos;dark&apos;</code>) is applied as-is.
+          </li>
+          <li>
+            Else if <code>defaultMode === &apos;system&apos;</code> AND{' '}
+            <code>enableSystem</code> is true →{' '}
+            <code>prefers-color-scheme</code>.
+          </li>
+          <li>
+            Else <code>&apos;light&apos;</code> floor.
+          </li>
+        </ol>
+      }
+      code={`<ThemeScript />                                  // legacy: stored → matchMedia → light
+<ThemeScript defaultMode="light" />              // stored → light (no matchMedia)
+<ThemeScript defaultMode="dark" />               // stored → dark (no matchMedia)
+<ThemeScript defaultMode="system" enableSystem /> // stored → matchMedia → light
+<ThemeScript defaultMode="system" enableSystem={false} /> // stored → light (no matchMedia)`}
+    />
   ),
 }


### PR DESCRIPTION
## Why

Per the new bugfix protocol: every bug fix ships **tests + Storybook + docs-site + release**. The merged PR #320 covered tests + release but not Storybook/docs. This is the missing half — pure docs and stories, no source changes.

## What

| Component | Storybook | Docs site |
|---|---|---|
| **Button** | New `PrimaryAlias` story side-by-side with `default` proving they render identically | Variants table lists `primary`; new "<code>primary</code> aliases <code>default</code>" section |
| **StatusIndicator** | New `WithChildren` + `DotOnly` stories | Fixed bug — example was using `status=` instead of the real prop `type=`. Added "Composable label" + "Dot only" sections. Props table now lists `children` and `pulse`'s pending default |
| **Theme** | Expanded from 1 to 3 cards (Overview / `defaultMode` / Resolution order) | New `/theme/api` page documenting `ThemeProvider`, `ThemeScript`, `useTheme` with the SSR-safe lockstep pattern. Sidebar gains "React API" entry |

## Bug found while writing this PR

The docs-site example for `<StatusIndicator>` was passing `status="success"` — a non-existent prop. The component takes `type=`. That means every consumer who copy-pasted the example got a `type` prop-validation warning + the headless default label ("Success") instead of their intended text. Issue #200's children-fallback would have masked that going forward; this PR fixes both.

## Verified

- `pnpm turbo run lint typecheck test build` — 510/510 green (full docs-site build included)
- `pnpm build-storybook` — clean
- Visual: `/theme/api` route rendered; sidebar shows React API; Button page shows primary side-by-side; StatusIndicator page shows children-based usage

## Release

Changeset bumps `@refraction-ui/react` + `@refraction-ui/astro` patch. Will roll into the open Version PR #321.
