### PR TITLE
test(video): add interaction tests for CallControls, PreCallLobby, FloatingReactions

### DIFF
--- a/packages/react-call-controls/__tests__/call-controls.interaction.test.tsx
+++ b/packages/react-call-controls/__tests__/call-controls.interaction.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as React from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { act } from "react"
+import { userEvent } from "@testing-library/user-event"
+import { CallControls, CallControlButton } from "../src/index.js"
+
+// React 19 expects this flag to be set when running tests outside a browser bundler.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui)
+  })
+}
+
+describe("CallControls interaction", () => {
+  it("CallControlButton click fires onClick", async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+    
+    render(
+      <CallControls>
+        <CallControlButton label="Mute" onClick={handleClick} />
+      </CallControls>
+    )
+    
+    const button = container.querySelector("button")!
+    expect(button).not.toBeNull()
+    
+    await user.click(button)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("aria-pressed reflects pressed and toggles", async () => {
+    const user = userEvent.setup()
+    
+    function TestComponent() {
+      const [pressed, setPressed] = React.useState(false)
+      return (
+        <CallControls>
+          <CallControlButton 
+            label="Mute" 
+            pressed={pressed} 
+            onClick={() => setPressed(p => !p)} 
+          />
+        </CallControls>
+      )
+    }
+    
+    render(<TestComponent />)
+    
+    const button = container.querySelector("button")!
+    expect(button.getAttribute("aria-pressed")).toBe("false")
+    
+    await user.click(button)
+    expect(button.getAttribute("aria-pressed")).toBe("true")
+    
+    await user.click(button)
+    expect(button.getAttribute("aria-pressed")).toBe("false")
+  })
+
+  it("Destructive (leave) button renders + click fires", async () => {
+    const user = userEvent.setup()
+    const handleLeave = vi.fn()
+    
+    render(
+      <CallControls>
+        <CallControlButton label="Leave" tone="destructive" onClick={handleLeave} />
+      </CallControls>
+    )
+    
+    const button = container.querySelector("button")!
+    expect(button.className).toContain("destructive")
+    
+    await user.click(button)
+    expect(handleLeave).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-call-controls/package.json
+++ b/packages/react-call-controls/package.json
@@ -33,8 +33,12 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/user-event": "14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/react-floating-reactions/__tests__/floating-reactions.interaction.test.tsx
+++ b/packages/react-floating-reactions/__tests__/floating-reactions.interaction.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as React from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { act } from "react"
+import { userEvent } from "@testing-library/user-event"
+import { FloatingReactions, useFloatingReactions } from "../src/index.js"
+import { REACTION_LIFETIME_MS } from "@refraction-ui/floating-reactions"
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.useRealTimers()
+})
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui)
+  })
+}
+
+describe("FloatingReactions interaction", () => {
+  it("useFloatingReactions: emitting adds a reaction", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    
+    function TestComponent() {
+      const { reactions, emit } = useFloatingReactions()
+      return (
+        <div>
+          <FloatingReactions reactions={reactions} />
+          <button onClick={() => emit("👍")}>Like</button>
+        </div>
+      )
+    }
+    
+    render(<TestComponent />)
+    
+    const btn = container.querySelector("button")!
+    await user.click(btn)
+    
+    const items = container.querySelectorAll("span[aria-hidden=\"true\"]")
+    expect(items.length).toBe(1)
+    expect(items[0].textContent).toContain("👍")
+  })
+
+  it("Each reaction auto-expires after REACTION_LIFETIME_MS", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    
+    function TestComponent() {
+      const { reactions, emit } = useFloatingReactions()
+      return (
+        <div>
+          <FloatingReactions reactions={reactions} />
+          <button onClick={() => emit("🔥")}>Fire</button>
+        </div>
+      )
+    }
+    
+    render(<TestComponent />)
+    
+    const btn = container.querySelector("button")!
+    await user.click(btn)
+    
+    expect(container.querySelectorAll("span[aria-hidden=\"true\"]").length).toBe(1)
+    
+    act(() => {
+      vi.advanceTimersByTime(REACTION_LIFETIME_MS)
+    })
+    
+    expect(container.querySelectorAll("span[aria-hidden=\"true\"]").length).toBe(0)
+  })
+
+  it("Multiple emits stack and expire independently", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    
+    function TestComponent() {
+      const { reactions, emit } = useFloatingReactions()
+      return (
+        <div>
+          <FloatingReactions reactions={reactions} />
+          <button data-testid="b1" onClick={() => emit("A")}>A</button>
+          <button data-testid="b2" onClick={() => emit("B")}>B</button>
+        </div>
+      )
+    }
+    
+    render(<TestComponent />)
+    
+    const b1 = container.querySelector("[data-testid=\"b1\"]")!
+    const b2 = container.querySelector("[data-testid=\"b2\"]")!
+    
+    await user.click(b1)
+    
+    act(() => {
+      vi.advanceTimersByTime(REACTION_LIFETIME_MS / 2)
+    })
+    
+    await user.click(b2)
+    
+    expect(container.querySelectorAll("span[aria-hidden=\"true\"]").length).toBe(2)
+    
+    act(() => {
+      vi.advanceTimersByTime(REACTION_LIFETIME_MS / 2)
+    })
+    
+    // First reaction should expire, second remains
+    const remaining1 = container.querySelectorAll("span[aria-hidden=\"true\"]")
+    expect(remaining1.length).toBe(1)
+    expect(remaining1[0].textContent).toContain("B")
+    
+    act(() => {
+      vi.advanceTimersByTime(REACTION_LIFETIME_MS / 2)
+    })
+    
+    // Second reaction expires
+    expect(container.querySelectorAll("span[aria-hidden=\"true\"]").length).toBe(0)
+  })
+
+  it("ids stable/unique without Math.random", async () => {
+    let capturedReactions: any[] = []
+    function TestComponent() {
+      const { reactions, emit } = useFloatingReactions()
+      capturedReactions = reactions
+      return (
+        <div>
+          <FloatingReactions reactions={reactions} />
+          <button onClick={() => emit("A")}>Emit</button>
+        </div>
+      )
+    }
+    
+    render(<TestComponent />)
+    const btn = container.querySelector("button")!
+    
+    // User clicks manually without userEvent since fake timers with userEvent can be tricky sometimes
+    act(() => { btn.click() })
+    act(() => { btn.click() })
+    
+    expect(capturedReactions.length).toBe(2)
+    expect(capturedReactions[0].id).toBe("fr-1")
+    expect(capturedReactions[1].id).toBe("fr-2")
+  })
+})

--- a/packages/react-floating-reactions/package.json
+++ b/packages/react-floating-reactions/package.json
@@ -33,8 +33,12 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/user-event": "14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/react-pre-call-lobby/__tests__/pre-call-lobby.interaction.test.tsx
+++ b/packages/react-pre-call-lobby/__tests__/pre-call-lobby.interaction.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as React from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { act } from "react"
+import { userEvent } from "@testing-library/user-event"
+import { PreCallLobby } from "../src/index.js"
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui)
+  })
+}
+
+describe("PreCallLobby interaction", () => {
+  it("Toggle camera flips state + fires onToggleCamera; camera-off shows placeholder", async () => {
+    const user = userEvent.setup()
+    const handleToggleCamera = vi.fn()
+    
+    function TestComponent() {
+      const [cameraOn, setCameraOn] = React.useState(true)
+      return (
+        <PreCallLobby 
+          cameraOn={cameraOn}
+          micOn={true}
+          onToggleCamera={() => {
+            setCameraOn(v => !v)
+            handleToggleCamera()
+          }}
+          previewSlot={<div data-testid="preview-slot">Video</div>}
+        />
+      )
+    }
+    
+    render(<TestComponent />)
+    
+    const toggle = container.querySelector("[data-testid=\"camera-toggle\"]")!
+    expect(toggle.getAttribute("aria-pressed")).toBe("true")
+    expect(container.querySelector("[data-testid=\"preview-slot\"]")).not.toBeNull()
+    expect(container.querySelector("[data-testid=\"camera-off-placeholder\"]")).toBeNull()
+    
+    await user.click(toggle)
+    
+    expect(handleToggleCamera).toHaveBeenCalledTimes(1)
+    expect(toggle.getAttribute("aria-pressed")).toBe("false")
+    expect(container.querySelector("[data-testid=\"preview-slot\"]")).toBeNull()
+    expect(container.querySelector("[data-testid=\"camera-off-placeholder\"]")).not.toBeNull()
+  })
+
+  it("Toggle mic fires onToggleMic", async () => {
+    const user = userEvent.setup()
+    const handleToggleMic = vi.fn()
+    
+    render(
+      <PreCallLobby 
+        cameraOn={true} 
+        micOn={true} 
+        onToggleMic={handleToggleMic} 
+      />
+    )
+    
+    const toggle = container.querySelector("[data-testid=\"mic-toggle\"]")!
+    await user.click(toggle)
+    
+    expect(handleToggleMic).toHaveBeenCalledTimes(1)
+  })
+
+  it("Device <select> change fires onDeviceChange with kind+id", async () => {
+    const user = userEvent.setup()
+    const handleDeviceChange = vi.fn()
+    
+    render(
+      <PreCallLobby 
+        cameraOn={true}
+        micOn={true}
+        cameras={[{ id: "cam1", label: "Camera 1" }, { id: "cam2", label: "Camera 2" }]}
+        microphones={[{ id: "mic1", label: "Mic 1" }, { id: "mic2", label: "Mic 2" }]}
+        speakers={[{ id: "spk1", label: "Speaker 1" }, { id: "spk2", label: "Speaker 2" }]}
+        selectedCamera="cam1"
+        selectedMicrophone="mic1"
+        selectedSpeaker="spk1"
+        onDeviceChange={handleDeviceChange}
+      />
+    )
+    
+    const camSelect = container.querySelector("[data-testid=\"camera-select\"]") as HTMLSelectElement
+    await user.selectOptions(camSelect, "cam2")
+    expect(handleDeviceChange).toHaveBeenCalledWith("camera", "cam2")
+    
+    const micSelect = container.querySelector("[data-testid=\"microphone-select\"]") as HTMLSelectElement
+    await user.selectOptions(micSelect, "mic2")
+    expect(handleDeviceChange).toHaveBeenCalledWith("microphone", "mic2")
+    
+    const spkSelect = container.querySelector("[data-testid=\"speaker-select\"]") as HTMLSelectElement
+    await user.selectOptions(spkSelect, "spk2")
+    expect(handleDeviceChange).toHaveBeenCalledWith("speaker", "spk2")
+  })
+
+  it("Join button fires onJoin; mic-level meter lit-bar count tracks micLevel", async () => {
+    const user = userEvent.setup()
+    const handleJoin = vi.fn()
+    
+    render(
+      <PreCallLobby 
+        cameraOn={true}
+        micOn={true}
+        micLevel={0.5} // 50% of 8 bars = 4 lit bars
+        onJoin={handleJoin}
+      />
+    )
+    
+    const joinBtn = container.querySelector("[data-testid=\"join-button\"]")!
+    await user.click(joinBtn)
+    expect(handleJoin).toHaveBeenCalledTimes(1)
+    
+    // Check mic level
+    const bars = Array.from(container.querySelectorAll("[data-testid^=\"mic-bar-\"]"))
+    expect(bars.length).toBe(8)
+    const litBars = bars.filter(b => b.getAttribute("data-lit") === "true")
+    expect(litBars.length).toBe(4)
+  })
+})

--- a/packages/react-pre-call-lobby/package.json
+++ b/packages/react-pre-call-lobby/package.json
@@ -33,8 +33,12 @@
     "react-dom": ">=18"
   },
   "devDependencies": {
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/user-event": "14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3555,12 +3555,24 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@testing-library/dom':
+        specifier: 10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.0
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.0.0
+      jsdom:
+        specifier: 29.0.2
+        version: 29.0.2
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4223,12 +4235,24 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@testing-library/dom':
+        specifier: 10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.0
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.0.0
+      jsdom:
+        specifier: 29.0.2
+        version: 29.0.2
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -5329,12 +5353,24 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@testing-library/dom':
+        specifier: 10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.0
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.0.0
+      jsdom:
+        specifier: 29.0.2
+        version: 29.0.2
       react:
         specifier: ^19.0.0
         version: 19.0.0


### PR DESCRIPTION
This PR adds real DOM interaction tests using jsdom and testing-library for the video components:
- `react-call-controls`
- `react-pre-call-lobby`
- `react-floating-reactions`

Resolves #399
Resolves #400
Resolves #401
Part of Epic #394.