### PR TITLE
fix(composer): visible focus ring + Flutter docs and example page

### DIFF
--- a/.changeset/composer-focus-ring.md
+++ b/.changeset/composer-focus-ring.md
@@ -1,0 +1,6 @@
+---
+'@refraction-ui/react': patch
+'@refraction-ui/astro': patch
+---
+
+Composer: use the theme `ring` token for the focus indicator (single focus ring on the pill surface) instead of a foreground-tint border, so keyboard focus is clearly visible and consistent with other Refraction inputs.

--- a/packages/composer/src/styles.ts
+++ b/packages/composer/src/styles.ts
@@ -10,7 +10,7 @@ import { cva } from '@refraction-ui/shared'
 export const composerSurfaceVariants = cva({
   base: [
     'overflow-hidden rounded-2xl border border-border bg-background shadow-sm',
-    'transition-shadow focus-within:border-foreground/25 focus-within:shadow-md',
+    'transition-shadow focus-within:border-ring focus-within:ring-1 focus-within:ring-ring focus-within:shadow-md',
   ].join(' '),
   variants: {
     disabled: {

--- a/packages/flutter-docs-site/src/app/components/composer/page.tsx
+++ b/packages/flutter-docs-site/src/app/components/composer/page.tsx
@@ -1,0 +1,59 @@
+import { FlutterPreview } from '@/components/flutter-preview'
+import { CodeBlock } from '@/components/code-block'
+
+export default function ComposerPage() {
+  return (
+    <div className="space-y-12">
+      <div>
+        <div className="flex items-center gap-3 mb-2">
+          <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">Component</span>
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Composer</h1>
+        <p className="mt-3 text-lg text-muted-foreground leading-relaxed">
+          A headless-core chat composer with auto-grow, IME-safe Enter-to-send,
+          @mention / /slash / :emoji: trigger menus committing atomic tokens,
+          attachments, drafts, edit-in-place, and busy/stop — the same
+          structured output as the React composer.
+        </p>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">Usage</h2>
+        <FlutterPreview path="/docs/composer" height={480} />
+        <div className="h-4"></div>
+        <CodeBlock
+          language="dart"
+          code={`import 'package:refraction_ui/refraction_ui.dart';
+
+class MyComposer extends StatelessWidget {
+  const MyComposer({super.key, required this.onSend});
+
+  final void Function(ComposerSubmission submission) onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return RefractionComposer(
+      placeholder: 'Message',
+      maxLines: 6,
+      triggers: [
+        ComposerTrigger(
+          id: 'mention',
+          symbol: '@',
+          resolve: (query) => searchTeam(query), // -> List<ComposerCandidate>
+        ),
+        ComposerTrigger(
+          id: 'slash-command',
+          symbol: '/',
+          scope: ComposerTriggerScope.startOfMessage,
+          resolve: (query) => searchCommands(query),
+          buildDisplay: (c) => '/\${c.display}',
+        ),
+      ],
+      onSubmit: onSend, // {plainText, tokens[{type,id,display,start,end}], attachments}
+    );
+  }
+}`} />
+      </section>
+    </div>
+  )
+}

--- a/packages/flutter-docs-site/src/components/sidebar.tsx
+++ b/packages/flutter-docs-site/src/components/sidebar.tsx
@@ -134,6 +134,10 @@ const componentGroups = [
         href: "/components/command-menu"
       },
       {
+        name: "Composer",
+        href: "/components/composer"
+      },
+      {
         name: "Content Protection",
         href: "/components/content-protection"
       },

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -11,6 +11,7 @@ import 'pages/docs_layout.dart';
 import 'pages/carousel_page.dart';
 import 'pages/accordion_page.dart';
 import 'pages/chat_input_page.dart';
+import 'pages/composer_page.dart';
 import 'pages/command_menu_page.dart';
 import 'pages/command_input_page.dart';
 import 'pages/radio_group_page.dart';
@@ -628,6 +629,8 @@ class _AppShell extends ConsumerWidget {
         );
       case '/docs/chat-input':
         return ChatInputPage();
+      case '/docs/composer':
+        return ComposerPage();
       case '/docs/select-&-dropdowns':
         return PreviewCanvas(
           title: "Select & Dropdowns",

--- a/packages/flutter/example/lib/pages/composer_page.dart
+++ b/packages/flutter/example/lib/pages/composer_page.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+import '../dev_tools/preview_canvas.dart';
+
+class ComposerPage extends StatefulWidget {
+  const ComposerPage({super.key});
+
+  @override
+  State<ComposerPage> createState() => _ComposerPageState();
+}
+
+class _ComposerPageState extends State<ComposerPage> {
+  static const _roster = [
+    ComposerCandidate(
+      id: 'u_priya',
+      display: 'Priya Sharma',
+      subtitle: '@priya',
+    ),
+    ComposerCandidate(
+      id: 'u_jordan',
+      display: 'Jordan Lee',
+      subtitle: '@jordan',
+    ),
+    ComposerCandidate(id: 'u_sam', display: 'Sam Okafor', subtitle: '@sam'),
+    ComposerCandidate(id: 'u_mei', display: 'Mei Tanaka', subtitle: '@mei'),
+    ComposerCandidate(id: 'u_alex', display: 'Alex Rivera', subtitle: '@alex'),
+  ];
+
+  static const _commands = [
+    ComposerCandidate(
+      id: 'poll',
+      display: 'poll',
+      subtitle: 'Create a quick poll',
+    ),
+    ComposerCandidate(
+      id: 'remind',
+      display: 'remind',
+      subtitle: 'Set a reminder',
+    ),
+    ComposerCandidate(
+      id: 'shrug',
+      display: 'shrug',
+      subtitle: r'Append ¯\_(ツ)_/¯',
+    ),
+  ];
+
+  late final RefractionComposerController _controller;
+  late final List<ComposerTrigger> _triggers;
+
+  @override
+  void initState() {
+    super.initState();
+    final shortcodes = refractionDefaultShortcodes();
+    _triggers = [
+      ComposerTrigger(
+        id: 'mention',
+        symbol: '@',
+        resolve: (query) => _roster
+            .where(
+              (c) =>
+                  c.display.toLowerCase().contains(query.toLowerCase()) ||
+                  (c.subtitle ?? '').toLowerCase().contains(
+                    query.toLowerCase(),
+                  ),
+            )
+            .toList(),
+      ),
+      ComposerTrigger(
+        id: 'slash-command',
+        symbol: '/',
+        scope: ComposerTriggerScope.startOfMessage,
+        resolve: (query) => _commands
+            .where((c) => c.display.startsWith(query.toLowerCase()))
+            .toList(),
+        buildDisplay: (candidate) => '/${candidate.display}',
+      ),
+      ComposerTrigger(
+        id: 'emoji',
+        symbol: ':',
+        maxVisibleResults: 9,
+        resolve: (query) => shortcodes.entries
+            .where((e) => e.key.contains(query.toLowerCase()))
+            .take(30)
+            .map(
+              (e) => ComposerCandidate(
+                id: ':${e.key}:',
+                display: e.value,
+                subtitle: ':${e.key}:',
+              ),
+            )
+            .toList(),
+        buildDisplay: (candidate) => candidate.display,
+      ),
+    ];
+    _controller = RefractionComposerController(
+      triggers: _triggers,
+      shortcodes: shortcodes,
+      maxLength: 2000,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit(ComposerSubmission submission) {
+    RefractionToast.show(
+      context: context,
+      title: 'Message sent',
+      description: submission.tokens.isEmpty
+          ? submission.plainText
+          : '${submission.plainText}\n(${submission.tokens.length} token(s))',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = RefractionTheme.of(context).colors;
+    return PreviewCanvas(
+      title: 'Composer',
+      description:
+          'A headless-core chat composer with auto-grow, IME-safe Enter-to-send, '
+          '@mention / /slash / :emoji: trigger menus committing atomic tokens, '
+          'attachments, drafts, and edit-in-place. Try typing @, / (at the start), '
+          'or :fire: below.',
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: RefractionComposer(
+            controller: _controller,
+            placeholder: 'Message the team — try @, / or :joy:',
+            maxLines: 6,
+            triggers: _triggers,
+            onSubmit: _handleSubmit,
+            onAttachRequested: () {
+              RefractionToast.show(
+                context: context,
+                title: 'Attach',
+                description: 'Wire this slot to your file picker.',
+              );
+            },
+            leadingBuilder: (context, controller) => IconButton(
+              onPressed: () => controller.addAttachment(
+                ComposerAttachment(
+                  id: '',
+                  kind: ComposerAttachmentKind.file,
+                  name: 'demo.pdf',
+                  sizeBytes: 48213,
+                  status: ComposerAttachmentStatus.ready,
+                ),
+              ),
+              icon: Icon(Icons.attach_file, color: colors.mutedForeground),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/react-composer/src/composer.tsx
+++ b/packages/react-composer/src/composer.tsx
@@ -896,7 +896,7 @@ export const RefractionComposer = React.forwardRef<HTMLTextAreaElement, Refracti
                 : {})}
               className={cn(
                 composerFieldClass,
-                'absolute inset-0 h-full overflow-y-auto rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                'absolute inset-0 h-full overflow-y-auto focus-visible:outline-none',
               )}
               style={{ lineHeight: FIELD_LINE_HEIGHT, maxHeight: fieldHeightFor(maxLines) }}
               onChange={handleChange}


### PR DESCRIPTION
## Summary
Follow-up from hands-on visual verification of the composer on real surfaces (Chromium via Playwright for React; iOS simulator + Android emulator for Flutter).

Two things came out of that pass:

1. **Focus ring (React/Astro).** On the web adapter the focus state was a subtle `foreground/25` border tint that read as *no* focus indicator. Switched to the theme `ring` token as a single ring on the pill surface — clearly visible for keyboard users and consistent with other Refraction inputs. Patch bump to `@refraction-ui/react` + `@refraction-ui/astro` via changeset.
2. **Flutter docs coverage.** The Flutter docs site had no Composer page. Added `/components/composer` (page + sidebar entry) and a runnable `ComposerPage` demo in the example app (mention/slash/emoji triggers + an attachment slot) so the Flutter surface documents the new widget.

## Verification evidence
- React: mention menu opens with `aria-expanded=true`, `aria-activedescendant` tracks Arrow keys, Enter commits an atomic token (`Ping @Alice Chen`), Backspace removes the whole token (`Ping `), `:fire:` → 🔥. Auto-grow, states, props table all render.
- Flutter: widget renders on iOS and Android; `@` opens the caret-anchored suggestion overlay with the roster (Priya/Jordan/Sam/Mei), filtering live.

No changes to the shipped headless-core or Flutter widget logic — this is a web focus-style fix plus docs/example additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)