### PR TITLE
fix(flutter): update stale feedback_dialog test to current widget API

### DIFF
--- a/packages/flutter/test/feedback_dialog_test.dart
+++ b/packages/flutter/test/feedback_dialog_test.dart
@@ -39,7 +39,7 @@ void main() {
           ),
         ),
       );
-      final textarea = tester.widget<RefractionTextarea>(
+      final textarea = tester.widget<RefractionInput>(
         find.byKey(const Key('feedback-comment-input')),
       );
       expect(textarea.placeholder, 'Type comment here');
@@ -78,7 +78,7 @@ void main() {
     testWidgets('Test case 8', (WidgetTester tester) async {
       // Submit enabled when comment typed
       await tester.pumpWidget(buildApp(const RefractionFeedbackDialog()));
-      await tester.enterText(find.byType(RefractionTextarea), 'This is great');
+      await tester.enterText(find.byKey(const Key('feedback-comment-input')), 'This is great');
       await tester.pumpAndSettle();
       final submitBtn = tester.widget<RefractionButton>(
         find.byKey(const Key('feedback-submit-button')),
@@ -91,7 +91,7 @@ void main() {
       await tester.pumpWidget(
         buildApp(RefractionFeedbackDialog(onSubmit: (d) => submitted = true)),
       );
-      await tester.enterText(find.byType(RefractionTextarea), 'This is great');
+      await tester.enterText(find.byKey(const Key('feedback-comment-input')), 'This is great');
       await tester.enterText(
         find.byKey(const Key('feedback-honeypot-input')),
         'bot data',
@@ -107,7 +107,7 @@ void main() {
       await tester.pumpWidget(
         buildApp(RefractionFeedbackDialog(onSubmit: (d) => data = d)),
       );
-      await tester.enterText(find.byType(RefractionTextarea), 'Awesome tool');
+      await tester.enterText(find.byKey(const Key('feedback-comment-input')), 'Awesome tool');
       await tester.enterText(
         find.byKey(const Key('feedback-email-input')),
         'test@test.com',
@@ -132,7 +132,7 @@ void main() {
           ),
         ),
       );
-      await tester.enterText(find.byType(RefractionTextarea), 'Async test');
+      await tester.enterText(find.byKey(const Key('feedback-comment-input')), 'Async test');
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('feedback-submit-button')));
       await tester.pump();
@@ -151,7 +151,7 @@ void main() {
           ),
         ),
       );
-      await tester.enterText(find.byType(RefractionTextarea), 'Error test');
+      await tester.enterText(find.byKey(const Key('feedback-comment-input')), 'Error test');
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('feedback-submit-button')));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Problem
`feedback_dialog_test.dart` references `RefractionTextarea`, but `RefractionFeedbackDialog` renders its comment field as a `RefractionInput(maxLines: 4)`. Six cases (3, 8–12) failed on every platform:
- Case 3 cast the keyed comment widget to `RefractionTextarea` → `_TypeError`.
- Cases 8–12 located it via `find.byType(RefractionTextarea)` → `Bad state: No element` in `enterText`.

These pre-existing failures are part of what kept the `flutter-publish` gate red (alongside the goldens fixed in #341).

## Fix
Target the comment field by its `feedback-comment-input` key and cast to `RefractionInput`. All 55 feedback_dialog tests pass locally.

Part of unblocking the `0.43.0` release (#339).