### PR TITLE
ci: deploy flutter widgetbook to GitHub Pages under /flutter/widgetbook/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Build Flutter UI Prototype
         working-directory: packages/flutter
         run: make build-web
+
+      - name: Build Flutter Widgetbook
+        # The Flutter component gallery (Widgetbook) — same role as the React
+        # Storybook, deployed at /flutter/widgetbook/. Separate output dir so
+        # it doesn't clobber the prototype build above; --base-href matches
+        # the Pages subpath (verified locally).
+        working-directory: packages/flutter/example
+        run: flutter build web -t lib/widgetbook.dart --base-href /refraction-ui/flutter/widgetbook/ --output "$GITHUB_WORKSPACE/packages/flutter/example/build/web-widgetbook"
         
       - name: Build Flutter Docs Site
         run: GITHUB_PAGES=true pnpm --filter @refraction-ui/flutter-docs-site build
@@ -67,6 +75,9 @@ jobs:
           # Static Storybook at /storybook/
           mkdir -p docs-site/out/storybook
           cp -r storybook-static/* docs-site/out/storybook/
+          # Flutter Widgetbook at /flutter/widgetbook/
+          mkdir -p docs-site/out/flutter/widgetbook
+          cp -r packages/flutter/example/build/web-widgetbook/* docs-site/out/flutter/widgetbook/
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

Same pattern as the React Storybook deploy (#443): the **Deploy Docs to GitHub Pages** workflow now also builds the Flutter example app's **Widgetbook** target for web and merges it into the Pages artifact at `/flutter/widgetbook/`.

## Details

- `flutter build web -t lib/widgetbook.dart` in `packages/flutter/example`, with `--base-href /refraction-ui/flutter/widgetbook/` so the Flutter web bootstrap resolves assets at the subpath.
- Separate output dir (`build/web-widgetbook`) so it doesn't clobber the existing prototype build (`build/web` → `/flutter/prototype/`).
- Lands at `https://elloloop.github.io/refraction-ui/flutter/widgetbook/` on the next main push after merge. Like the React one: a dev surface for checking Flutter component ↔ docs sync, not linked from the docs nav.

## Verified

- The exact build command succeeds locally (~19 s) and the emitted `index.html` carries `<base href="/refraction-ui/flutter/widgetbook/">`.
- Output is ~55 MB (dominated by the package's bundled Twemoji/animated-emoji/sticker assets) — same weight class as the existing prototype deploy.