### PR TITLE
ci: share turbo cache across jobs (broaden restore-keys) — speeds up the validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install deps
         run: make install
       - name: Run CI for React
@@ -106,7 +106,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install deps
         run: make install
       - name: Run CI for Astro

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -87,7 +87,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-validation-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-validation-
+            turbo-${{ runner.os }}-
       - run: make install
       - name: Run CI
         run: make ci

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -32,7 +32,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
       - name: Run CI for React
@@ -64,7 +64,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
       - name: Run CI for Astro
@@ -110,7 +110,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
       - name: Build packages
@@ -141,7 +141,7 @@ jobs:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
+            turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
       - name: Build for performance testing


### PR DESCRIPTION
Follow-up to #390. The `validation` job (`make ci`) runs only on PRs, so it never seeds a main-scoped cache; with per-job restore-keys a fresh PR's validation had nothing to restore and stayed ~30 min. Broaden `restore-keys` to the shared `turbo-${{ runner.os }}-` prefix so validation restores the cache main's build-test jobs already seed (Turbo cache is content-addressed → a build cached by one job is a valid hit for another). Save keys stay per-job.

This PR changes only workflow files (not Turbo task inputs), so it doubles as a **cache speed measurement**: its `validation` run should be a fraction of the ~30-min baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)