### PR TITLE
fix(react): adapter standards — forwardRef coverage, ARIA typing, onSelect Omit, SSR strings

### DIFF
--- a/.changeset/adapter-standards-fixes.md
+++ b/.changeset/adapter-standards-fixes.md
@@ -1,0 +1,13 @@
+---
+"@refraction-ui/react": patch
+---
+
+Adapter standards fixes across the React adapter packages (all ride the `@refraction-ui/react` meta):
+
+- **forwardRef coverage**: root components in avatar-group, calendar (Calendar + CalendarHeader), conversation (Chat + Composer), cookie-consent, device-frame, emoji-picker, file-upload, inline-editor, language-selector, location-selector, app-shell (root + all subcomponents), keyboard-shortcut (ShortcutHint), radio (RadioGroup + RadioItem), search-bar (ref to the input), version-selector, reaction-bar, thread-view, presence-indicator, status-indicator, and tabs now forward refs to their root element; `TabsProps` now extends `React.HTMLAttributes<HTMLDivElement>` and spreads rest props.
+- **charts**: all chart components (Chart, Bars, Circles, Gradient, Histogram, Line, PieChart, ScatterPlot, XAxis, YAxis) accept `className`, forwarded to the root `<svg>`/`<g>`.
+- **call-controls**: core `ariaProps` retyped from `Partial<AccessibilityProps>` to `Record<string, string | number | boolean>`; the adapter spreads `{...api.ariaProps}` directly without an `as React.AriaAttributes` cast.
+- **command / dropdown-menu**: `CommandItemProps`/`DropdownMenuItemProps` now `Omit` the DOM-colliding `onSelect` from `React.HTMLAttributes`, fixing a consumer-facing type break.
+- **diff-viewer**: status-bar strings render as single template literals (SSR-safe composed output).
+- **core ARIA typing**: thread-view, voice-pill, device-frame, reaction-bar, emoji-picker, presence-indicator, and status-indicator cores return `Record<string, string | number | boolean>` instead of `Record<string, unknown>`.
+- **payment**: added missing vitest wiring (test script + config) and an SSR renderToString test.

--- a/packages/call-controls/src/call-controls.ts
+++ b/packages/call-controls/src/call-controls.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 /** Visual/semantic tone of a call control button. */
 export type CallControlTone = 'default' | 'active' | 'destructive'
 
@@ -33,7 +31,7 @@ export interface CallControlsProps {
 
 export interface CallControlsAPI {
   /** ARIA attributes to spread on the toolbar element (`role="toolbar"`). */
-  ariaProps: Partial<AccessibilityProps>
+  ariaProps: Record<string, string | number | boolean>
   /** Data attributes for styling hooks. */
   dataAttributes: Record<string, string>
 }
@@ -66,7 +64,7 @@ export function controlTone(
  * attributes; adapters spread these onto their container element.
  */
 export function createCallControls(_props: CallControlsProps = {}): CallControlsAPI {
-  const ariaProps: Partial<AccessibilityProps> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'toolbar',
     'aria-label': 'Call controls',
   }

--- a/packages/device-frame/src/device-frame.ts
+++ b/packages/device-frame/src/device-frame.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 export type DeviceType = 'iphone' | 'ipad' | 'android-phone' | 'android-tablet'
 export type DeviceOrientation = 'portrait' | 'landscape'
 
@@ -27,7 +25,7 @@ export interface DeviceFrameAPI {
   /** Computed dimensions for the device */
   dimensions: DeviceDimensions
   /** ARIA attributes for the device frame */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** Data attributes for styling hooks */
   dataAttributes: Record<string, string>
 }
@@ -92,7 +90,7 @@ export function createDeviceFrame(props: DeviceFrameProps): DeviceFrameAPI {
     homeIndicator: spec.homeIndicator,
   }
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'img',
     'aria-label': `${DEVICE_LABELS[device]} device frame in ${orientation} orientation`,
   }

--- a/packages/emoji-picker/src/emoji-picker.ts
+++ b/packages/emoji-picker/src/emoji-picker.ts
@@ -1,4 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
 import { generateId } from '@refraction-ui/shared'
 import {
   EMOJI_DATA,
@@ -39,7 +38,7 @@ export interface EmojiPickerAPI {
   /** Category tabs with labels */
   categoryTabs: { category: EmojiCategory; label: string; emoji: string }[]
   /** ARIA props for the picker container */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** ARIA props for the search input */
   searchInputProps: Record<string, unknown>
   /** Get ARIA props for an emoji button */
@@ -118,7 +117,7 @@ export function createEmojiPicker(props: EmojiPickerProps = {}): EmojiPickerAPI 
     emoji: CATEGORY_ICONS[cat],
   }))
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'dialog',
     'aria-labelledby': labelId,
     id: containerId,

--- a/packages/presence-indicator/src/presence-indicator.ts
+++ b/packages/presence-indicator/src/presence-indicator.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 export type PresenceStatus = 'online' | 'offline' | 'away' | 'busy' | 'dnd'
 
 export interface PresenceProps {
@@ -13,7 +11,7 @@ export interface PresenceProps {
 
 export interface PresenceAPI {
   /** ARIA attributes for the indicator */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** CSS color for the status dot */
   color: string
   /** Human-readable label for the status */
@@ -48,7 +46,7 @@ export function createPresence(props: PresenceProps): PresenceAPI {
   const color = STATUS_COLORS[status]
   const label = labelOverride ?? STATUS_LABELS[status]
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'status',
     'aria-label': label,
   }

--- a/packages/react-app-shell/src/app-shell.tsx
+++ b/packages/react-app-shell/src/app-shell.tsx
@@ -41,7 +41,8 @@ export interface AppShellProps {
   className?: string
 }
 
-function AppShellRoot({ config, children, className }: AppShellProps) {
+const AppShellRoot = React.forwardRef<HTMLDivElement, AppShellProps>(
+  ({ config, children, className }, ref) => {
   // Create the headless API once
   const apiRef = React.useRef<AppShellAPI | null>(null)
   if (apiRef.current === null) {
@@ -100,6 +101,7 @@ function AppShellRoot({ config, children, className }: AppShellProps) {
     React.createElement(
       'div',
       {
+        ref,
         className: cn('flex h-screen w-full overflow-hidden', className),
         style: cssVars as React.CSSProperties,
         'data-shell': '',
@@ -107,7 +109,8 @@ function AppShellRoot({ config, children, className }: AppShellProps) {
       children,
     ),
   )
-}
+  },
+)
 
 AppShellRoot.displayName = 'AppShell'
 
@@ -120,7 +123,8 @@ export interface AppShellSidebarProps {
   className?: string
 }
 
-function Sidebar({ children, className }: AppShellSidebarProps) {
+const Sidebar = React.forwardRef<HTMLElement, AppShellSidebarProps>(
+  ({ children, className }, ref) => {
   const { api, state } = useAppShell()
   const isRight = api.config.sidebarPosition === 'right'
 
@@ -153,6 +157,7 @@ function Sidebar({ children, className }: AppShellSidebarProps) {
   return React.createElement(
     'aside',
     {
+      ref,
       ...api.sidebarAriaProps,
       className: cn(baseClasses.join(' '), mobileClasses.join(' '), className),
       'data-collapsed': state.sidebarCollapsed ? '' : undefined,
@@ -160,7 +165,8 @@ function Sidebar({ children, className }: AppShellSidebarProps) {
     },
     children,
   )
-}
+  },
+)
 
 Sidebar.displayName = 'AppShell.Sidebar'
 
@@ -173,15 +179,18 @@ export interface AppShellMainProps {
   className?: string
 }
 
-function Main({ children, className }: AppShellMainProps) {
+const Main = React.forwardRef<HTMLDivElement, AppShellMainProps>(
+  ({ children, className }, ref) => {
   return React.createElement(
     'div',
     {
+      ref,
       className: cn('flex flex-1 flex-col min-w-0 h-full', className),
     },
     children,
   )
-}
+  },
+)
 
 Main.displayName = 'AppShell.Main'
 
@@ -194,7 +203,8 @@ export interface AppShellHeaderProps {
   className?: string
 }
 
-function Header({ children, className }: AppShellHeaderProps) {
+const Header = React.forwardRef<HTMLElement, AppShellHeaderProps>(
+  ({ children, className }, ref) => {
   const { api, state } = useAppShell()
 
   const hamburger = state.isMobile
@@ -232,6 +242,7 @@ function Header({ children, className }: AppShellHeaderProps) {
   return React.createElement(
     'header',
     {
+      ref,
       ...api.headerAriaProps,
       className: cn(
         'sticky top-0 z-30 flex items-center shrink-0',
@@ -243,7 +254,8 @@ function Header({ children, className }: AppShellHeaderProps) {
     hamburger,
     children,
   )
-}
+  },
+)
 
 Header.displayName = 'AppShell.Header'
 
@@ -258,13 +270,15 @@ export interface AppShellContentProps {
   maxWidth?: string
 }
 
-function Content({ children, className, maxWidth }: AppShellContentProps) {
+const Content = React.forwardRef<HTMLElement, AppShellContentProps>(
+  ({ children, className, maxWidth }, ref) => {
   const { api } = useAppShell()
   const mwClass = maxWidth ? `max-w-${maxWidth}` : ''
 
   return React.createElement(
     'main',
     {
+      ref,
       ...api.mainAriaProps,
       className: cn(
         'flex-1 overflow-y-auto',
@@ -275,7 +289,8 @@ function Content({ children, className, maxWidth }: AppShellContentProps) {
     },
     children,
   )
-}
+  },
+)
 
 Content.displayName = 'AppShell.Content'
 
@@ -288,7 +303,8 @@ export interface AppShellMobileNavProps {
   className?: string
 }
 
-function MobileNav({ children, className }: AppShellMobileNavProps) {
+const MobileNav = React.forwardRef<HTMLElement, AppShellMobileNavProps>(
+  ({ children, className }, ref) => {
   const { api, state } = useAppShell()
 
   if (!state.isMobile) return null
@@ -297,6 +313,7 @@ function MobileNav({ children, className }: AppShellMobileNavProps) {
   return React.createElement(
     'nav',
     {
+      ref,
       ...api.mobileNavAriaProps,
       className: cn(
         'fixed bottom-0 left-0 right-0 z-30',
@@ -308,7 +325,8 @@ function MobileNav({ children, className }: AppShellMobileNavProps) {
     },
     children,
   )
-}
+  },
+)
 
 MobileNav.displayName = 'AppShell.MobileNav'
 
@@ -320,12 +338,14 @@ export interface AppShellOverlayProps {
   className?: string
 }
 
-function Overlay({ className }: AppShellOverlayProps) {
+const Overlay = React.forwardRef<HTMLDivElement, AppShellOverlayProps>(
+  ({ className }, ref) => {
   const { api, state } = useAppShell()
 
   if (!state.isMobile || !state.sidebarOpen) return null
 
   return React.createElement('div', {
+    ref,
     ...api.overlayAriaProps,
     className: cn(
       'fixed inset-0 z-30 bg-black/50 transition-opacity',
@@ -334,7 +354,8 @@ function Overlay({ className }: AppShellOverlayProps) {
     onClick: () => api.closeSidebar(),
     'data-shell-overlay': '',
   })
-}
+  },
+)
 
 Overlay.displayName = 'AppShell.Overlay'
 

--- a/packages/react-auth/__tests__/auth.test.tsx
+++ b/packages/react-auth/__tests__/auth.test.tsx
@@ -60,9 +60,10 @@ describe('AuthGuard (SSR)', () => {
         ),
       ),
     )
-    // Mock adapter starts unauthenticated on SSR (no user)
-    // Either shows fallback or protected depending on mock timing
-    expect(html).toBeDefined()
+    // Mock adapter never fires onAuthStateChange, so SSR stays unauthenticated
+    // and the guard renders the fallback.
+    expect(html).toContain('Loading...')
+    expect(html).not.toContain('Protected')
   })
 })
 

--- a/packages/react-avatar-group/src/avatar-group.tsx
+++ b/packages/react-avatar-group/src/avatar-group.tsx
@@ -18,12 +18,13 @@ export interface AvatarGroupProps {
   className?: string
 }
 
-export function AvatarGroup({ users, max, size = 'md', className }: AvatarGroupProps) {
+export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ users, max, size = 'md', className }, ref) => {
   const api = createAvatarGroup({ users, max, size })
 
   return React.createElement(
     'div',
-    { ...api.ariaProps, className: cn(avatarGroupStyles, className) },
+    { ref, ...api.ariaProps, className: cn(avatarGroupStyles, className) },
     api.visibleUsers.map((user) =>
       React.createElement(
         'div',
@@ -55,6 +56,7 @@ export function AvatarGroup({ users, max, size = 'md', className }: AvatarGroupP
         `+${api.overflowCount}`,
       ),
   )
-}
+  },
+)
 
 AvatarGroup.displayName = 'AvatarGroup'

--- a/packages/react-calendar/src/calendar.tsx
+++ b/packages/react-calendar/src/calendar.tsx
@@ -24,17 +24,8 @@ const MONTH_NAMES = [
 
 const DAY_HEADERS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
-export function Calendar({
-  className,
-  value,
-  defaultValue,
-  onSelect,
-  month,
-  onMonthChange,
-  minDate,
-  maxDate,
-  disabledDates,
-}: CalendarProps) {
+export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
+  ({ className, value, defaultValue, onSelect, month, onMonthChange, minDate, maxDate, disabledDates }: CalendarProps, ref) => {
   const [uncontrolledValue, setUncontrolledValue] = React.useState<Date | undefined>(defaultValue)
   const [uncontrolledMonth, setUncontrolledMonth] = React.useState<Date>(
     () => month ?? value ?? defaultValue ?? new Date(),
@@ -89,6 +80,7 @@ export function Calendar({
   return React.createElement(
     'div',
     {
+      ref,
       className: cn(calendarVariants(), className),
       ...api.ariaProps,
     },
@@ -144,7 +136,8 @@ export function Calendar({
       }),
     ),
   )
-}
+  },
+)
 
 Calendar.displayName = 'Calendar'
 
@@ -160,16 +153,12 @@ export interface CalendarHeaderProps {
   className?: string
 }
 
-export function CalendarHeader({
-  label,
-  labelId,
-  onPrevMonth,
-  onNextMonth,
-  className,
-}: CalendarHeaderProps) {
+export const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
+  ({ label, labelId, onPrevMonth, onNextMonth, className }, ref) => {
   return React.createElement(
     'div',
     {
+      ref,
       className: cn('flex items-center justify-between mb-2', className),
     },
     React.createElement(
@@ -202,6 +191,7 @@ export function CalendarHeader({
       '\u203A',
     ),
   )
-}
+  },
+)
 
 CalendarHeader.displayName = 'CalendarHeader'

--- a/packages/react-call-controls/src/call-controls.tsx
+++ b/packages/react-call-controls/src/call-controls.tsx
@@ -100,7 +100,7 @@ export const CallControls = React.forwardRef<HTMLDivElement, CallControlsProps>(
       <div
         ref={ref}
         className={cn(callControlsVariants({ size }), className)}
-        {...(api.ariaProps as React.AriaAttributes & { role: string })}
+        {...api.ariaProps}
         {...api.dataAttributes}
         {...props}
       >

--- a/packages/react-charts/src/bars.tsx
+++ b/packages/react-charts/src/bars.tsx
@@ -7,9 +7,10 @@ export interface BarsProps<T = unknown> {
   x: (d: T) => string
   y: (d: T) => number
   fill?: string
+  className?: string
 }
 
-export function Bars<T>({ data, x, y, fill = 'currentColor' }: BarsProps<T>) {
+export function Bars<T>({ data, x, y, fill = 'currentColor', className }: BarsProps<T>) {
   const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
 
@@ -21,7 +22,7 @@ export function Bars<T>({ data, x, y, fill = 'currentColor' }: BarsProps<T>) {
   const yScale = createLinearScale([0, maxVal], [boundedHeight, 0])
 
   return (
-    <g>
+    <g className={className}>
       {data.map((d, i) => {
         const label = labels[i]
         const value = values[i]

--- a/packages/react-charts/src/chart.tsx
+++ b/packages/react-charts/src/chart.tsx
@@ -8,6 +8,7 @@ export interface ChartProps {
   height?: number
   margin?: Partial<Margin>
   children?: React.ReactNode
+  className?: string
 }
 
 export function Chart({
@@ -15,11 +16,12 @@ export function Chart({
   height = 400,
   margin,
   children,
+  className,
 }: ChartProps) {
   const dimensions = combineDimensions({ width, height, margin })
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} className={className}>
       <ChartContext.Provider value={{ dimensions }}>
         <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
           {children}

--- a/packages/react-charts/src/circles.tsx
+++ b/packages/react-charts/src/circles.tsx
@@ -8,6 +8,7 @@ export interface CirclesProps<T = unknown> {
   cy: (d: T) => number
   r?: number
   fill?: string
+  className?: string
 }
 
 export function Circles<T>({
@@ -16,6 +17,7 @@ export function Circles<T>({
   cy,
   r = 4,
   fill = 'currentColor',
+  className,
 }: CirclesProps<T>) {
   const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
@@ -29,7 +31,7 @@ export function Circles<T>({
   const yScale = createLinearScale([yMin, yMax], [boundedHeight, 0])
 
   return (
-    <g>
+    <g className={className}>
       {data.map((d, i) => (
         <circle
           key={i}

--- a/packages/react-charts/src/gradient.tsx
+++ b/packages/react-charts/src/gradient.tsx
@@ -5,6 +5,7 @@ export interface GradientProps {
   from: string
   to: string
   direction?: 'vertical' | 'horizontal'
+  className?: string
 }
 
 export function Gradient({
@@ -12,11 +13,12 @@ export function Gradient({
   from,
   to,
   direction = 'vertical',
+  className,
 }: GradientProps) {
   const isVertical = direction === 'vertical'
 
   return (
-    <defs>
+    <defs className={className}>
       <linearGradient
         id={id}
         x1="0"

--- a/packages/react-charts/src/histogram.tsx
+++ b/packages/react-charts/src/histogram.tsx
@@ -15,6 +15,7 @@ export interface HistogramProps {
   bins?: number
   fill?: string
   margin?: Partial<Margin>
+  className?: string
 }
 
 export function Histogram({
@@ -24,6 +25,7 @@ export function Histogram({
   bins: binCount = 10,
   fill = 'steelblue',
   margin,
+  className,
 }: HistogramProps) {
   const dimensions = combineDimensions({ width, height, margin })
   const { boundedWidth, boundedHeight } = dimensions
@@ -38,7 +40,7 @@ export function Histogram({
   const yTicks = yScale.ticks(5)
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} className={className}>
       <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
         {histBins.map((bin, i) => {
           const label = labels[i]

--- a/packages/react-charts/src/line.tsx
+++ b/packages/react-charts/src/line.tsx
@@ -9,6 +9,7 @@ export interface LineProps<T = unknown> {
   stroke?: string
   strokeWidth?: number
   fill?: string
+  className?: string
 }
 
 export function Line<T>({
@@ -18,6 +19,7 @@ export function Line<T>({
   stroke = 'currentColor',
   strokeWidth = 2,
   fill = 'none',
+  className,
 }: LineProps<T>) {
   const { dimensions } = useChartContext()
   const { boundedWidth, boundedHeight } = dimensions
@@ -39,6 +41,7 @@ export function Line<T>({
 
   return (
     <path
+      className={className}
       d={d}
       stroke={stroke}
       strokeWidth={strokeWidth}

--- a/packages/react-charts/src/pie-chart.tsx
+++ b/packages/react-charts/src/pie-chart.tsx
@@ -13,6 +13,7 @@ export interface PieChartProps<T = unknown> {
   width?: number
   height?: number
   colors?: string[]
+  className?: string
 }
 
 export function PieChart<T>({
@@ -21,6 +22,7 @@ export function PieChart<T>({
   width = 300,
   height = 300,
   colors = DEFAULT_COLORS,
+  className,
 }: PieChartProps<T>) {
   const cx = width / 2
   const cy = height / 2
@@ -40,7 +42,7 @@ export function PieChart<T>({
   })
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} className={className}>
       {arcs.map((arc, i) => (
         <path
           key={i}

--- a/packages/react-charts/src/scatter-plot.tsx
+++ b/packages/react-charts/src/scatter-plot.tsx
@@ -16,6 +16,7 @@ export interface ScatterPlotProps<T = unknown> {
   r?: number
   fill?: string
   margin?: Partial<Margin>
+  className?: string
 }
 
 export function ScatterPlot<T>({
@@ -27,6 +28,7 @@ export function ScatterPlot<T>({
   r = 4,
   fill = 'steelblue',
   margin,
+  className,
 }: ScatterPlotProps<T>) {
   const dimensions = combineDimensions({ width, height, margin })
   const { boundedWidth, boundedHeight } = dimensions
@@ -43,7 +45,7 @@ export function ScatterPlot<T>({
   const yTicks = yScale.ticks(5)
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} className={className}>
       <g transform={`translate(${dimensions.margin.left},${dimensions.margin.top})`}>
         {data.map((d, i) => (
           <circle

--- a/packages/react-charts/src/x-axis.tsx
+++ b/packages/react-charts/src/x-axis.tsx
@@ -5,6 +5,7 @@ export interface XAxisProps {
   scale: (value: number | string) => number
   height: number
   tickSize?: number
+  className?: string
 }
 
 export function XAxis({
@@ -12,9 +13,10 @@ export function XAxis({
   scale,
   height,
   tickSize = 6,
+  className,
 }: XAxisProps) {
   return (
-    <g transform={`translate(0,${height})`}>
+    <g className={className} transform={`translate(0,${height})`}>
       {ticks.map((tick, i) => {
         const x = scale(tick)
         return (

--- a/packages/react-charts/src/y-axis.tsx
+++ b/packages/react-charts/src/y-axis.tsx
@@ -4,15 +4,17 @@ export interface YAxisProps {
   ticks: (number | string)[]
   scale: (value: number | string) => number
   tickSize?: number
+  className?: string
 }
 
 export function YAxis({
   ticks,
   scale,
   tickSize = 6,
+  className,
 }: YAxisProps) {
   return (
-    <g>
+    <g className={className}>
       {ticks.map((tick, i) => {
         const y = scale(tick)
         return (

--- a/packages/react-command/src/command.tsx
+++ b/packages/react-command/src/command.tsx
@@ -282,7 +282,7 @@ CommandGroup.displayName = 'CommandGroup'
 // CommandItem
 // ---------------------------------------------------------------------------
 
-export interface CommandItemProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CommandItemProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
   value?: string
   disabled?: boolean
   onSelect?: () => void

--- a/packages/react-conversation/src/chat.tsx
+++ b/packages/react-conversation/src/chat.tsx
@@ -418,19 +418,8 @@ function ModeToggle({ conversation }: { conversation: UseConversationResult }) {
  * bubble. Markdown/code/gifs, reactions, edit/delete, streaming, and a composer
  * with `/` commands, `@` mentions, `:` emoji, and a formatting toolbar.
  */
-export function Chat({
-  conversation,
-  showConversationList = true,
-  showModeToggle = true,
-  placeholder,
-  currentUserId,
-  emptyState,
-  className,
-  slashCommands,
-  mentions,
-  onSlashCommand,
-  composerToolbar = true,
-}: ChatProps) {
+export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
+  ({ conversation, showConversationList = true, showModeToggle = true, placeholder, currentUserId, emptyState, className, slashCommands, mentions, onSlashCommand, composerToolbar = true }: ChatProps, ref) => {
   const { state, sendMessage } = conversation
   const timeline = selectMainTimeline(state.messages, state.threadingMode)
   const activeConv = state.conversations.find((c) => c.id === state.activeConversationId)
@@ -489,7 +478,7 @@ export function Chat({
 
   return h(
     'div',
-    { className: cn('flex h-full min-h-0 overflow-hidden rounded-xl border border-border bg-background', className) },
+    { ref, className: cn('flex h-full min-h-0 overflow-hidden rounded-xl border border-border bg-background', className) },
     showConversationList ? h(ConversationSidebar, { conversation }) : null,
     h(
       'div',
@@ -505,4 +494,7 @@ export function Chat({
     ),
     h(ThreadPanel, { conversation, currentUserId, composer: threadComposer }),
   )
-}
+  },
+)
+
+Chat.displayName = 'Chat'

--- a/packages/react-conversation/src/composer.tsx
+++ b/packages/react-conversation/src/composer.tsx
@@ -159,27 +159,14 @@ function detectTrigger(text: string, caret: number): TriggerState | null {
  * Composer — rich message input: markdown formatting toolbar + Cmd/Ctrl shortcuts,
  * and `/` command, `@` mention, and `:` emoji autocomplete menus.
  */
-export function Composer({
-  placeholder = 'Send a message…',
-  busy = false,
-  slashCommands = [],
-  mentions,
-  toolbar = true,
-  emoji = true,
-  attachments = true,
-  error,
-  onRetry,
-  onSubmit,
-  onStop,
-  onSlashCommand,
-  autoFocus,
-}: ComposerProps) {
+export const Composer = React.forwardRef<HTMLDivElement, ComposerProps>(
+  ({ placeholder = 'Send a message…', busy = false, slashCommands = [], mentions, toolbar = true, emoji = true, attachments = true, error, onRetry, onSubmit, onStop, onSlashCommand, autoFocus }: ComposerProps, ref) => {
   const [value, setValue] = React.useState('')
   const [pending, setPending] = React.useState<MessageAttachment[]>([])
   const [trigger, setTrigger] = React.useState<TriggerState | null>(null)
   const [active, setActive] = React.useState(0)
   const [mentionItems, setMentionItems] = React.useState<Mention[]>([])
-  const ref = React.useRef<HTMLTextAreaElement>(null)
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null)
   const fileRef = React.useRef<HTMLInputElement>(null)
 
   // Resolve `@` mentions for the current query.
@@ -254,7 +241,7 @@ export function Composer({
 
   function queueCaret(pos: number) {
     requestAnimationFrame(() => {
-      const el = ref.current
+      const el = textareaRef.current
       if (!el) return
       el.focus()
       el.setSelectionRange(pos, pos)
@@ -263,7 +250,7 @@ export function Composer({
 
   /** Wrap or prefix the current selection for a toolbar action. */
   function format(kind: 'bold' | 'italic' | 'code' | 'link' | 'quote' | 'ul' | 'ol') {
-    const el = ref.current
+    const el = textareaRef.current
     if (!el) return
     const start = el.selectionStart ?? 0
     const end = el.selectionEnd ?? 0
@@ -384,7 +371,7 @@ export function Composer({
 
   return h(
     'div',
-    { className: 'p-3' },
+    { ref, className: 'p-3' },
     h(
       'div',
       { className: 'relative' },
@@ -428,7 +415,7 @@ export function Composer({
           : null,
         // textarea (borderless)
         h('textarea', {
-          ref,
+          ref: textareaRef,
           className: 'block max-h-40 w-full resize-none bg-transparent px-3.5 py-3 text-sm placeholder:text-muted-foreground focus:outline-none',
           rows: 1,
           value,
@@ -500,4 +487,7 @@ export function Composer({
       ),
     ),
   )
-}
+  },
+)
+
+Composer.displayName = 'Composer'

--- a/packages/react-cookie-consent/src/cookie-consent.tsx
+++ b/packages/react-cookie-consent/src/cookie-consent.tsx
@@ -75,15 +75,16 @@ function CookieIcon() {
  * CookieConsent — batteries-included consent banner over `useCookieConsent()`.
  * Renders nothing once the user has consented.
  */
-export function CookieConsent({
-  consent,
-  position = 'bottom',
-  title = 'We use cookies',
-  description = 'We use cookies to run the site, remember your preferences, and measure traffic. Choose which to allow.',
-  policyUrl,
-  policyLabel = 'Cookie policy',
-  className,
-}: CookieConsentProps) {
+export const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps>(
+  ({
+    consent,
+    position = 'bottom',
+    title = 'We use cookies',
+    description = 'We use cookies to run the site, remember your preferences, and measure traffic. Choose which to allow.',
+    policyUrl,
+    policyLabel = 'Cookie policy',
+    className,
+  }: CookieConsentProps, ref) => {
   const { state, acceptAll, rejectAll, savePreferences, setPreference } = consent
   const [settings, setSettings] = React.useState(false)
 
@@ -169,7 +170,10 @@ export function CookieConsent({
 
   return h(
     'div',
-    { className: wrapper, role: 'dialog', 'aria-label': 'Cookie consent', 'aria-modal': false },
+    { ref, className: wrapper, role: 'dialog', 'aria-label': 'Cookie consent', 'aria-modal': false },
     h('div', { className: panel }, settings ? settingsView : promptView),
   )
-}
+  },
+)
+
+CookieConsent.displayName = 'CookieConsent'

--- a/packages/react-device-frame/src/device-frame.tsx
+++ b/packages/react-device-frame/src/device-frame.tsx
@@ -19,17 +19,14 @@ export interface DeviceFrameProps {
   children?: React.ReactNode
 }
 
-export function DeviceFrame({
-  device,
-  orientation = 'portrait',
-  className,
-  children,
-}: DeviceFrameProps) {
+export const DeviceFrame = React.forwardRef<HTMLDivElement, DeviceFrameProps>(
+  ({ device, orientation = 'portrait', className, children }, ref) => {
   const api = createDeviceFrame({ device, orientation })
 
   return React.createElement(
     'div',
     {
+      ref,
       className: cn(deviceFrameVariants({ device, orientation }), className),
       style: {
         width: `${api.dimensions.width}px`,
@@ -64,6 +61,7 @@ export function DeviceFrame({
         })
       : null,
   )
-}
+  },
+)
 
 DeviceFrame.displayName = 'DeviceFrame'

--- a/packages/react-diff-viewer/src/DiffViewer.tsx
+++ b/packages/react-diff-viewer/src/DiffViewer.tsx
@@ -264,11 +264,11 @@ export const DiffViewer = React.forwardRef<HTMLDivElement, DiffViewerProps>(
             {statusBarTitle && <span>{statusBarTitle}</span>}
             {activeFile && <span>{activeFile.path}</span>}
             <span style={{ marginLeft: 'auto' }}>
-              +{api.totalAdditions()} -{api.totalDeletions()}
+              {`+${api.totalAdditions()} -${api.totalDeletions()}`}
             </span>
             {statusBarStatus && <span>{statusBarStatus}</span>}
             <span>
-              {files.length} {files.length === 1 ? 'file' : 'files'}
+              {`${files.length} ${files.length === 1 ? 'file' : 'files'}`}
             </span>
           </div>
         )}

--- a/packages/react-dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react-dropdown-menu/src/dropdown-menu.tsx
@@ -207,7 +207,7 @@ DropdownMenuContent.displayName = 'DropdownMenuContent'
 // DropdownMenuItem
 // ---------------------------------------------------------------------------
 
-export interface DropdownMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface DropdownMenuItemProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
   disabled?: boolean
   onSelect?: () => void
 }

--- a/packages/react-emoji-picker/src/emoji-picker.tsx
+++ b/packages/react-emoji-picker/src/emoji-picker.tsx
@@ -110,16 +110,8 @@ export interface EmojiPickerProps {
 
 const RECENT_LIMIT = 20
 
-export function EmojiPicker({
-  onSelect,
-  onStickerSelect,
-  recentEmojis: initialRecent = [],
-  className,
-  emojiRenderer,
-  twemojiBaseUrl,
-  stickerSets = [STARTER_STICKER_SET],
-  stickerRenderer = defaultStickerRenderer,
-}: EmojiPickerProps) {
+export const EmojiPicker = React.forwardRef<HTMLDivElement, EmojiPickerProps>(
+  ({ onSelect, onStickerSelect, recentEmojis: initialRecent = [], className, emojiRenderer, twemojiBaseUrl, stickerSets = [STARTER_STICKER_SET], stickerRenderer = defaultStickerRenderer }: EmojiPickerProps, ref) => {
   const [search, setSearch] = React.useState('')
   const [activeCategory, setActiveCategory] = React.useState<EmojiCategory>('smileys')
   const [mode, setMode] = React.useState<'emoji' | 'sticker'>('emoji')
@@ -159,7 +151,7 @@ export function EmojiPicker({
   const panelKey = search ? 'search' : mode === 'sticker' ? 'sticker' : activeCategory
 
   return (
-    <div className={cn(emojiPickerContainerStyles, className)} {...api.ariaProps}>
+    <div ref={ref} className={cn(emojiPickerContainerStyles, className)} {...api.ariaProps}>
       <input
         {...api.searchInputProps}
         className={emojiPickerSearchStyles}
@@ -266,7 +258,8 @@ export function EmojiPicker({
       </div>
     </div>
   )
-}
+  },
+)
 
 function StickerPanel({
   stickerSets,

--- a/packages/react-file-upload/src/file-upload.tsx
+++ b/packages/react-file-upload/src/file-upload.tsx
@@ -24,16 +24,8 @@ export interface FileUploadProps {
   children?: React.ReactNode
 }
 
-export function FileUpload({
-  accept,
-  maxSize,
-  maxFiles,
-  multiple = false,
-  onFilesSelected,
-  onError,
-  className,
-  children,
-}: FileUploadProps) {
+export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
+  ({ accept, maxSize, maxFiles, multiple = false, onFilesSelected, onError, className, children }, ref) => {
   const [files, setFiles] = React.useState<FileEntry[]>([])
   const [isDragging, setIsDragging] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -116,7 +108,7 @@ export function FileUpload({
 
   return React.createElement(
     'div',
-    { className },
+    { ref, className },
     // Hidden file input
     React.createElement('input', {
       ref: inputRef,
@@ -213,6 +205,7 @@ export function FileUpload({
         ),
       ),
   )
-}
+  },
+)
 
 FileUpload.displayName = 'FileUpload'

--- a/packages/react-form/__tests__/form.ssr.test.tsx
+++ b/packages/react-form/__tests__/form.ssr.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useForm,
+} from '../src/index.js'
+
+function EmailForm({ message }: { message?: string }) {
+  const form = useForm({ defaultValues: { email: '' } })
+  return (
+    <Form {...form}>
+      <form>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <input {...field} />
+              </FormControl>
+              <FormDescription>We never share your email.</FormDescription>
+              <FormMessage>{message}</FormMessage>
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  )
+}
+
+describe('Form primitives (SSR)', () => {
+  it('renders the FormItem/FormLabel/FormControl/FormDescription structure with ARIA wiring', () => {
+    const html = renderToString(<EmailForm />)
+    // FormItem wrapper div
+    expect(html).toContain('class="space-y-2"')
+    // Label and control share the generated -form-item id
+    expect(html).toMatch(/<label[^>]*for="[^"]+-form-item"/)
+    expect(html).toMatch(/<input[^>]*id="[^"]+-form-item"/)
+    // Valid field: control points at the description, no aria-invalid
+    expect(html).toMatch(/aria-describedby="[^"]+-form-item-description"/)
+    expect(html).not.toContain('aria-invalid')
+    // Description text rendered
+    expect(html).toContain('We never share your email.')
+  })
+
+  it('binds the label htmlFor and control id to the same field id', () => {
+    const html = renderToString(<EmailForm />)
+    const forMatch = html.match(/<label[^>]*for="([^"]+)"/)
+    const idMatch = html.match(/<input[^>]*id="([^"]+)"/)
+    expect(forMatch?.[1]).toBeTruthy()
+    expect(forMatch?.[1]).toBe(idMatch?.[1])
+  })
+
+  it('FormMessage renders children under the message id, and nothing when empty', () => {
+    const withMessage = renderToString(<EmailForm message="Required" />)
+    expect(withMessage).toMatch(/<p[^>]*id="[^"]+-form-item-message"[^>]*>Required/)
+
+    const withoutMessage = renderToString(<EmailForm />)
+    expect(withoutMessage).not.toContain('-form-item-message')
+  })
+})

--- a/packages/react-form/vitest.config.ts
+++ b/packages/react-form/vitest.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
+    // SSR tests run in node; the interaction suite opts into jsdom via a
+    // per-file `// @vitest-environment jsdom` pragma.
+    environment: 'node',
     globals: false,
     passWithNoTests: true,
   },

--- a/packages/react-inline-editor/src/InlineEditor.tsx
+++ b/packages/react-inline-editor/src/InlineEditor.tsx
@@ -19,12 +19,8 @@ export interface InlineEditorProps {
   className?: string
 }
 
-export function InlineEditor({
-  value: initialValue,
-  onSave,
-  onCancel,
-  className,
-}: InlineEditorProps) {
+export const InlineEditor = React.forwardRef<HTMLDivElement, InlineEditorProps>(
+  ({ value: initialValue, onSave, onCancel, className }, ref) => {
   const [isEditing, setIsEditing] = React.useState(false)
   const [editValue, setEditValue] = React.useState(initialValue)
 
@@ -62,6 +58,7 @@ export function InlineEditor({
     return React.createElement(
       'div',
       {
+        ref,
         className: cn(editorVariants({ state: 'viewing' }), className),
         onClick: handleStartEditing,
         role: 'button',
@@ -82,6 +79,7 @@ export function InlineEditor({
   return React.createElement(
     'div',
     {
+      ref,
       className: cn(editorVariants({ state: 'editing' }), className),
     },
     // Toolbar
@@ -137,6 +135,7 @@ export function InlineEditor({
       ),
     ),
   )
-}
+  },
+)
 
 InlineEditor.displayName = 'InlineEditor'

--- a/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
+++ b/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
@@ -88,7 +88,8 @@ export interface ShortcutHintProps extends Omit<ShortcutBadgeProps, 'keys'> {
   action?: string;
 }
 
-export function ShortcutHint({ shortcut, action, className, platform = true, ...props }: ShortcutHintProps) {
+export const ShortcutHint = React.forwardRef<HTMLDivElement, ShortcutHintProps>(
+  ({ shortcut, action, className, platform = true, ...props }, ref) => {
   const showHints = React.useContext(ShortcutContext);
 
   const keys = React.useMemo(() => {
@@ -104,11 +105,14 @@ export function ShortcutHint({ shortcut, action, className, platform = true, ...
   if (!showHints || keys.length === 0) return null;
 
   return (
-    <div className={cn("absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none z-10", className)}>
+    <div ref={ref} className={cn("absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none z-10", className)}>
       <ShortcutBadge keys={keys} platform={platform} {...props} />
     </div>
   );
-}
+  },
+)
+
+ShortcutHint.displayName = 'ShortcutHint'
 
 export interface KeyboardShortcutProps {
   /** Key combination */

--- a/packages/react-language-selector/__tests__/dev-warn.test.tsx
+++ b/packages/react-language-selector/__tests__/dev-warn.test.tsx
@@ -26,7 +26,8 @@ afterEach(() => {
 
 describe('react-language-selector devWarn (footgun: compound-context-throw)', () => {
   it('exports the LanguageSelector component (guard module loads)', () => {
-    expect(typeof LanguageSelectorModule.LanguageSelector).toBe('function')
+    // React.forwardRef components are objects ({ $$typeof, render }), not plain functions.
+    expect(['function', 'object']).toContain(typeof LanguageSelectorModule.LanguageSelector)
   })
 
   it('warns once in dev for the guard code', () => {

--- a/packages/react-language-selector/src/language-selector.tsx
+++ b/packages/react-language-selector/src/language-selector.tsx
@@ -48,14 +48,8 @@ export interface LanguageSelectorProps {
   className?: string
 }
 
-export function LanguageSelector({
-  value: controlledValue,
-  onValueChange,
-  options,
-  multiple = false,
-  placeholder = 'Select language...',
-  className,
-}: LanguageSelectorProps) {
+export const LanguageSelector = React.forwardRef<HTMLDivElement, LanguageSelectorProps>(
+  ({ value: controlledValue, onValueChange, options, multiple = false, placeholder = 'Select language...', className }: LanguageSelectorProps, ref) => {
   const initialValues = Array.isArray(controlledValue)
     ? controlledValue
     : controlledValue
@@ -65,6 +59,14 @@ export function LanguageSelector({
   const [selectedValues, setSelectedValues] = React.useState<string[]>(initialValues)
   const [isOpen, setIsOpen] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node
+      if (typeof ref === 'function') ref(node)
+      else if (ref) ref.current = node
+    },
+    [ref],
+  )
 
   const handleValueChange = React.useCallback(
     (val: string | string[]) => {
@@ -176,7 +178,7 @@ export function LanguageSelector({
     { value: ctx },
     React.createElement(
       'div',
-      { ref: containerRef, className: cn('rfr-language-selector relative inline-block', className) },
+      { ref: mergedRef, className: cn('rfr-language-selector relative inline-block', className) },
       // Trigger
       React.createElement(
         'button',
@@ -254,6 +256,7 @@ export function LanguageSelector({
         ),
     ),
   )
-}
+  },
+)
 
 LanguageSelector.displayName = 'LanguageSelector'

--- a/packages/react-location-selector/src/location-selector.tsx
+++ b/packages/react-location-selector/src/location-selector.tsx
@@ -10,13 +10,8 @@ export interface LocationSelectorProps {
   className?: string
 }
 
-export function LocationSelector({
-  defaultCountry = 'US',
-  defaultLanguage = 'en',
-  onCountryChange,
-  onLanguageChange,
-  className,
-}: LocationSelectorProps) {
+export const LocationSelector = React.forwardRef<HTMLDivElement, LocationSelectorProps>(
+  ({ defaultCountry = 'US', defaultLanguage = 'en', onCountryChange, onLanguageChange, className }, ref) => {
   const [country, setCountry] = React.useState(defaultCountry)
   const [language, setLanguage] = React.useState(defaultLanguage)
 
@@ -49,7 +44,7 @@ export function LocationSelector({
 
   return React.createElement(
     'div',
-    { className: cn('flex flex-col gap-4 sm:flex-row', className) },
+    { ref, className: cn('flex flex-col gap-4 sm:flex-row', className) },
     React.createElement(
       'div',
       { className: 'flex flex-col gap-1.5 flex-1' },
@@ -87,4 +82,7 @@ export function LocationSelector({
       )
     )
   )
-}
+  },
+)
+
+LocationSelector.displayName = 'LocationSelector'

--- a/packages/react-payment/__tests__/payment.ssr.test.tsx
+++ b/packages/react-payment/__tests__/payment.ssr.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { Payment } from '../src/index.js'
+
+describe('Payment (SSR)', () => {
+  it('renders the root with data-slot, composed className, and children', () => {
+    const html = renderToString(
+      React.createElement(Payment, { className: 'custom-class' }, 'Pay now'),
+    )
+    expect(html).toContain('<div')
+    expect(html).toContain('data-slot="payment"')
+    expect(html).toContain('custom-class')
+    expect(html).toContain('Pay now')
+  })
+
+  it('applies disabled styling when disabled', () => {
+    const html = renderToString(React.createElement(Payment, { disabled: true }))
+    expect(html).toContain('opacity-50')
+    expect(html).toContain('pointer-events-none')
+  })
+})

--- a/packages/react-payment/package.json
+++ b/packages/react-payment/package.json
@@ -17,6 +17,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/react-payment/vitest.config.ts
+++ b/packages/react-payment/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/react-presence-indicator/src/presence-indicator.tsx
+++ b/packages/react-presence-indicator/src/presence-indicator.tsx
@@ -16,24 +16,20 @@ export interface PresenceIndicatorProps {
   className?: string
 }
 
-export function PresenceIndicator({
-  status,
-  showLabel = false,
-  label,
-  size = 'md',
-  className,
-}: PresenceIndicatorProps) {
+export const PresenceIndicator = React.forwardRef<HTMLSpanElement, PresenceIndicatorProps>(
+  ({ status, showLabel = false, label, size = 'md', className }, ref) => {
   const api = createPresence({ status, showLabel, label })
 
   return React.createElement(
     'span',
-    { ...api.ariaProps, className: cn(presenceContainerStyles, className) },
+    { ref, ...api.ariaProps, className: cn(presenceContainerStyles, className) },
     React.createElement('span', {
       className: presenceDotVariants({ status, size }),
     }),
     api.showLabel &&
       React.createElement('span', { className: presenceLabelStyles }, api.label),
   )
-}
+  },
+)
 
 PresenceIndicator.displayName = 'PresenceIndicator'

--- a/packages/react-radio/src/radio.tsx
+++ b/packages/react-radio/src/radio.tsx
@@ -22,16 +22,8 @@ export interface RadioGroupProps extends CoreRadioGroupProps {
   className?: string
 }
 
-export function RadioGroup({
-  children,
-  className,
-  value: controlledValue,
-  defaultValue,
-  onValueChange,
-  name,
-  disabled = false,
-  orientation = 'vertical',
-}: RadioGroupProps) {
+export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
+  ({ children, className, value: controlledValue, defaultValue, onValueChange, name, disabled = false, orientation = 'vertical' }: RadioGroupProps, ref) => {
   const [internalValue, setInternalValue] = React.useState(defaultValue)
   const isControlled = controlledValue !== undefined
   const currentValue = isControlled ? controlledValue : internalValue
@@ -56,11 +48,12 @@ export function RadioGroup({
     { value: ctx },
     React.createElement(
       'div',
-      { ...api.groupProps, className: cn(radioGroupVariants({ orientation }), className) },
+      { ref, ...api.groupProps, className: cn(radioGroupVariants({ orientation }), className) },
       children,
     ),
   )
-}
+  },
+)
 
 export interface RadioItemProps {
   value: string
@@ -69,7 +62,8 @@ export interface RadioItemProps {
   className?: string
 }
 
-export function RadioItem({ value, children, disabled = false, className }: RadioItemProps) {
+export const RadioItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(
+  ({ value, children, disabled = false, className }, ref) => {
   const ctx = React.useContext(RadioContext)
   if (!ctx) {
     devWarn(
@@ -85,6 +79,7 @@ export function RadioItem({ value, children, disabled = false, className }: Radi
   return React.createElement(
     'label',
     {
+      ref,
       className: cn(radioItemVariants({ disabled: isDisabled ? 'true' : 'false' }), className),
       'data-state': isChecked ? 'checked' : 'unchecked',
     },
@@ -108,7 +103,8 @@ export function RadioItem({ value, children, disabled = false, className }: Radi
     ),
     children && React.createElement('span', { className: 'text-sm' }, children),
   )
-}
+  },
+)
 
 RadioGroup.displayName = 'RadioGroup'
 RadioItem.displayName = 'RadioItem'

--- a/packages/react-reaction-bar/src/reaction-bar.tsx
+++ b/packages/react-reaction-bar/src/reaction-bar.tsx
@@ -18,18 +18,13 @@ export interface ReactionBarProps {
   className?: string
 }
 
-export function ReactionBar({
-  reactions,
-  onToggle,
-  onAdd,
-  showAddButton = true,
-  className,
-}: ReactionBarProps) {
+export const ReactionBar = React.forwardRef<HTMLDivElement, ReactionBarProps>(
+  ({ reactions, onToggle, onAdd, showAddButton = true, className }, ref) => {
   const api = createReactionBar({ reactions, onToggle, onAdd })
 
   return React.createElement(
     'div',
-    { ...api.ariaProps, className: cn(reactionBarStyles, className) },
+    { ref, ...api.ariaProps, className: cn(reactionBarStyles, className) },
     api.reactions.map((reaction, i) =>
       React.createElement(
         'button',
@@ -58,6 +53,7 @@ export function ReactionBar({
         '+',
       ),
   )
-}
+  },
+)
 
 ReactionBar.displayName = 'ReactionBar'

--- a/packages/react-search-bar/src/search-bar.tsx
+++ b/packages/react-search-bar/src/search-bar.tsx
@@ -47,18 +47,8 @@ export interface SearchBarProps extends Omit<React.InputHTMLAttributes<HTMLInput
   children?: React.ReactNode
 }
 
-export function SearchBar({
-  value: controlledValue,
-  defaultValue = '',
-  onValueChange,
-  onSearch,
-  debounceMs = 300,
-  loading = false,
-  placeholder,
-  className,
-  children,
-  ...inputProps
-}: SearchBarProps) {
+export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
+  ({ value: controlledValue, defaultValue = '', onValueChange, onSearch, debounceMs = 300, loading = false, placeholder, className, children, ...inputProps }, ref) => {
   const [internalValue, setInternalValue] = React.useState(controlledValue ?? defaultValue)
   const isControlled = controlledValue !== undefined
   const currentValue = isControlled ? controlledValue : internalValue
@@ -153,6 +143,7 @@ export function SearchBar({
       { className: cn(searchBarVariants(), className) },
       React.createElement('span', { className: 'rfr-search-icon', 'aria-hidden': 'true' }, '\u{1F50D}'),
       React.createElement('input', {
+        ref,
         ...inputProps,
         role: api.inputProps.role,
         'aria-expanded': api.inputProps['aria-expanded'],
@@ -181,7 +172,8 @@ export function SearchBar({
     ),
     children,
   )
-}
+  },
+)
 
 SearchBar.displayName = 'SearchBar'
 

--- a/packages/react-status-indicator/src/status-indicator.tsx
+++ b/packages/react-status-indicator/src/status-indicator.tsx
@@ -33,14 +33,8 @@ function deriveAriaLabel(
   return fallback
 }
 
-export function StatusIndicator({
-  type,
-  label,
-  children,
-  pulse,
-  showLabel = true,
-  className,
-}: StatusIndicatorProps) {
+export const StatusIndicator = React.forwardRef<HTMLSpanElement, StatusIndicatorProps>(
+  ({ type, label, children, pulse, showLabel = true, className }, ref) => {
   const api = createStatusIndicator({ type, label, pulse })
   const ariaLabel = deriveAriaLabel(label, children, api.label)
   const visibleLabel: React.ReactNode = label ?? children ?? api.label
@@ -51,6 +45,7 @@ export function StatusIndicator({
 
   return (
     <span
+      ref={ref}
       {...api.ariaProps}
       aria-label={ariaLabel}
       className={cn(statusContainerStyles, className)}
@@ -59,6 +54,7 @@ export function StatusIndicator({
       {showLabel && <span className={statusLabelStyles}>{visibleLabel}</span>}
     </span>
   )
-}
+  },
+)
 
 StatusIndicator.displayName = 'StatusIndicator'

--- a/packages/react-tabs/src/tabs.tsx
+++ b/packages/react-tabs/src/tabs.tsx
@@ -36,7 +36,7 @@ function useTabsContext(): TabsContextValue {
 // Tabs (root provider)
 // ---------------------------------------------------------------------------
 
-export interface TabsProps {
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
   value?: string
   defaultValue?: string
   onValueChange?: (value: string) => void
@@ -45,14 +45,8 @@ export interface TabsProps {
   children?: React.ReactNode
 }
 
-export function Tabs({
-  value: controlledValue,
-  defaultValue = '',
-  onValueChange,
-  orientation = 'horizontal',
-  className,
-  children,
-}: TabsProps) {
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  ({ value: controlledValue, defaultValue = '', onValueChange, orientation = 'horizontal', className, children, ...props }: TabsProps, ref) => {
   const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue)
   const isControlled = controlledValue !== undefined
   const value = isControlled ? controlledValue : uncontrolledValue
@@ -86,10 +80,11 @@ export function Tabs({
 
   return React.createElement(
     'div',
-    { className, 'data-orientation': orientation },
+    { ref, className, 'data-orientation': orientation, ...props },
     React.createElement(TabsContext.Provider, { value: ctx }, children),
   )
-}
+  },
+)
 
 Tabs.displayName = 'Tabs'
 

--- a/packages/react-thread-view/src/thread-view.tsx
+++ b/packages/react-thread-view/src/thread-view.tsx
@@ -124,18 +124,13 @@ function MessageComponent({
   )
 }
 
-export function ThreadView({
-  messages,
-  onReply,
-  onReact,
-  currentUserId,
-  className,
-}: ThreadViewProps) {
+export const ThreadView = React.forwardRef<HTMLDivElement, ThreadViewProps>(
+  ({ messages, onReply, onReact, currentUserId, className }, ref) => {
   const api = createThreadView({ messages, onReply, onReact, currentUserId })
 
   return React.createElement(
     'div',
-    { ...api.ariaProps, className: cn(threadContainerStyles, className) },
+    { ref, ...api.ariaProps, className: cn(threadContainerStyles, className) },
     messages.map((message) =>
       React.createElement(MessageComponent, {
         key: message.id,
@@ -144,6 +139,7 @@ export function ThreadView({
       }),
     ),
   )
-}
+  },
+)
 
 ThreadView.displayName = 'ThreadView'

--- a/packages/react-version-selector/__tests__/dev-warn.test.tsx
+++ b/packages/react-version-selector/__tests__/dev-warn.test.tsx
@@ -26,7 +26,8 @@ afterEach(() => {
 
 describe('react-version-selector devWarn (footgun: compound-context-throw)', () => {
   it('exports the VersionSelector component (guard module loads)', () => {
-    expect(typeof VersionSelectorModule.VersionSelector).toBe('function')
+    // React.forwardRef components are objects ({ $$typeof, render }), not plain functions.
+    expect(['function', 'object']).toContain(typeof VersionSelectorModule.VersionSelector)
   })
 
   it('warns once in dev for the guard code', () => {

--- a/packages/react-version-selector/src/version-selector.tsx
+++ b/packages/react-version-selector/src/version-selector.tsx
@@ -47,16 +47,19 @@ export interface VersionSelectorProps {
   className?: string
 }
 
-export function VersionSelector({
-  value: controlledValue,
-  onValueChange,
-  versions,
-  placeholder = 'Select version...',
-  className,
-}: VersionSelectorProps) {
+export const VersionSelector = React.forwardRef<HTMLDivElement, VersionSelectorProps>(
+  ({ value: controlledValue, onValueChange, versions, placeholder = 'Select version...', className }: VersionSelectorProps, ref) => {
   const [selectedVersion, setSelectedVersion] = React.useState(controlledValue ?? '')
   const [isOpen, setIsOpen] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const mergedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node
+      if (typeof ref === 'function') ref(node)
+      else if (ref) ref.current = node
+    },
+    [ref],
+  )
 
   const handleValueChange = React.useCallback(
     (val: string) => {
@@ -136,7 +139,7 @@ export function VersionSelector({
     { value: ctx },
     React.createElement(
       'div',
-      { ref: containerRef, className: cn('rfr-version-selector relative inline-block', className) },
+      { ref: mergedRef, className: cn('rfr-version-selector relative inline-block', className) },
       // Trigger
       React.createElement(
         'button',
@@ -192,6 +195,7 @@ export function VersionSelector({
         ),
     ),
   )
-}
+  },
+)
 
 VersionSelector.displayName = 'VersionSelector'

--- a/packages/reaction-bar/src/reaction-bar.ts
+++ b/packages/reaction-bar/src/reaction-bar.ts
@@ -1,4 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
 import { generateId } from '@refraction-ui/shared'
 
 export interface Reaction {
@@ -27,7 +26,7 @@ export interface ReactionBarAPI {
   /** Add a new reaction */
   add(emoji: string): void
   /** ARIA props for the reaction bar container */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** Get ARIA props for an individual reaction pill */
   getReactionAriaProps(reaction: Reaction): Record<string, unknown>
   /** ARIA props for the "add reaction" button */
@@ -53,7 +52,7 @@ export function createReactionBar(props: ReactionBarProps): ReactionBarAPI {
     onAdd?.(emoji)
   }
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'group',
     'aria-label': 'Reactions',
     id: containerId,

--- a/packages/status-indicator/src/status-indicator.ts
+++ b/packages/status-indicator/src/status-indicator.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 export type StatusType = 'success' | 'error' | 'warning' | 'info' | 'pending' | 'neutral'
 
 export interface StatusProps {
@@ -13,7 +11,7 @@ export interface StatusProps {
 
 export interface StatusAPI {
   /** ARIA attributes for the status indicator */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** The status type */
   type: StatusType
   /** The display label */
@@ -54,7 +52,7 @@ export function createStatusIndicator(props: StatusProps): StatusAPI {
   const label = labelOverride ?? STATUS_INDICATOR_LABELS[type]
   const pulse = pulseOverride ?? (type === 'pending')
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'status',
     'aria-label': label,
   }

--- a/packages/thread-view/src/thread-view.ts
+++ b/packages/thread-view/src/thread-view.ts
@@ -1,4 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
 import { generateId } from '@refraction-ui/shared'
 
 export interface MessageReaction {
@@ -70,11 +69,11 @@ export interface ThreadViewAPI {
   /** Format relative time (e.g., "2 minutes ago") */
   formatRelativeTime(date: Date): string
   /** ARIA props for the thread container */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** Get ARIA props for a message */
-  getMessageAriaProps(message: MessageData): Record<string, unknown>
+  getMessageAriaProps(message: MessageData): Record<string, string | number | boolean>
   /** Get ARIA props for a reply button */
-  getReplyButtonAriaProps(messageId: string): Record<string, unknown>
+  getReplyButtonAriaProps(messageId: string): Record<string, string | number | boolean>
   /** Generated IDs */
   ids: {
     thread: string
@@ -132,14 +131,14 @@ export function createThreadView(props: ThreadViewProps): ThreadViewAPI {
     onReact?.(messageId, emoji)
   }
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'log',
     'aria-label': 'Message thread',
     'aria-live': 'polite',
     id: threadId,
   }
 
-  function getMessageAriaProps(message: MessageData): Record<string, unknown> {
+  function getMessageAriaProps(message: MessageData): Record<string, string | number | boolean> {
     const isOwn = currentUserId && message.author.id === currentUserId
     return {
       role: 'article',
@@ -147,7 +146,7 @@ export function createThreadView(props: ThreadViewProps): ThreadViewAPI {
     }
   }
 
-  function getReplyButtonAriaProps(_messageId: string): Record<string, unknown> {
+  function getReplyButtonAriaProps(_messageId: string): Record<string, string | number | boolean> {
     return {
       role: 'button',
       'aria-label': `Reply to message`,

--- a/packages/voice-pill/src/voice-pill.ts
+++ b/packages/voice-pill/src/voice-pill.ts
@@ -1,5 +1,3 @@
-import type { AccessibilityProps } from '@refraction-ui/shared'
-
 export type VoicePillSpeaker = 'ai' | 'user' | (string & {})
 
 export type VoicePillPosition =
@@ -60,7 +58,7 @@ export interface VoicePillAPI {
   /** Invoke the mute callback when provided */
   toggleMute(): void
   /** ARIA props for the live status pill */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Record<string, string | number | boolean>
   /** ARIA props for the mute toggle */
   toggleMuteAriaProps: Record<string, unknown>
   /** Data attributes reflecting speaker/state */
@@ -196,7 +194,7 @@ export function createVoicePill(props: VoicePillProps): VoicePillAPI {
     onToggleMute?.()
   }
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Record<string, string | number | boolean> = {
     role: 'status',
     'aria-live': 'polite',
     'aria-atomic': true,


### PR DESCRIPTION
## Summary
Batch of standards fixes from the project review, all verified (214 lint/typecheck/test tasks + full meta build green):

- **forwardRef coverage**: 20 adapters now forward refs to their root elements (avatar-group, calendar, conversation, cookie-consent, device-frame, emoji-picker, file-upload, inline-editor, language-selector, location-selector, app-shell ×7, ShortcutHint, RadioGroup/RadioItem, SearchBar input, version-selector, reaction-bar, thread-view, presence/status-indicator, Tabs root + rest props)
- **react-charts**: all 10 components accept className (previously zero)
- **call-controls**: forbidden `as React.AriaAttributes` cast removed by retyping the core's ariaProps to `Record<string, string|number|boolean>`
- **command/dropdown-menu**: `onSelect` prop collision fixed with Omit (consumers can pass standard DOM handlers)
- **diff-viewer**: SSR-composed strings as single template literals
- **7 cores**: ARIA returns narrowed from `Record<string, unknown>`
- **react-form**: added node-env SSR structural/ARIA suite (jsdom suite untouched)
- **react-payment**: added missing test script + vitest config + SSR test
- **react-auth**: replaced the repo's only existence-only assertion

## Checklist
- [x] Tests added or updated
- [x] Axe/Accessibility checks pass (ARIA assertions are the repo's a11y convention)
- [x] Docs updated (no docs impact — no rendered-output changes)
- [x] Changeset added if package API changed (patch @refraction-ui/react)

## Breaking changes?
None — additive ref forwarding and type narrowings only.