### PR TITLE
docs(storybook): group all 126 components into category sections

### DIFF
--- a/.changeset/react-0-18-2.md
+++ b/.changeset/react-0-18-2.md
@@ -1,0 +1,7 @@
+---
+'@refraction-ui/react': patch
+---
+
+SlideViewer: arrow-key navigation (ArrowRight/ArrowLeft) now actually re-renders the component — previously the headless state advanced and `onSlideChange` fired, but the slide counter, progress bar, content, and button states stayed stale until the next click.
+
+Also re-aligns the version/changelog history: a stale merge tree in #442 clobbered the 0.18.1 bump and its changelog entry (the slide-viewer change was then written as a duplicate 0.18.1 in #445), so this patch publishes the SlideViewer fix for real.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,11 @@ Every component is three artifacts that **must stay in sync and ship together**:
    (`packages/<feature>`, `packages/<fw>-<feature>`). The source of truth for
    behavior, props, and tokens.
 2. **Storybook story** — `docs-site/src/app/components/<slug>/<Name>.stories.tsx`
-   (plus the `examples.tsx` it renders). The interactive showcase.
+   (plus the `examples.tsx` it renders). The interactive showcase. The story
+   `title` must be `<Category>/<Name>` where Category is one of: **Inputs,
+   Navigation, Data Display, Feedback, Overlays, Layout, Chat & AI, Calls &
+   Media, Marketing, Editors & IDE, Utilities** (the sidebar taxonomy — flat
+   `Components/<Name>` titles are not allowed).
 3. **Docs-site page** — `docs-site/src/app/components/<slug>/page.tsx` with the
    live examples, a props table, and an install snippet.
 

--- a/docs-site/src/app/components/accordion/Accordion.stories.tsx
+++ b/docs-site/src/app/components/accordion/Accordion.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@refraction-ui/react-accordion'
 
 const meta: Meta<typeof Accordion> = {
-  title: 'Components/Accordion',
+  title: 'Navigation/Accordion',
   component: Accordion,
   argTypes: {
     type: { control: 'radio', options: ['single', 'multiple'] },

--- a/docs-site/src/app/components/animated-text/AnimatedText.stories.tsx
+++ b/docs-site/src/app/components/animated-text/AnimatedText.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AnimatedText, TypewriterText } from '@refraction-ui/react-animated-text'
 
 const meta: Meta<typeof AnimatedText> = {
-  title: 'Components/AnimatedText',
+  title: 'Utilities/AnimatedText',
   component: AnimatedText,
 }
 export default meta

--- a/docs-site/src/app/components/app-shell/AppShell.stories.tsx
+++ b/docs-site/src/app/components/app-shell/AppShell.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AppShell } from '@refraction-ui/react-app-shell'
 
 const meta: Meta<typeof AppShell> = {
-  title: 'Components/AppShell',
+  title: 'Navigation/AppShell',
   component: AppShell,
 }
 export default meta

--- a/docs-site/src/app/components/audience-feature-card/AudienceFeatureCard.stories.tsx
+++ b/docs-site/src/app/components/audience-feature-card/AudienceFeatureCard.stories.tsx
@@ -1,7 +1,7 @@
 import { AudienceFeatureCardExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/AudienceFeatureCard' }
+const meta = { title: 'Marketing/AudienceFeatureCard' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/audio-room/AudioRoom.stories.tsx
+++ b/docs-site/src/app/components/audio-room/AudioRoom.stories.tsx
@@ -1,7 +1,7 @@
 import { AudioRoomExamples, SpeakingOrbDemo } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/AudioRoom' }
+const meta = { title: 'Calls & Media/AudioRoom' }
 export default meta
 
 export const BasicRoom = {

--- a/docs-site/src/app/components/avatar-group/AvatarGroup.stories.tsx
+++ b/docs-site/src/app/components/avatar-group/AvatarGroup.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { AvatarGroup } from '@refraction-ui/react-avatar-group'
 
 const meta: Meta<typeof AvatarGroup> = {
-  title: 'Components/AvatarGroup',
+  title: 'Data Display/AvatarGroup',
   component: AvatarGroup,
   argTypes: {
     max: { control: 'number' },

--- a/docs-site/src/app/components/avatar/Avatar.stories.tsx
+++ b/docs-site/src/app/components/avatar/Avatar.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Avatar, AvatarImage, AvatarFallback } from '@refraction-ui/react-avatar'
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Components/Avatar',
+  title: 'Data Display/Avatar',
   component: Avatar,
   argTypes: {
     size: {

--- a/docs-site/src/app/components/badge/Badge.stories.tsx
+++ b/docs-site/src/app/components/badge/Badge.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Badge } from '@refraction-ui/react-badge'
 
 const meta: Meta<typeof Badge> = {
-  title: 'Components/Badge',
+  title: 'Data Display/Badge',
   component: Badge,
   argTypes: {
     variant: {

--- a/docs-site/src/app/components/bottom-nav/BottomNav.stories.tsx
+++ b/docs-site/src/app/components/bottom-nav/BottomNav.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { BottomNav } from '@refraction-ui/react-bottom-nav'
 
 const meta: Meta<typeof BottomNav> = {
-  title: 'Components/BottomNav',
+  title: 'Navigation/BottomNav',
   component: BottomNav,
   argTypes: {
     currentPath: { control: 'text' },

--- a/docs-site/src/app/components/brand-network-cell/BrandNetworkCell.stories.tsx
+++ b/docs-site/src/app/components/brand-network-cell/BrandNetworkCell.stories.tsx
@@ -1,7 +1,7 @@
 import { BrandNetworkCellExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/BrandNetworkCell' }
+const meta = { title: 'Marketing/BrandNetworkCell' }
 export default meta
 
 export const Current = {

--- a/docs-site/src/app/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/docs-site/src/app/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Breadcrumbs } from '@refraction-ui/react-breadcrumbs'
 
 const meta: Meta<typeof Breadcrumbs> = {
-  title: 'Components/Breadcrumbs',
+  title: 'Navigation/Breadcrumbs',
   component: Breadcrumbs,
   argTypes: {
     pathname: { control: 'text' },

--- a/docs-site/src/app/components/browser-chrome-mock/BrowserChromeMock.stories.tsx
+++ b/docs-site/src/app/components/browser-chrome-mock/BrowserChromeMock.stories.tsx
@@ -1,7 +1,7 @@
 import { BrowserChromeMockExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/BrowserChromeMock' }
+const meta = { title: 'Marketing/BrowserChromeMock' }
 export default meta
 
 export const Basic = { render: () => <BrowserChromeMockExamples section="basic" /> }

--- a/docs-site/src/app/components/button/Button.stories.tsx
+++ b/docs-site/src/app/components/button/Button.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Button } from '@refraction-ui/react-button'
 
 const meta: Meta<typeof Button> = {
-  title: 'Components/Button',
+  title: 'Inputs/Button',
   component: Button,
   argTypes: {
     variant: {

--- a/docs-site/src/app/components/calendar/Calendar.stories.tsx
+++ b/docs-site/src/app/components/calendar/Calendar.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { Calendar } from '@refraction-ui/react-calendar'
 
 const meta: Meta<typeof Calendar> = {
-  title: 'Components/Calendar',
+  title: 'Data Display/Calendar',
   component: Calendar,
 }
 export default meta

--- a/docs-site/src/app/components/call-controls/CallControls.stories.tsx
+++ b/docs-site/src/app/components/call-controls/CallControls.stories.tsx
@@ -1,7 +1,7 @@
 import { CallControlsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/CallControls' }
+const meta = { title: 'Calls & Media/CallControls' }
 export default meta
 
 export const Basic = { render: () => <CallControlsExamples section="basic" /> }

--- a/docs-site/src/app/components/callout/Callout.stories.tsx
+++ b/docs-site/src/app/components/callout/Callout.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@refraction-ui/react-callout'
 
 const meta: Meta<typeof Callout> = {
-  title: 'Components/Callout',
+  title: 'Feedback/Callout',
   component: Callout,
   argTypes: {
     variant: {

--- a/docs-site/src/app/components/card-grid/CardGrid.stories.tsx
+++ b/docs-site/src/app/components/card-grid/CardGrid.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { CardGrid } from '@refraction-ui/react-card-grid'
 
 const meta: Meta<typeof CardGrid> = {
-  title: 'Components/CardGrid',
+  title: 'Data Display/CardGrid',
   component: CardGrid,
   argTypes: {
     columns: { control: { type: 'number', min: 1, max: 6 } },

--- a/docs-site/src/app/components/card/Card.stories.tsx
+++ b/docs-site/src/app/components/card/Card.stories.tsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 import { Button } from '@refraction-ui/react-button'
 
 const meta: Meta<typeof Card> = {
-  title: 'Components/Card',
+  title: 'Data Display/Card',
   component: Card,
   args: {},
 }

--- a/docs-site/src/app/components/carousel/Carousel.stories.tsx
+++ b/docs-site/src/app/components/carousel/Carousel.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from '@refraction-ui/react-carousel'
 
 const meta: Meta<typeof Carousel> = {
-  title: 'Components/Carousel',
+  title: 'Data Display/Carousel',
   component: Carousel,
   argTypes: {
     type: { control: 'radio', options: ['single', 'multiple'] },

--- a/docs-site/src/app/components/charts/Charts.stories.tsx
+++ b/docs-site/src/app/components/charts/Charts.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Chart, Bars, Line, Circles, PieChart } from '@refraction-ui/react-charts'
 
 const meta: Meta<typeof Chart> = {
-  title: 'Components/Charts',
+  title: 'Data Display/Charts',
   component: Chart,
 }
 export default meta

--- a/docs-site/src/app/components/checkbox/Checkbox.stories.tsx
+++ b/docs-site/src/app/components/checkbox/Checkbox.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Checkbox } from '@refraction-ui/react-checkbox'
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'Components/Checkbox',
+  title: 'Inputs/Checkbox',
   component: Checkbox,
   argTypes: {
     checked: { control: 'radio', options: [true, false, 'indeterminate'] },

--- a/docs-site/src/app/components/checklist/Checklist.stories.tsx
+++ b/docs-site/src/app/components/checklist/Checklist.stories.tsx
@@ -1,7 +1,7 @@
 import { ChecklistExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Checklist' }
+const meta = { title: 'Data Display/Checklist' }
 export default meta
 
 export const Basic = { render: () => <ChecklistExamples section="basic" /> }

--- a/docs-site/src/app/components/code-block/CodeBlock.stories.tsx
+++ b/docs-site/src/app/components/code-block/CodeBlock.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from '@refraction-ui/react-code-block'
 
 const meta: Meta<typeof RuiCodeBlock> = {
-  title: 'Components/CodeBlock',
+  title: 'Data Display/CodeBlock',
   component: RuiCodeBlock,
   args: {},
 }

--- a/docs-site/src/app/components/code-editor/CodeEditor.stories.tsx
+++ b/docs-site/src/app/components/code-editor/CodeEditor.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { CodeEditor } from '@refraction-ui/react-code-editor'
 
 const meta: Meta<typeof CodeEditor> = {
-  title: 'Components/CodeEditor',
+  title: 'Editors & IDE/CodeEditor',
   component: CodeEditor,
   argTypes: {
     language: { control: 'text' },

--- a/docs-site/src/app/components/collapsible/Collapsible.stories.tsx
+++ b/docs-site/src/app/components/collapsible/Collapsible.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@refraction-ui/react-collapsible'
 
 const meta: Meta<typeof Collapsible> = {
-  title: 'Components/Collapsible',
+  title: 'Layout/Collapsible',
   component: Collapsible,
   argTypes: {
     defaultOpen: { control: 'boolean' },

--- a/docs-site/src/app/components/combobox/Combobox.stories.tsx
+++ b/docs-site/src/app/components/combobox/Combobox.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@refraction-ui/react-combobox'
 
 const meta: Meta<typeof Combobox> = {
-  title: 'Components/Combobox',
+  title: 'Inputs/Combobox',
   component: Combobox,
   args: {},
 }

--- a/docs-site/src/app/components/command-input/CommandInput.stories.tsx
+++ b/docs-site/src/app/components/command-input/CommandInput.stories.tsx
@@ -3,7 +3,7 @@ import { CommandInput } from '@refraction-ui/react-command-input'
 import { useState } from 'react'
 
 const meta: Meta<typeof CommandInput> = {
-  title: 'Components/CommandInput',
+  title: 'Inputs/CommandInput',
   component: CommandInput,
   argTypes: {},
 }

--- a/docs-site/src/app/components/command/Command.stories.tsx
+++ b/docs-site/src/app/components/command/Command.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@refraction-ui/react-command'
 
 const meta: Meta<typeof Command> = {
-  title: 'Components/Command',
+  title: 'Navigation/Command',
   component: Command,
   argTypes: {},
 }

--- a/docs-site/src/app/components/composer/Composer.stories.tsx
+++ b/docs-site/src/app/components/composer/Composer.stories.tsx
@@ -1,7 +1,7 @@
 import { ComposerExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Composer' }
+const meta = { title: 'Chat & AI/Composer' }
 export default meta
 
 export const Basic = { render: () => <ComposerExamples section="basic" /> }

--- a/docs-site/src/app/components/content-protection/ContentProtection.stories.tsx
+++ b/docs-site/src/app/components/content-protection/ContentProtection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ContentProtection } from '@refraction-ui/react-content-protection'
 
 const meta: Meta<typeof ContentProtection> = {
-  title: 'Components/ContentProtection',
+  title: 'Feedback/ContentProtection',
   component: ContentProtection,
   argTypes: {
     watermark: { control: 'object' },

--- a/docs-site/src/app/components/conversation/Chat.stories.tsx
+++ b/docs-site/src/app/components/conversation/Chat.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@refraction-ui/react-conversation'
 
 const meta: Meta<typeof Chat> = {
-  title: 'Components/Chat',
+  title: 'Chat & AI/Chat',
   component: Chat,
   argTypes: {},
 }

--- a/docs-site/src/app/components/cookie-consent/CookieConsent.stories.tsx
+++ b/docs-site/src/app/components/cookie-consent/CookieConsent.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { CookieConsent, useCookieConsent } from '@refraction-ui/react-cookie-consent'
 
 const meta: Meta<typeof CookieConsent> = {
-  title: 'Components/CookieConsent',
+  title: 'Feedback/CookieConsent',
   component: CookieConsent,
   argTypes: {
     policyUrl: { control: 'text' },

--- a/docs-site/src/app/components/data-table/DataTable.stories.tsx
+++ b/docs-site/src/app/components/data-table/DataTable.stories.tsx
@@ -9,7 +9,7 @@ const sampleData = [
 ]
 
 const meta: Meta<typeof DataTable> = {
-  title: 'Components/DataTable',
+  title: 'Data Display/DataTable',
   component: DataTable,
   argTypes: {},
   args: {

--- a/docs-site/src/app/components/date-picker/DatePicker.stories.tsx
+++ b/docs-site/src/app/components/date-picker/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import { DatePicker } from '@refraction-ui/react-date-picker'
 import { useState } from 'react'
 
 const meta: Meta<typeof DatePicker> = {
-  title: 'Components/DatePicker',
+  title: 'Inputs/DatePicker',
   component: DatePicker,
   argTypes: {},
 }

--- a/docs-site/src/app/components/device-frame/DeviceFrame.stories.tsx
+++ b/docs-site/src/app/components/device-frame/DeviceFrame.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { DeviceFrame } from '@refraction-ui/react-device-frame'
 
 const meta: Meta<typeof DeviceFrame> = {
-  title: 'Components/DeviceFrame',
+  title: 'Layout/DeviceFrame',
   component: DeviceFrame,
   argTypes: {
     device: {

--- a/docs-site/src/app/components/dialog/Dialog.stories.tsx
+++ b/docs-site/src/app/components/dialog/Dialog.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from '@refraction-ui/react-input'
 
 const meta: Meta<typeof Dialog> = {
-  title: 'Components/Dialog',
+  title: 'Feedback/Dialog',
   component: Dialog,
   argTypes: {},
 }

--- a/docs-site/src/app/components/diff-viewer/DiffViewer.stories.tsx
+++ b/docs-site/src/app/components/diff-viewer/DiffViewer.stories.tsx
@@ -18,7 +18,7 @@ const FILES: DiffFile[] = [
 ]
 
 const meta: Meta<typeof DiffViewer> = {
-  title: 'Components/DiffViewer',
+  title: 'Data Display/DiffViewer',
   component: DiffViewer,
   argTypes: {
     viewMode: { control: 'radio', options: ['split', 'inline'] },

--- a/docs-site/src/app/components/dropdown-menu/DropdownMenu.stories.tsx
+++ b/docs-site/src/app/components/dropdown-menu/DropdownMenu.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '@refraction-ui/react-button'
 
 const meta: Meta<typeof DropdownMenu> = {
-  title: 'Components/DropdownMenu',
+  title: 'Overlays/DropdownMenu',
   component: DropdownMenu,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/editor-status-bar/EditorStatusBar.stories.tsx
+++ b/docs-site/src/app/components/editor-status-bar/EditorStatusBar.stories.tsx
@@ -1,7 +1,7 @@
 import { EditorStatusBarExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/EditorStatusBar' }
+const meta = { title: 'Editors & IDE/EditorStatusBar' }
 export default meta
 
 export const ConvenienceProps = {

--- a/docs-site/src/app/components/editor-tabs/EditorTabs.stories.tsx
+++ b/docs-site/src/app/components/editor-tabs/EditorTabs.stories.tsx
@@ -1,7 +1,7 @@
 import { EditorTabsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/EditorTabs' }
+const meta = { title: 'Editors & IDE/EditorTabs' }
 export default meta
 
 export const Basic = { render: () => <EditorTabsExamples section="basic" /> }

--- a/docs-site/src/app/components/emoji-picker/EmojiPicker.stories.tsx
+++ b/docs-site/src/app/components/emoji-picker/EmojiPicker.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { EmojiPicker } from '@refraction-ui/react-emoji-picker'
 
 const meta: Meta<typeof EmojiPicker> = {
-  title: 'Components/EmojiPicker',
+  title: 'Utilities/EmojiPicker',
   component: EmojiPicker,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/empty-state/EmptyState.stories.tsx
+++ b/docs-site/src/app/components/empty-state/EmptyState.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { EmptyState, ConfirmationCard } from '@refraction-ui/react-empty-state'
 
 const meta: Meta<typeof EmptyState> = {
-  title: 'Components/EmptyState',
+  title: 'Feedback/EmptyState',
   component: EmptyState,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/feedback-dialog/FeedbackDialog.stories.tsx
+++ b/docs-site/src/app/components/feedback-dialog/FeedbackDialog.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FeedbackDialog, FeedbackButton } from '@refraction-ui/react-feedback-dialog'
 
 const meta: Meta<typeof FeedbackDialog> = {
-  title: 'Components/FeedbackDialog',
+  title: 'Feedback/FeedbackDialog',
   component: FeedbackDialog,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/file-tree/FileTree.stories.tsx
+++ b/docs-site/src/app/components/file-tree/FileTree.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FileTree } from '@refraction-ui/react-file-tree'
 
 const meta: Meta<typeof FileTree> = {
-  title: 'Components/FileTree',
+  title: 'Data Display/FileTree',
   component: FileTree,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/file-upload/FileUpload.stories.tsx
+++ b/docs-site/src/app/components/file-upload/FileUpload.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FileUpload } from '@refraction-ui/react-file-upload'
 
 const meta: Meta<typeof FileUpload> = {
-  title: 'Components/FileUpload',
+  title: 'Inputs/FileUpload',
   component: FileUpload,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/floating-reactions/FloatingReactions.stories.tsx
+++ b/docs-site/src/app/components/floating-reactions/FloatingReactions.stories.tsx
@@ -1,7 +1,7 @@
 import { FloatingReactionsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/FloatingReactions' }
+const meta = { title: 'Calls & Media/FloatingReactions' }
 export default meta
 
 export const StaticBurst = { render: () => <FloatingReactionsExamples section="static" /> }

--- a/docs-site/src/app/components/flow-editor/FlowEditor.stories.tsx
+++ b/docs-site/src/app/components/flow-editor/FlowEditor.stories.tsx
@@ -1,7 +1,7 @@
 import { FlowEditorExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/FlowEditor' }
+const meta = { title: 'Layout/FlowEditor' }
 export default meta
 
 export const Architecture = {

--- a/docs-site/src/app/components/footer/Footer.stories.tsx
+++ b/docs-site/src/app/components/footer/Footer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Footer } from '@refraction-ui/react-footer'
 
 const meta: Meta<typeof Footer> = {
-  title: 'Components/Footer',
+  title: 'Layout/Footer',
   component: Footer,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/form/Form.stories.tsx
+++ b/docs-site/src/app/components/form/Form.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '@refraction-ui/react-form'
 
 const meta: Meta<typeof Form> = {
-  title: 'Components/Form',
+  title: 'Inputs/Form',
   component: Form,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/graph-view/GraphView.stories.tsx
+++ b/docs-site/src/app/components/graph-view/GraphView.stories.tsx
@@ -1,7 +1,7 @@
 import { GraphViewExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/GraphView' }
+const meta = { title: 'Data Display/GraphView' }
 export default meta
 
 export const KnowledgeMap = {

--- a/docs-site/src/app/components/infinite-canvas/InfiniteCanvas.stories.tsx
+++ b/docs-site/src/app/components/infinite-canvas/InfiniteCanvas.stories.tsx
@@ -1,7 +1,7 @@
 import { InfiniteCanvasExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/InfiniteCanvas' }
+const meta = { title: 'Layout/InfiniteCanvas' }
 export default meta
 
 export const Basic = { render: () => <InfiniteCanvasExamples section="basic" /> }

--- a/docs-site/src/app/components/inline-editor/InlineEditor.stories.tsx
+++ b/docs-site/src/app/components/inline-editor/InlineEditor.stories.tsx
@@ -3,7 +3,7 @@ import { InlineEditor } from '@refraction-ui/react-inline-editor'
 import { useState } from 'react'
 
 const meta: Meta<typeof InlineEditor> = {
-  title: 'Components/InlineEditor',
+  title: 'Chat & AI/InlineEditor',
   component: InlineEditor,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/input-group/InputGroup.stories.tsx
+++ b/docs-site/src/app/components/input-group/InputGroup.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from '@refraction-ui/react-input-group'
 
 const meta: Meta<typeof InputGroup> = {
-  title: 'Components/InputGroup',
+  title: 'Inputs/InputGroup',
   component: InputGroup,
   args: {
     orientation: 'horizontal',

--- a/docs-site/src/app/components/input/Input.stories.tsx
+++ b/docs-site/src/app/components/input/Input.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Input } from '@refraction-ui/react-input'
 
 const meta: Meta<typeof Input> = {
-  title: 'Components/Input',
+  title: 'Inputs/Input',
   component: Input,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/install-prompt/InstallPrompt.stories.tsx
+++ b/docs-site/src/app/components/install-prompt/InstallPrompt.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { InstallPrompt } from '@refraction-ui/react-install-prompt'
 
 const meta: Meta<typeof InstallPrompt> = {
-  title: 'Components/InstallPrompt',
+  title: 'Feedback/InstallPrompt',
   component: InstallPrompt,
   args: {
     appName: 'My App',

--- a/docs-site/src/app/components/kanban-board/KanbanBoard.stories.tsx
+++ b/docs-site/src/app/components/kanban-board/KanbanBoard.stories.tsx
@@ -1,7 +1,7 @@
 import { KanbanBoardExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/KanbanBoard' }
+const meta = { title: 'Data Display/KanbanBoard' }
 export default meta
 
 export const Basic = { render: () => <KanbanBoardExamples section="basic" /> }

--- a/docs-site/src/app/components/keyboard-shortcut/KeyboardShortcut.stories.tsx
+++ b/docs-site/src/app/components/keyboard-shortcut/KeyboardShortcut.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ShortcutBadge } from '@refraction-ui/react-keyboard-shortcut'
 
 const meta: Meta<typeof ShortcutBadge> = {
-  title: 'Components/KeyboardShortcut',
+  title: 'Utilities/KeyboardShortcut',
   component: ShortcutBadge,
   args: {
     keys: ['Cmd', 'K'],

--- a/docs-site/src/app/components/language-selector/LanguageSelector.stories.tsx
+++ b/docs-site/src/app/components/language-selector/LanguageSelector.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { LanguageSelector } from '@refraction-ui/react-language-selector'
 
 const meta: Meta<typeof LanguageSelector> = {
-  title: 'Components/LanguageSelector',
+  title: 'Inputs/LanguageSelector',
   component: LanguageSelector,
   args: {
     options: [

--- a/docs-site/src/app/components/link-card/LinkCard.stories.tsx
+++ b/docs-site/src/app/components/link-card/LinkCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { LinkCard } from '@refraction-ui/react-link-card'
 
 const meta: Meta<typeof LinkCard> = {
-  title: 'Components/LinkCard',
+  title: 'Data Display/LinkCard',
   component: LinkCard,
   args: {
     href: 'https://refraction-ui.dev/docs',

--- a/docs-site/src/app/components/live-captions/LiveCaptions.stories.tsx
+++ b/docs-site/src/app/components/live-captions/LiveCaptions.stories.tsx
@@ -1,7 +1,7 @@
 import { LiveCaptionsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/LiveCaptions' }
+const meta = { title: 'Calls & Media/LiveCaptions' }
 export default meta
 
 export const SingleLine = { render: () => <LiveCaptionsExamples section="single-line" /> }

--- a/docs-site/src/app/components/live-cursors/LiveCursors.stories.tsx
+++ b/docs-site/src/app/components/live-cursors/LiveCursors.stories.tsx
@@ -1,7 +1,7 @@
 import { LiveCursorsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/LiveCursors' }
+const meta = { title: 'Calls & Media/LiveCursors' }
 export default meta
 
 export const WithLabels = { render: () => <LiveCursorsExamples section="labeled" /> }

--- a/docs-site/src/app/components/live-transcript/LiveTranscript.stories.tsx
+++ b/docs-site/src/app/components/live-transcript/LiveTranscript.stories.tsx
@@ -1,7 +1,7 @@
 import { LiveTranscriptExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/LiveTranscript' }
+const meta = { title: 'Calls & Media/LiveTranscript' }
 export default meta
 
 export const Basic = { render: () => <LiveTranscriptExamples section="basic" /> }

--- a/docs-site/src/app/components/location-selector/LocationSelector.stories.tsx
+++ b/docs-site/src/app/components/location-selector/LocationSelector.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { LocationSelector } from '@refraction-ui/react-location-selector'
 
 const meta: Meta<typeof LocationSelector> = {
-  title: 'Components/LocationSelector',
+  title: 'Inputs/LocationSelector',
   component: LocationSelector,
   args: {
     defaultCountry: 'US',

--- a/docs-site/src/app/components/markdown-renderer/MarkdownRenderer.stories.tsx
+++ b/docs-site/src/app/components/markdown-renderer/MarkdownRenderer.stories.tsx
@@ -18,7 +18,7 @@ console.log(greeting)
 `
 
 const meta: Meta<typeof MarkdownRenderer> = {
-  title: 'Components/MarkdownRenderer',
+  title: 'Data Display/MarkdownRenderer',
   component: MarkdownRenderer,
   args: {
     content: sampleMarkdown,

--- a/docs-site/src/app/components/marquee-strip/MarqueeStrip.stories.tsx
+++ b/docs-site/src/app/components/marquee-strip/MarqueeStrip.stories.tsx
@@ -1,7 +1,7 @@
 import { MarqueeStripExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/MarqueeStrip' }
+const meta = { title: 'Marketing/MarqueeStrip' }
 export default meta
 
 export const Static = { render: () => <MarqueeStripExamples section="static" /> }

--- a/docs-site/src/app/components/mastery-bar/MasteryBar.stories.tsx
+++ b/docs-site/src/app/components/mastery-bar/MasteryBar.stories.tsx
@@ -1,7 +1,7 @@
 import { MasteryBarExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/MasteryBar' }
+const meta = { title: 'Chat & AI/MasteryBar' }
 export default meta
 
 export const Basic = { render: () => <MasteryBarExamples section="basic" /> }

--- a/docs-site/src/app/components/mini-map/MiniMap.stories.tsx
+++ b/docs-site/src/app/components/mini-map/MiniMap.stories.tsx
@@ -1,7 +1,7 @@
 import { MiniMapExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/MiniMap' }
+const meta = { title: 'Layout/MiniMap' }
 export default meta
 
 export const BasicOverview = { render: () => <MiniMapExamples section="basic" /> }

--- a/docs-site/src/app/components/mobile-nav/MobileNav.stories.tsx
+++ b/docs-site/src/app/components/mobile-nav/MobileNav.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@refraction-ui/react-mobile-nav'
 
 const meta: Meta<typeof MobileNav> = {
-  title: 'Components/MobileNav',
+  title: 'Navigation/MobileNav',
   component: MobileNav,
   args: {
     defaultOpen: false,

--- a/docs-site/src/app/components/navbar/Navbar.stories.tsx
+++ b/docs-site/src/app/components/navbar/Navbar.stories.tsx
@@ -2,7 +2,7 @@ import { Navbar } from '@refraction-ui/react-navbar'
 import { NavbarExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Navbar' }
+const meta = { title: 'Navigation/Navbar' }
 export default meta
 
 export const Basic = { render: () => <NavbarExamples section="basic" /> }

--- a/docs-site/src/app/components/numbered-steps/NumberedSteps.stories.tsx
+++ b/docs-site/src/app/components/numbered-steps/NumberedSteps.stories.tsx
@@ -1,7 +1,7 @@
 import { NumberedStepsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/NumberedSteps' }
+const meta = { title: 'Marketing/NumberedSteps' }
 export default meta
 
 export const FourSteps = {

--- a/docs-site/src/app/components/otp-input/OtpInput.stories.tsx
+++ b/docs-site/src/app/components/otp-input/OtpInput.stories.tsx
@@ -1,7 +1,7 @@
 import { OtpInputExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/OtpInput' }
+const meta = { title: 'Inputs/OtpInput' }
 export default meta
 
 export const Lengths = {

--- a/docs-site/src/app/components/pagination/Pagination.stories.tsx
+++ b/docs-site/src/app/components/pagination/Pagination.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Pagination } from '@refraction-ui/react-pagination';
 
 const meta: Meta<typeof Pagination> = {
-  title: 'Components/Pagination',
+  title: 'Navigation/Pagination',
   component: Pagination,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/password-input/PasswordInput.stories.tsx
+++ b/docs-site/src/app/components/password-input/PasswordInput.stories.tsx
@@ -1,7 +1,7 @@
 import { PasswordInputExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/PasswordInput' }
+const meta = { title: 'Inputs/PasswordInput' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/payment/Payment.stories.tsx
+++ b/docs-site/src/app/components/payment/Payment.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Payment } from '@refraction-ui/react-payment';
 
 const meta: Meta<typeof Payment> = {
-  title: 'Components/Payment',
+  title: 'Inputs/Payment',
   component: Payment,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/popover/Popover.stories.tsx
+++ b/docs-site/src/app/components/popover/Popover.stories.tsx
@@ -6,7 +6,7 @@ import {
 import { PopoverExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Popover' }
+const meta = { title: 'Overlays/Popover' }
 export default meta
 
 export const Basic = { render: () => <PopoverExamples section="basic" /> }

--- a/docs-site/src/app/components/pre-call-lobby/PreCallLobby.stories.tsx
+++ b/docs-site/src/app/components/pre-call-lobby/PreCallLobby.stories.tsx
@@ -1,7 +1,7 @@
 import { PreCallLobbyExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/PreCallLobby' }
+const meta = { title: 'Calls & Media/PreCallLobby' }
 export default meta
 
 export const Basic = { render: () => <PreCallLobbyExamples section="basic" /> }

--- a/docs-site/src/app/components/presence-indicator/PresenceIndicator.stories.tsx
+++ b/docs-site/src/app/components/presence-indicator/PresenceIndicator.stories.tsx
@@ -2,7 +2,7 @@ import { PresenceIndicator } from '@refraction-ui/react-presence-indicator'
 import { PresenceIndicatorExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/PresenceIndicator' }
+const meta = { title: 'Data Display/PresenceIndicator' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/pricing-card/PricingCard.stories.tsx
+++ b/docs-site/src/app/components/pricing-card/PricingCard.stories.tsx
@@ -1,7 +1,7 @@
 import { PricingCardExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/PricingCard' }
+const meta = { title: 'Marketing/PricingCard' }
 export default meta
 
 export const Basic = { render: () => <PricingCardExamples section="basic" /> }

--- a/docs-site/src/app/components/progress-display/ProgressDisplay.stories.tsx
+++ b/docs-site/src/app/components/progress-display/ProgressDisplay.stories.tsx
@@ -6,7 +6,7 @@ import {
 import { ProgressDisplayExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/ProgressDisplay' }
+const meta = { title: 'Data Display/ProgressDisplay' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/radial-gauge/RadialGauge.stories.tsx
+++ b/docs-site/src/app/components/radial-gauge/RadialGauge.stories.tsx
@@ -1,7 +1,7 @@
 import { RadialGaugeExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/RadialGauge' }
+const meta = { title: 'Data Display/RadialGauge' }
 export default meta
 
 export const Basic = { render: () => <RadialGaugeExamples section="basic" /> }

--- a/docs-site/src/app/components/radio/Radio.stories.tsx
+++ b/docs-site/src/app/components/radio/Radio.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { RadioGroup, RadioItem } from '@refraction-ui/react-radio';
 
 const meta: Meta<typeof RadioGroup> = {
-  title: 'Components/Radio',
+  title: 'Inputs/Radio',
   component: RadioGroup,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/rating-scale/RatingScale.stories.tsx
+++ b/docs-site/src/app/components/rating-scale/RatingScale.stories.tsx
@@ -1,7 +1,7 @@
 import { RatingScaleExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/RatingScale' }
+const meta = { title: 'Inputs/RatingScale' }
 export default meta
 
 export const Basic = { render: () => <RatingScaleExamples section="basic" /> }

--- a/docs-site/src/app/components/reaction-bar/ReactionBar.stories.tsx
+++ b/docs-site/src/app/components/reaction-bar/ReactionBar.stories.tsx
@@ -8,7 +8,7 @@ import {
 // Composed directly from the adapter: the docs-site example predates the
 // current `userReacted`/`onToggle` API and no longer typechecks against it.
 const meta: Meta<typeof ReactionBar> = {
-  title: 'Components/ReactionBar',
+  title: 'Data Display/ReactionBar',
   component: ReactionBar,
 }
 export default meta

--- a/docs-site/src/app/components/resizable-layout/ResizableLayout.stories.tsx
+++ b/docs-site/src/app/components/resizable-layout/ResizableLayout.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ResizableLayout } from '@refraction-ui/react-resizable-layout';
 
 const meta: Meta<typeof ResizableLayout> = {
-  title: 'Components/ResizableLayout',
+  title: 'Layout/ResizableLayout',
   component: ResizableLayout,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/rich-editor/RichEditor.stories.tsx
+++ b/docs-site/src/app/components/rich-editor/RichEditor.stories.tsx
@@ -1,7 +1,7 @@
 // The @refraction-ui/react-rich-editor adapter is still in early development —
 // the package currently exports nothing — so this story mirrors the docs-site
 // page's status content instead of rendering a live component.
-const meta = { title: 'Components/RichEditor' }
+const meta = { title: 'Chat & AI/RichEditor' }
 export default meta
 
 export const ComingSoon = {

--- a/docs-site/src/app/components/search-bar/SearchBar.stories.tsx
+++ b/docs-site/src/app/components/search-bar/SearchBar.stories.tsx
@@ -6,7 +6,7 @@ import {
 import { SearchBarExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SearchBar' }
+const meta = { title: 'Inputs/SearchBar' }
 export default meta
 
 export const Basic = { render: () => <SearchBarExamples section="basic" /> }

--- a/docs-site/src/app/components/section-head/SectionHead.stories.tsx
+++ b/docs-site/src/app/components/section-head/SectionHead.stories.tsx
@@ -1,7 +1,7 @@
 import { SectionHeadExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SectionHead' }
+const meta = { title: 'Marketing/SectionHead' }
 export default meta
 
 export const Centered = { render: () => <SectionHeadExamples section="centered" /> }

--- a/docs-site/src/app/components/segmented-control/SegmentedControl.stories.tsx
+++ b/docs-site/src/app/components/segmented-control/SegmentedControl.stories.tsx
@@ -1,7 +1,7 @@
 import { SegmentedControlExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SegmentedControl' }
+const meta = { title: 'Inputs/SegmentedControl' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/select/Select.stories.tsx
+++ b/docs-site/src/app/components/select/Select.stories.tsx
@@ -1,7 +1,7 @@
 import { SelectExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Select' }
+const meta = { title: 'Inputs/Select' }
 export default meta
 
 export const Basic = { render: () => <SelectExamples section="basic" /> }

--- a/docs-site/src/app/components/separator/Separator.stories.tsx
+++ b/docs-site/src/app/components/separator/Separator.stories.tsx
@@ -1,7 +1,7 @@
 import { SeparatorExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Separator' }
+const meta = { title: 'Layout/Separator' }
 export default meta
 
 export const Basic = { render: () => <SeparatorExamples section="basic" /> }

--- a/docs-site/src/app/components/sheet/Sheet.stories.tsx
+++ b/docs-site/src/app/components/sheet/Sheet.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@refraction-ui/react-sheet';
 
 const meta: Meta<typeof Sheet> = {
-  title: 'Components/Sheet',
+  title: 'Overlays/Sheet',
   component: Sheet,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/sidebar-component/Sidebar.stories.tsx
+++ b/docs-site/src/app/components/sidebar-component/Sidebar.stories.tsx
@@ -2,7 +2,7 @@ import { Sidebar } from '@refraction-ui/react-sidebar'
 import { SidebarExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Sidebar' }
+const meta = { title: 'Navigation/Sidebar' }
 export default meta
 
 export const Basic = { render: () => <SidebarExamples section="basic" /> }

--- a/docs-site/src/app/components/skeleton/Skeleton.stories.tsx
+++ b/docs-site/src/app/components/skeleton/Skeleton.stories.tsx
@@ -1,7 +1,7 @@
 import { SkeletonExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Skeleton' }
+const meta = { title: 'Feedback/Skeleton' }
 export default meta
 
 export const Shapes = { render: () => <SkeletonExamples section="shapes" /> }

--- a/docs-site/src/app/components/skip-to-content/SkipToContent.stories.tsx
+++ b/docs-site/src/app/components/skip-to-content/SkipToContent.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SkipToContent } from '@refraction-ui/react-skip-to-content';
 
 const meta: Meta<typeof SkipToContent> = {
-  title: 'Components/SkipToContent',
+  title: 'Navigation/SkipToContent',
   component: SkipToContent,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/slide-viewer/SlideViewer.stories.tsx
+++ b/docs-site/src/app/components/slide-viewer/SlideViewer.stories.tsx
@@ -1,7 +1,7 @@
 import { SlideViewerExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SlideViewer' }
+const meta = { title: 'Data Display/SlideViewer' }
 export default meta
 
 export const Basic = { render: () => <SlideViewerExamples section="basic" /> }

--- a/docs-site/src/app/components/slider/Slider.stories.tsx
+++ b/docs-site/src/app/components/slider/Slider.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Slider } from '@refraction-ui/react-slider';
 
 const meta: Meta<typeof Slider> = {
-  title: 'Components/Slider',
+  title: 'Inputs/Slider',
   component: Slider,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/slot-picker/SlotPicker.stories.tsx
+++ b/docs-site/src/app/components/slot-picker/SlotPicker.stories.tsx
@@ -1,7 +1,7 @@
 import { SlotPickerExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SlotPicker' }
+const meta = { title: 'Inputs/SlotPicker' }
 export default meta
 
 export const Basic = { render: () => <SlotPickerExamples section="basic" /> }

--- a/docs-site/src/app/components/social-auth-button/SocialAuthButton.stories.tsx
+++ b/docs-site/src/app/components/social-auth-button/SocialAuthButton.stories.tsx
@@ -1,7 +1,7 @@
 import { SocialAuthButtonExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SocialAuthButton' }
+const meta = { title: 'Utilities/SocialAuthButton' }
 export default meta
 
 export const Basic = { render: () => <SocialAuthButtonExamples section="basic" /> }

--- a/docs-site/src/app/components/sortable-list/SortableList.stories.tsx
+++ b/docs-site/src/app/components/sortable-list/SortableList.stories.tsx
@@ -1,7 +1,7 @@
 import { SortableListExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/SortableList' }
+const meta = { title: 'Data Display/SortableList' }
 export default meta
 
 export const Basic = { render: () => <SortableListExamples section="basic" /> }

--- a/docs-site/src/app/components/stat-grid/StatGrid.stories.tsx
+++ b/docs-site/src/app/components/stat-grid/StatGrid.stories.tsx
@@ -1,7 +1,7 @@
 import { StatGridExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/StatGrid' }
+const meta = { title: 'Marketing/StatGrid' }
 export default meta
 
 export const ThreeStats = { render: () => <StatGridExamples section="three-stats" /> }

--- a/docs-site/src/app/components/status-indicator/StatusIndicator.stories.tsx
+++ b/docs-site/src/app/components/status-indicator/StatusIndicator.stories.tsx
@@ -1,7 +1,7 @@
 import { StatusIndicatorExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/StatusIndicator' }
+const meta = { title: 'Data Display/StatusIndicator' }
 export default meta
 
 export const Basic = { render: () => <StatusIndicatorExamples section="basic" /> }

--- a/docs-site/src/app/components/steps/Steps.stories.tsx
+++ b/docs-site/src/app/components/steps/Steps.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Steps } from '@refraction-ui/react-steps';
 
 const meta: Meta<typeof Steps> = {
-  title: 'Components/Steps',
+  title: 'Navigation/Steps',
   component: Steps,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/sticky-note/StickyNote.stories.tsx
+++ b/docs-site/src/app/components/sticky-note/StickyNote.stories.tsx
@@ -1,7 +1,7 @@
 import { StickyNoteExamples } from './examples'
 
 // Stories generated from the docs-site examples.
-const meta = { title: 'Components/StickyNote' }
+const meta = { title: 'Layout/StickyNote' }
 export default meta
 
 export const Colors = { render: () => <StickyNoteExamples section="colors" /> }

--- a/docs-site/src/app/components/switch/Switch.stories.tsx
+++ b/docs-site/src/app/components/switch/Switch.stories.tsx
@@ -1,7 +1,7 @@
 import { SwitchExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Switch' }
+const meta = { title: 'Inputs/Switch' }
 export default meta
 
 export const Sizes = { render: () => <SwitchExamples section="sizes" /> }

--- a/docs-site/src/app/components/table-of-contents/TableOfContents.stories.tsx
+++ b/docs-site/src/app/components/table-of-contents/TableOfContents.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { TableOfContents } from '@refraction-ui/react-table-of-contents';
 
 const meta: Meta<typeof TableOfContents> = {
-  title: 'Components/TableOfContents',
+  title: 'Navigation/TableOfContents',
   component: TableOfContents,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/tabs/Tabs.stories.tsx
+++ b/docs-site/src/app/components/tabs/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import { TabsExample } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Tabs' }
+const meta = { title: 'Navigation/Tabs' }
 export default meta
 
 export const Default = { render: () => <TabsExample /> }

--- a/docs-site/src/app/components/terminal/Terminal.stories.tsx
+++ b/docs-site/src/app/components/terminal/Terminal.stories.tsx
@@ -1,7 +1,7 @@
 import { TerminalExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Terminal' }
+const meta = { title: 'Editors & IDE/Terminal' }
 export default meta
 
 export const BasicRunOutput = {

--- a/docs-site/src/app/components/test-results/TestResults.stories.tsx
+++ b/docs-site/src/app/components/test-results/TestResults.stories.tsx
@@ -1,7 +1,7 @@
 import { TestResultsExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/TestResults' }
+const meta = { title: 'Editors & IDE/TestResults' }
 export default meta
 
 export const AllPassing = {

--- a/docs-site/src/app/components/textarea/Textarea.stories.tsx
+++ b/docs-site/src/app/components/textarea/Textarea.stories.tsx
@@ -1,7 +1,7 @@
 import { TextareaExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Textarea' }
+const meta = { title: 'Inputs/Textarea' }
 export default meta
 
 export const Sizes = { render: () => <TextareaExamples section="sizes" /> }

--- a/docs-site/src/app/components/thread-view/ThreadView.stories.tsx
+++ b/docs-site/src/app/components/thread-view/ThreadView.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ThreadView } from '@refraction-ui/react-thread-view';
 
 const meta: Meta<typeof ThreadView> = {
-  title: 'Components/ThreadView',
+  title: 'Chat & AI/ThreadView',
   component: ThreadView,
   parameters: {
     layout: 'centered',

--- a/docs-site/src/app/components/timeline/Timeline.stories.tsx
+++ b/docs-site/src/app/components/timeline/Timeline.stories.tsx
@@ -1,7 +1,7 @@
 import { TimelineExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Timeline' }
+const meta = { title: 'Data Display/Timeline' }
 export default meta
 
 export const Vertical = { render: () => <TimelineExamples section="vertical" /> }

--- a/docs-site/src/app/components/toast/Toast.stories.tsx
+++ b/docs-site/src/app/components/toast/Toast.stories.tsx
@@ -1,7 +1,7 @@
 import { ToastExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Toast' }
+const meta = { title: 'Feedback/Toast' }
 export default meta
 
 export const Default = { render: () => <ToastExamples /> }

--- a/docs-site/src/app/components/tooltip/Tooltip.stories.tsx
+++ b/docs-site/src/app/components/tooltip/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { TooltipExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Tooltip' }
+const meta = { title: 'Overlays/Tooltip' }
 export default meta
 
 export const Basic = { render: () => <TooltipExamples section="basic" /> }

--- a/docs-site/src/app/components/version-selector/VersionSelector.stories.tsx
+++ b/docs-site/src/app/components/version-selector/VersionSelector.stories.tsx
@@ -1,7 +1,7 @@
 import { VersionSelectorExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/VersionSelector' }
+const meta = { title: 'Inputs/VersionSelector' }
 export default meta
 
 export const Basic = {

--- a/docs-site/src/app/components/video-grid/VideoGrid.stories.tsx
+++ b/docs-site/src/app/components/video-grid/VideoGrid.stories.tsx
@@ -1,7 +1,7 @@
 import { VideoGridExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/VideoGrid' }
+const meta = { title: 'Calls & Media/VideoGrid' }
 export default meta
 
 export const SmallGroup = {

--- a/docs-site/src/app/components/video-player/VideoPlayer.stories.tsx
+++ b/docs-site/src/app/components/video-player/VideoPlayer.stories.tsx
@@ -1,7 +1,7 @@
 import { VideoPlayerExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/VideoPlayer' }
+const meta = { title: 'Calls & Media/VideoPlayer' }
 export default meta
 
 export const Basic = { render: () => <VideoPlayerExamples section="basic" /> }

--- a/docs-site/src/app/components/video-tile/VideoTile.stories.tsx
+++ b/docs-site/src/app/components/video-tile/VideoTile.stories.tsx
@@ -1,7 +1,7 @@
 import { VideoTileExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/VideoTile' }
+const meta = { title: 'Calls & Media/VideoTile' }
 export default meta
 
 export const Basic = { render: () => <VideoTileExamples section="basic" /> }

--- a/docs-site/src/app/components/voice-pill/VoicePill.stories.tsx
+++ b/docs-site/src/app/components/voice-pill/VoicePill.stories.tsx
@@ -1,7 +1,7 @@
 import { VoicePillExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/VoicePill' }
+const meta = { title: 'Calls & Media/VoicePill' }
 export default meta
 
 export const Basic = { render: () => <VoicePillExamples section="basic" /> }

--- a/docs-site/src/app/components/waveform/Waveform.stories.tsx
+++ b/docs-site/src/app/components/waveform/Waveform.stories.tsx
@@ -1,7 +1,7 @@
 import { WaveformExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Waveform' }
+const meta = { title: 'Calls & Media/Waveform' }
 export default meta
 
 export const Basic = { render: () => <WaveformExamples section="basic" /> }

--- a/docs-site/src/app/components/wizard/Wizard.stories.tsx
+++ b/docs-site/src/app/components/wizard/Wizard.stories.tsx
@@ -1,7 +1,7 @@
 import { WizardExamples } from './examples'
 
 // Generated from the docs-site example (curated, real props/content).
-const meta = { title: 'Components/Wizard' }
+const meta = { title: 'Navigation/Wizard' }
 export default meta
 
 export const Basic = { render: () => <WizardExamples section="basic" /> }

--- a/packages/react-ai/src/Ai.stories.tsx
+++ b/packages/react-ai/src/Ai.stories.tsx
@@ -1,5 +1,5 @@
 // @refraction-ui/react-ai is a headless provider/hook package — no standalone UI.
-export default { title: 'Components/Ai' }
+export default { title: 'Chat & AI/Ai' }
 
 export const Overview = {
   render: () => (

--- a/packages/react-analytics/src/Analytics.stories.tsx
+++ b/packages/react-analytics/src/Analytics.stories.tsx
@@ -1,5 +1,5 @@
 // @refraction-ui/react-analytics is a headless provider/hook package — no standalone UI.
-export default { title: 'Components/Analytics' }
+export default { title: 'Utilities/Analytics' }
 
 export const Overview = {
   render: () => (

--- a/packages/react-auth/src/Auth.stories.tsx
+++ b/packages/react-auth/src/Auth.stories.tsx
@@ -1,5 +1,5 @@
 // @refraction-ui/react-auth is a headless provider/hook package — no standalone UI.
-export default { title: 'Components/Auth' }
+export default { title: 'Utilities/Auth' }
 
 export const Overview = {
   render: () => (

--- a/packages/react-logger/src/Logger.stories.tsx
+++ b/packages/react-logger/src/Logger.stories.tsx
@@ -1,5 +1,5 @@
 // @refraction-ui/react-logger is a headless provider/hook package — no standalone UI.
-export default { title: 'Components/Logger' }
+export default { title: 'Utilities/Logger' }
 
 export const Overview = {
   render: () => (

--- a/packages/react-mascot/src/Mascot.stories.tsx
+++ b/packages/react-mascot/src/Mascot.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Mascot } from './mascot.js'
 
 const meta: Meta<typeof Mascot> = {
-  title: 'Components/Mascot',
+  title: 'Marketing/Mascot',
   component: Mascot,
   argTypes: {
     mood: {

--- a/packages/react-meta/CHANGELOG.md
+++ b/packages/react-meta/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- e05f851: SlideViewer: arrow-key navigation (ArrowRight/ArrowLeft) now actually re-renders the component — previously the headless state advanced and `onSlideChange` fired, but the slide counter, progress bar, content, and button states stayed stale until the next click.
+- 76a8ae1: Composer: the suggestion menu (`@` mentions, `/` commands, `:emoji:`) now opens on whichever side of the composer has more viewport space — previously it always opened above, which could render it off-screen when the composer sat near the top of the viewport. The menu also caps its height to the available space and scrolls.
 
 ## 0.18.0
 

--- a/packages/react-theme/src/Theme.stories.tsx
+++ b/packages/react-theme/src/Theme.stories.tsx
@@ -4,7 +4,7 @@
  */
 import * as React from 'react'
 
-export default { title: 'Components/Theme' }
+export default { title: 'Utilities/Theme' }
 
 interface DocCardProps {
   title: string


### PR DESCRIPTION
## Summary

All 272 stories sat flat under a single `Components/` group — 126 components in one alphabetical pile. This retitles every story to `<Category>/<Name>`, organizing the sidebar into 11 purpose-based sections:

| Section | Count | Examples |
|---|---|---|
| Inputs | 48 | Button, Select, Switch, OtpInput, DatePicker, Payment |
| Data Display | 54 | Card, Charts, DataTable, Timeline, KanbanBoard |
| Calls & Media | 31 | VideoPlayer/Grid/Tile, AudioRoom, CallControls, Waveform |
| Marketing | 28 | PricingCard, StatGrid, SectionHead, Mascot |
| Navigation | 25 | Accordion, AppShell, Navbar, Tabs, Wizard |
| Layout | 22 | Collapsible, ResizableLayout, InfiniteCanvas, StickyNote |
| Chat & AI | 17 | Composer, Chat, ThreadView, RichEditor |
| Utilities | 15 | Theme, Logger, EmojiPicker, Auth |
| Editors & IDE | 13 | CodeEditor, EditorTabs, Terminal, TestResults |
| Feedback | 13 | Toast, Dialog, Skeleton, EmptyState |
| Overlays | 6 | DropdownMenu, Popover, Sheet, Tooltip |

## Details

- One-line `title:` change per story file (126 files); component names preserved verbatim.
- Verified against the live Storybook index: 11 groups, **0 ungrouped stories**.
- CLAUDE.md's component playbook now requires the `<Category>/<Name>` title form for future stories.
- No ID-breaking side effects: Lost Pixel baselines are keyed by docs-page paths (unchanged), and the e2e suite targets docs pages, not story IDs.

## Out of scope (flagged by the review agents)

- `packages/flutter-docs-site/**` and the Astro storybook (`.storybook-astro`) mirror the same flat `Components/` titles — can get the same treatment in a follow-up if wanted.