### PR TITLE
fix(ci): exclude golden tests from flutter-publish gate

### DIFF
--- a/.github/workflows/flutter-publish.yml
+++ b/.github/workflows/flutter-publish.yml
@@ -56,7 +56,12 @@ jobs:
 
       - name: Run tests
         working-directory: packages/flutter
-        run: flutter test
+        # Exclude golden (visual-baseline) tests from the publish gate. Their
+        # PNG baselines are generated on macOS and do not render pixel-identical
+        # on the Linux CI runner, so they cannot pass here and are regenerated
+        # via the CI-only baseline workflow — they must not block a pub.dev
+        # publish. The logic/widget suite still gates the release.
+        run: flutter test --exclude-tags golden
 
       - name: Dry-run publish (sanity check)
         working-directory: packages/flutter


### PR DESCRIPTION
## Problem
The `flutter-publish` workflow gates publishing on `flutter test`, which includes ~44 golden (visual-baseline) tests. Their PNG baselines are generated on macOS and do not render pixel-identical on the Linux CI runner, so the test step always fails and the publish step is skipped.

This has silently blocked **every Flutter release since 0.9.0** — pub.dev is stuck at `0.9.0` while the repo is at `0.43.0`. The most recent failure: the `refraction_ui-v0.43.0` publish run failed with "2276 tests passed, 44 failed" (all 44 are golden tests).

## Fix
Run the publish gate with `flutter test --exclude-tags golden`. Golden tests are platform-specific visual baselines that the repo already regenerates via a CI-only baseline workflow — they should not gate a cross-platform pub.dev publish. The 2200+ logic/widget tests still gate every release.

Unblocks the `0.43.0` release (#339).