### PR TITLE
fix(react): restore 0.18.1 changelog entry + changeset for 0.18.2

### DIFF
--- a/.changeset/react-0-18-2.md
+++ b/.changeset/react-0-18-2.md
@@ -1,0 +1,7 @@
+---
+'@refraction-ui/react': patch
+---
+
+SlideViewer: arrow-key navigation (ArrowRight/ArrowLeft) now actually re-renders the component — previously the headless state advanced and `onSlideChange` fired, but the slide counter, progress bar, content, and button states stayed stale until the next click.
+
+Also re-aligns the version/changelog history: a stale merge tree in #442 clobbered the 0.18.1 bump and its changelog entry (the slide-viewer change was then written as a duplicate 0.18.1 in #445), so this patch publishes the SlideViewer fix for real.

--- a/packages/react-meta/CHANGELOG.md
+++ b/packages/react-meta/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- e05f851: SlideViewer: arrow-key navigation (ArrowRight/ArrowLeft) now actually re-renders the component — previously the headless state advanced and `onSlideChange` fired, but the slide counter, progress bar, content, and button states stayed stale until the next click.
+- 76a8ae1: Composer: the suggestion menu (`@` mentions, `/` commands, `:emoji:`) now opens on whichever side of the composer has more viewport space — previously it always opened above, which could render it off-screen when the composer sat near the top of the viewport. The menu also caps its height to the available space and scrolls.
 
 ## 0.18.0
 


### PR DESCRIPTION
## Summary

Repairs the react release history after a stale merge tree in #442 reverted `packages/react-meta/package.json` and its CHANGELOG to their pre-0.18.1 state:

- **#441** published `@refraction-ui/react@0.18.1` (composer menu flip) correctly.
- **#442** (my branch, cut from a stale local main) clobbered both files back to 0.18.0 on merge.
- **#445** then computed the SlideViewer changeset as a bump to **0.18.1 again** — a version npm already has — so the SlideViewer fix never actually shipped.

## Fix

- Restore the original 0.18.1 changelog entry (menu flip) in `packages/react-meta/CHANGELOG.md`.
- Add a patch changeset so the next Version PR publishes **0.18.2** carrying the SlideViewer arrow-key fix.