### PR TITLE
fix: injectable clock/rng seams in headless cores (hydration-safe)

### DIFF
--- a/.changeset/core-determinism.md
+++ b/.changeset/core-determinism.md
@@ -1,0 +1,13 @@
+---
+'@refraction-ui/react': patch
+'@refraction-ui/astro': patch
+---
+
+- **Core determinism**: headless cores no longer hard-depend on ambient time/randomness — each now accepts an optional, injectable clock/rng at its config seam (defaults stay ambient, so existing usage is unchanged):
+  - **Conversation**: `now?: () => Date` for conversation/message timestamps.
+  - **Calendar** / **DatePicker**: `today?: Date` reference date — fixes SSR/CSR hydration mismatch when server and client render on different days (also drives time-default fallbacks in DatePicker).
+  - **Toast**: `now?: () => number` for timer pause/resume math and manager `createdAt` stamps.
+  - **Analytics**: `now?: () => Date` (default event `timestamp`, HTTP-sink `sentAt`) and `random?: () => number` (sample-rate decisions); per-call `timestamp` override still wins.
+  - **Logger**: `now?: () => number` (record timestamps, span timing) and `random?: () => number` (sampling).
+  - **Footer**: `year?: number` for the default copyright text — fixes year-boundary SSR/CSR mismatch.
+- **Calendar**: ARIA prop returns are now typed `Record<string, string | number | boolean>` (spread-safe), with `aria-current` omitted rather than `undefined` on non-today cells.

--- a/packages/analytics/__tests__/analytics-manager.test.ts
+++ b/packages/analytics/__tests__/analytics-manager.test.ts
@@ -320,3 +320,38 @@ describe('createAnalytics — noop kill switch', () => {
     expect(a.enabled).toBe(true)
   })
 })
+
+
+describe('determinism (injected now/random)', () => {
+  it('defaults event timestamps to the injected clock', () => {
+    const { a, sink } = devConfig(createMockSink(), {
+      now: () => new Date('2026-01-02T03:04:05.000Z'),
+    })
+    a.track('X')
+    expect(sink.events[0].timestamp).toBe('2026-01-02T03:04:05.000Z')
+  })
+
+  it('per-call timestamp override still wins over the injected clock', () => {
+    const { a, sink } = devConfig(createMockSink(), {
+      now: () => new Date('2026-01-02T03:04:05.000Z'),
+    })
+    a.track('X', undefined, { timestamp: '1999-12-31T23:59:59.000Z' })
+    expect(sink.events[0].timestamp).toBe('1999-12-31T23:59:59.000Z')
+  })
+
+  it('sampling decisions follow the injected rng', () => {
+    const { a: kept, sink: keptSink } = devConfig(createMockSink(), {
+      sampleRate: 0.5,
+      random: () => 0.4,
+    })
+    kept.track('X')
+    expect(keptSink.events).toHaveLength(1)
+
+    const { a: dropped, sink: droppedSink } = devConfig(createMockSink(), {
+      sampleRate: 0.5,
+      random: () => 0.6,
+    })
+    dropped.track('X')
+    expect(droppedSink.events).toHaveLength(0)
+  })
+})

--- a/packages/analytics/__tests__/http-sink.test.ts
+++ b/packages/analytics/__tests__/http-sink.test.ts
@@ -351,3 +351,19 @@ describe('http sink — consent categories', () => {
     expect(sink.consentCategories).toEqual(['marketing', 'analytics'])
   })
 })
+
+
+describe('determinism (injected now)', () => {
+  it('stamps sentAt from the injected clock', async () => {
+    const be = mockBackend()
+    const sink = createHttpSink({
+      endpoint: 'https://collector.example.com',
+      writeKey: 'WK123',
+      fetchImpl: be.fetchImpl,
+      now: () => new Date('2026-01-02T03:04:05.000Z'),
+    })
+    await sink.deliver([makeEvent()], CTX_ONLINE)
+    const body = be.calls[0].body as { sentAt: string }
+    expect(body.sentAt).toBe('2026-01-02T03:04:05.000Z')
+  })
+})

--- a/packages/analytics/src/analytics-manager.ts
+++ b/packages/analytics/src/analytics-manager.ts
@@ -64,6 +64,9 @@ export function createAnalytics(config: AnalyticsConfig): Analytics {
   const sampleRate = config.sampleRate ?? 1
   const batchSize = config.batchSize ?? 20
   const flushIntervalMs = config.flushIntervalMs ?? 10_000
+  // Injection boundary: ambient time/randomness default here; inject `now`/`random` for determinism.
+  const now = config.now ?? (() => new Date())
+  const random = config.random ?? (() => Math.random())
 
   const session = createSession(config.session)
   const identity = createIdentity(config.identity)
@@ -86,6 +89,8 @@ export function createAnalytics(config: AnalyticsConfig): Analytics {
       createHttpSink({
         endpoint: config.endpoint,
         writeKey: config.writeKey ?? '',
+        // One clock for the whole manager: the auto sink stamps sentAt with it too.
+        now,
       }),
     )
   }
@@ -203,7 +208,7 @@ export function createAnalytics(config: AnalyticsConfig): Analytics {
   function sampled(): boolean {
     if (sampleRate >= 1) return true
     if (sampleRate <= 0) return false
-    return Math.random() < sampleRate
+    return random() < sampleRate
   }
 
   function enqueue(ev: AnalyticsEvent): void {
@@ -238,7 +243,7 @@ export function createAnalytics(config: AnalyticsConfig): Analytics {
       userId: identity.userId(),
       sessionId,
       context: buildContext(opts?.context, childCtx),
-      timestamp: opts?.timestamp ?? new Date().toISOString(),
+      timestamp: opts?.timestamp ?? now().toISOString(),
       schemaVersion: SCHEMA_VERSION,
       ...fields,
     }

--- a/packages/analytics/src/http-sink.ts
+++ b/packages/analytics/src/http-sink.ts
@@ -113,6 +113,8 @@ export function createHttpSink(options: HttpSinkOptions): AnalyticsSink {
   const base = endpoint.replace(/\/+$/, '')
   const url = `${base}/v${SCHEMA_VERSION}/batch`
   const authHeader = `Basic ${base64(`${writeKey}:`)}`
+  // Injection boundary: `sentAt` defaults to ambient time; inject `now` for determinism.
+  const now = options.now ?? (() => new Date())
 
   const resolveFetch = (): typeof fetch => {
     if (options.fetchImpl) return options.fetchImpl
@@ -137,7 +139,7 @@ export function createHttpSink(options: HttpSinkOptions): AnalyticsSink {
   function envelope(batch: AnalyticsEvent[]) {
     return {
       batch,
-      sentAt: new Date().toISOString(),
+      sentAt: now().toISOString(),
       batchId: uuidv4(),
     }
   }

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -187,6 +187,8 @@ export interface HttpSinkOptions {
   maxBatchBytes?: number
   /** Soft per-event byte cap (Segment ≈ 32KB). Default 32_000. */
   maxEventBytes?: number
+  /** Clock for the batch `sentAt` stamp. Default: ambient `new Date()` — inject for deterministic tests. */
+  now?: () => Date
 }
 
 /** `createAnalytics` configuration. */
@@ -222,6 +224,10 @@ export interface AnalyticsConfig {
   batchSize?: number
   /** Auto-flush interval in ms (prod). Default 10_000. */
   flushIntervalMs?: number
+  /** Clock for default event timestamps. Default: ambient `new Date()` — inject for deterministic tests/SSR. */
+  now?: () => Date
+  /** RNG for sample-rate decisions. Default: ambient `Math.random` — inject for deterministic tests. */
+  random?: () => number
 }
 
 /** Options accepted by every top-level call. */

--- a/packages/calendar/__tests__/calendar.test.ts
+++ b/packages/calendar/__tests__/calendar.test.ts
@@ -256,3 +256,28 @@ describe('calendar styles', () => {
     expect(dayVariants({ state: 'default' })).toContain('hover:bg-accent')
   })
 })
+
+
+describe('determinism (injected today)', () => {
+  it('marks the injected today as isToday with aria-current=date', () => {
+    const today = new Date(2026, 0, 15)
+    const api = createCalendar({ today, month: today })
+    const todayDays = api.days.filter((d) => d.isToday)
+    expect(todayDays).toHaveLength(1)
+    expect(todayDays[0]!.date).toEqual(today)
+    expect(api.getDayAriaProps(todayDays[0]!)['aria-current']).toBe('date')
+  })
+
+  it('two instances with the same injected today render identical grids', () => {
+    const today = new Date(2026, 0, 15)
+    const a = createCalendar({ today })
+    const b = createCalendar({ today })
+    expect(a.days.map((d) => d.isToday)).toEqual(b.days.map((d) => d.isToday))
+    expect(a.state.currentMonth).toEqual(b.state.currentMonth)
+  })
+
+  it('injected today drives the default displayed month', () => {
+    const api = createCalendar({ today: new Date(2025, 10, 20) })
+    expect(api.state.currentMonth).toEqual(new Date(2025, 10, 1))
+  })
+})

--- a/packages/calendar/src/calendar.ts
+++ b/packages/calendar/src/calendar.ts
@@ -18,6 +18,8 @@ export interface CalendarProps {
   maxDate?: Date
   /** Specific dates to disable */
   disabledDates?: Date[]
+  /** Reference "today" for isToday/aria-current. Default: ambient `new Date()` — inject to avoid SSR/CSR hydration mismatch. */
+  today?: Date
 }
 
 export interface CalendarDay {
@@ -52,9 +54,9 @@ export interface CalendarAPI {
   /** Select a date */
   select(date: Date): void
   /** ARIA attributes for the calendar grid */
-  ariaProps: Partial<AccessibilityProps> & Record<string, unknown>
+  ariaProps: Partial<AccessibilityProps> & Record<string, string | number | boolean>
   /** Get ARIA attributes for a specific day cell */
-  getDayAriaProps(day: CalendarDay): Partial<AccessibilityProps> & Record<string, unknown>
+  getDayAriaProps(day: CalendarDay): Partial<AccessibilityProps> & Record<string, string | number | boolean>
   /** Generated IDs */
   ids: {
     grid: string
@@ -89,9 +91,11 @@ export function createCalendar(props: CalendarProps = {}): CalendarAPI {
     minDate,
     maxDate,
     disabledDates = [],
+    today: injectedToday,
   } = props
 
-  const today = new Date()
+  // Injection boundary: ambient "today" is the default; inject `today` so SSR and client agree.
+  const today = injectedToday ?? new Date()
 
   // Determine selected date
   const selectedDate = controlledValue ?? defaultValue
@@ -167,18 +171,19 @@ export function createCalendar(props: CalendarProps = {}): CalendarAPI {
     }
   }
 
-  const ariaProps: Partial<AccessibilityProps> & Record<string, unknown> = {
+  const ariaProps: Partial<AccessibilityProps> & Record<string, string | number | boolean> = {
     role: 'grid',
     'aria-labelledby': labelId,
     id: gridId,
   }
 
-  function getDayAriaProps(day: CalendarDay): Partial<AccessibilityProps> & Record<string, unknown> {
+  function getDayAriaProps(day: CalendarDay): Partial<AccessibilityProps> & Record<string, string | number | boolean> {
     return {
       role: 'gridcell',
       'aria-selected': day.isSelected,
       'aria-disabled': day.isDisabled,
-      'aria-current': day.isToday ? ('date' as const) : undefined,
+      // Key absent (not undefined) when not today — the ARIA record type excludes undefined.
+      ...(day.isToday ? { 'aria-current': 'date' as const } : {}),
       'aria-label': `${DAY_NAMES[day.date.getDay()]}, ${day.date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`,
     }
   }

--- a/packages/conversation/__tests__/conversation.test.ts
+++ b/packages/conversation/__tests__/conversation.test.ts
@@ -315,3 +315,36 @@ describe('subscribe', () => {
     expect(listener.mock.calls.length).toBe(before)
   })
 })
+
+
+describe('determinism (injected now)', () => {
+  it('stamps conversations and messages with the injected clock', async () => {
+    let tick = new Date('2026-01-02T03:04:05.000Z').getTime()
+    const now = () => new Date(tick)
+    const c = createConversation({ now, transport: echoTransport(['ok']) })
+
+    const conv = c.newConversation()
+    expect(conv.createdAt).toEqual(new Date('2026-01-02T03:04:05.000Z'))
+    expect(conv.updatedAt).toEqual(conv.createdAt)
+
+    tick += 60_000
+    await c.sendMessage('hello')
+    const { messages } = c.getState()
+    expect(messages[0]!.timestamp).toEqual(new Date(tick))
+    expect(messages[1]!.timestamp).toEqual(new Date(tick))
+    expect(c.getState().conversations[0]!.updatedAt).toEqual(new Date(tick))
+  })
+
+  it('produces identical timestamps for two stores on the same fixed clock', async () => {
+    const fixed = new Date('2026-06-30T12:00:00.000Z')
+    const now = () => new Date(fixed.getTime())
+    const a = createConversation({ now })
+    const b = createConversation({ now })
+    await a.sendMessage('hi')
+    await b.sendMessage('hi')
+    expect(a.getState().messages[0]!.timestamp).toEqual(b.getState().messages[0]!.timestamp)
+    expect(a.getState().conversations[0]!.createdAt).toEqual(
+      b.getState().conversations[0]!.createdAt,
+    )
+  })
+})

--- a/packages/conversation/src/conversation.ts
+++ b/packages/conversation/src/conversation.ts
@@ -33,6 +33,8 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
   const assistant = config.assistant ?? DEFAULT_ASSISTANT
   const currentUser = config.currentUser ?? DEFAULT_USER
   const generateTitle = config.generateTitle ?? defaultGenerateTitle
+  // Injection boundary: ambient time is the default; inject `now` for deterministic timestamps.
+  const now = config.now ?? (() => new Date())
 
   let transport = config.transport
   let threadingMode: ThreadingMode = config.threadingMode ?? 'inline'
@@ -87,7 +89,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
 
   function touch(conversationId: string): void {
     const c = conversations.get(conversationId)
-    if (c) conversations.set(conversationId, { ...c, updatedAt: new Date() })
+    if (c) conversations.set(conversationId, { ...c, updatedAt: now() })
   }
 
   function ensureActiveConversation(opts?: SendOptions): string {
@@ -103,12 +105,12 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
     opts: { title?: string; metadata?: Record<string, unknown> },
     id?: string,
   ): Conversation {
-    const now = new Date()
+    const timestamp = now()
     const conversation: Conversation = {
       id: id ?? generateId('rfr-conv'),
       title: opts.title ?? DEFAULT_TITLE,
-      createdAt: now,
-      updatedAt: now,
+      createdAt: timestamp,
+      updatedAt: timestamp,
       metadata: opts.metadata,
     }
     conversations.set(conversation.id, conversation)
@@ -294,7 +296,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
         role: 'user',
         author: currentUser,
         content: trimmed,
-        timestamp: new Date(),
+        timestamp: now(),
         status: 'sent',
         parentId,
         replyToId,
@@ -323,7 +325,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
         role: 'assistant',
         author: assistant,
         content: '',
-        timestamp: new Date(),
+        timestamp: now(),
         status: 'streaming',
         parentId,
       }
@@ -350,7 +352,7 @@ export function createConversation(config: ConversationConfig = {}): Conversatio
         role: 'assistant',
         author: assistant,
         content: '',
-        timestamp: new Date(),
+        timestamp: now(),
         status: 'streaming',
         parentId,
       }

--- a/packages/conversation/src/types.ts
+++ b/packages/conversation/src/types.ts
@@ -170,6 +170,8 @@ export interface ConversationConfig {
   generateTitle?: (firstMessage: string) => string
   /** Threading mode (default 'inline') */
   threadingMode?: ThreadingMode
+  /** Clock for conversation/message timestamps. Default: ambient `new Date()` — inject for deterministic SSR/tests. */
+  now?: () => Date
 }
 
 /** Options for a single `sendMessage`. */

--- a/packages/date-picker/__tests__/date-picker.test.ts
+++ b/packages/date-picker/__tests__/date-picker.test.ts
@@ -412,3 +412,33 @@ describe('date-picker styles', () => {
     expect(datePickerTimeInputStyles).toContain('rounded')
   })
 })
+
+
+describe('determinism (injected today)', () => {
+  it('marks the injected today as isToday', () => {
+    const today = new Date(2026, 0, 15, 9, 30)
+    const api = createDatePicker({ today })
+    const todayCells = api.days.filter((d) => d.isToday)
+    expect(todayCells).toHaveLength(1)
+    expect(todayCells[0]!.date).toEqual(new Date(2026, 0, 15))
+    expect(api.getDayAriaProps(todayCells[0]!)['aria-current']).toBe('date')
+  })
+
+  it('two instances with the same injected today render identical grids', () => {
+    const today = new Date(2026, 0, 15)
+    const a = createDatePicker({ today })
+    const b = createDatePicker({ today })
+    expect(a.days.map((d) => d.isToday)).toEqual(b.days.map((d) => d.isToday))
+    expect(a.state.currentMonth).toEqual(b.state.currentMonth)
+  })
+
+  it('setHours/setMinutes fall back to the injected today when no value', () => {
+    const today = new Date(2026, 0, 15, 9, 30)
+    const onChange = vi.fn()
+    const api = createDatePicker({ today, onChange, showTime: true })
+    api.setHours(14)
+    expect(onChange).toHaveBeenCalledWith(new Date(2026, 0, 15, 14, 30))
+    api.setMinutes(45)
+    expect(onChange).toHaveBeenCalledWith(new Date(2026, 0, 15, 9, 45))
+  })
+})

--- a/packages/date-picker/src/date-picker.ts
+++ b/packages/date-picker/src/date-picker.ts
@@ -26,6 +26,8 @@ export interface DatePickerProps {
   onOpenChange?: (open: boolean) => void
   /** The currently displayed month (controlled) */
   currentMonth?: Date
+  /** Reference "today" for isToday/aria-current and time defaults. Default: ambient `new Date()` — inject to avoid SSR/CSR hydration mismatch. */
+  today?: Date
 }
 
 export interface DatePickerState {
@@ -149,7 +151,8 @@ export function createDatePicker(props: DatePickerProps = {}): DatePickerAPI {
     onOpenChange,
   } = props
 
-  const today = new Date()
+  // Injection boundary: ambient "today" is the default; inject `today` so SSR and client agree.
+  const today = props.today ?? new Date()
   let internalOpen = controlledOpen ?? defaultOpen
   let currentMonth = props.currentMonth ?? (value ? startOfMonth(value) : startOfMonth(today))
   let view: DatePickerView = 'calendar'
@@ -230,14 +233,14 @@ export function createDatePicker(props: DatePickerProps = {}): DatePickerAPI {
 
   function setHours(h: number): void {
     if (h < 0 || h > 23) return
-    const newDate = value ? new Date(value) : new Date()
+    const newDate = value ? new Date(value) : new Date(today.getTime())
     newDate.setHours(h)
     onChange?.(newDate)
   }
 
   function setMinutes(m: number): void {
     if (m < 0 || m > 59) return
-    const newDate = value ? new Date(value) : new Date()
+    const newDate = value ? new Date(value) : new Date(today.getTime())
     newDate.setMinutes(m)
     onChange?.(newDate)
   }

--- a/packages/footer/__tests__/footer.test.ts
+++ b/packages/footer/__tests__/footer.test.ts
@@ -8,11 +8,9 @@ describe('createFooter', () => {
     expect(api.ariaProps.role).toBe('contentinfo')
   })
 
-  it('generates default copyright with current year', () => {
-    const api = createFooter()
-    const year = new Date().getFullYear()
-    expect(api.copyrightText).toContain(String(year))
-    expect(api.copyrightText).toContain('All rights reserved')
+  it('generates default copyright with the injected year', () => {
+    const api = createFooter({ year: 2026 })
+    expect(api.copyrightText).toBe('© 2026 All rights reserved.')
   })
 
   it('uses custom copyright text', () => {
@@ -24,10 +22,14 @@ describe('createFooter', () => {
 // ── Additional tests ──
 
 describe('createFooter - year and copyright', () => {
-  it('year in copyright is current year', () => {
+  it('year in copyright comes from the year prop', () => {
+    const api = createFooter({ year: 2030 })
+    expect(api.copyrightText).toContain('2030')
+  })
+
+  it('default copyright falls back to a 4-digit current year', () => {
     const api = createFooter()
-    const year = new Date().getFullYear()
-    expect(api.copyrightText).toContain(String(year))
+    expect(api.copyrightText).toMatch(/^© \d{4} All rights reserved\.$/)
   })
 
   it('default copyright contains copyright symbol', () => {

--- a/packages/footer/src/footer.ts
+++ b/packages/footer/src/footer.ts
@@ -13,6 +13,8 @@ export interface FooterProps {
   copyright?: string
   socialLinks?: SocialLink[]
   columns?: FooterColumn[]
+  /** Year for the default copyrightText. Default: ambient current year — inject to avoid year-boundary SSR/CSR mismatch. */
+  year?: number
 }
 
 export interface FooterAPI {
@@ -22,7 +24,8 @@ export interface FooterAPI {
 
 export function createFooter(props: FooterProps = {}): FooterAPI {
   const { copyright } = props
-  const year = new Date().getFullYear()
+  // Injection boundary: ambient year is the default; inject `year` so SSR and client agree.
+  const year = props.year ?? new Date().getFullYear()
   const copyrightText = copyright ?? `© ${year} All rights reserved.`
 
   return {

--- a/packages/logger/__tests__/telemetry-manager.test.ts
+++ b/packages/logger/__tests__/telemetry-manager.test.ts
@@ -332,3 +332,41 @@ describe('createTelemetry', () => {
     })
   })
 })
+
+
+describe('determinism (injected now/random)', () => {
+  it('stamps log records from the injected clock', () => {
+    const t = createTelemetry({ ...baseDev, now: () => 1_700_000_000_000 })
+    const sink = createMockSink()
+    t.addSink(sink)
+    t.info('hello')
+    expect(sink.logs[0].timestamp).toBe(1_700_000_000_000)
+  })
+
+  it('span timing comes from the injected clock', () => {
+    let tick = 5_000
+    const t = createTelemetry({ ...baseDev, now: () => tick })
+    const sink = createMockSink()
+    t.addSink(sink)
+    const span = t.startSpan('op')
+    tick += 250
+    span.end()
+    expect(sink.spans[0].startTime).toBe(5_000)
+    expect(sink.spans[0].endTime).toBe(5_250)
+    expect(sink.spans[0].durationMs).toBe(250)
+  })
+
+  it('sampling decisions follow the injected rng', () => {
+    const kept = createTelemetry({ ...baseDev, sampleRate: 0.5, random: () => 0.4 })
+    const keptSink = createMockSink()
+    kept.addSink(keptSink)
+    kept.info('x')
+    expect(keptSink.logs).toHaveLength(1)
+
+    const dropped = createTelemetry({ ...baseDev, sampleRate: 0.5, random: () => 0.6 })
+    const droppedSink = createMockSink()
+    dropped.addSink(droppedSink)
+    dropped.info('x')
+    expect(droppedSink.logs).toHaveLength(0)
+  })
+})

--- a/packages/logger/src/telemetry-manager.ts
+++ b/packages/logger/src/telemetry-manager.ts
@@ -34,6 +34,9 @@ export function createTelemetry(config: TelemetryConfig): Telemetry {
   const preset = resolvePreset(config.env)
   const sampleRate = config.sampleRate ?? preset.sampleRate
   const redactKeys = config.redactKeys ?? []
+  // Injection boundary: ambient time/randomness default here; inject `now`/`random` for determinism.
+  const now = config.now ?? (() => Date.now())
+  const random = config.random ?? (() => Math.random())
 
   const sinks = new Map<string, TelemetrySink>()
   /** Insertion-ordered sink names. */
@@ -71,7 +74,7 @@ export function createTelemetry(config: TelemetryConfig): Telemetry {
   function shouldSample(): boolean {
     if (sampleRate >= 1) return true
     if (sampleRate <= 0) return false
-    return Math.random() < sampleRate
+    return random() < sampleRate
   }
 
   function dispatch(
@@ -134,7 +137,7 @@ export function createTelemetry(config: TelemetryConfig): Telemetry {
       const record: LogRecord = {
         level,
         message,
-        timestamp: Date.now(),
+        timestamp: now(),
         app: config.app,
         env: config.env,
         context: merged,
@@ -164,13 +167,13 @@ export function createTelemetry(config: TelemetryConfig): Telemetry {
       },
 
       startSpan(name: string, attributes?: LogContext): Span {
-        const startTime = Date.now()
+        const startTime = now()
         let ended = false
         return {
           end(opts?: { error?: unknown; attributes?: LogContext }): void {
             if (ended) return
             ended = true
-            const endTime = Date.now()
+            const endTime = now()
             const merged = redact(
               { ...boundContext, ...attributes, ...opts?.attributes },
               redactKeys,

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -84,6 +84,10 @@ export interface TelemetryConfig {
    * PII / secrets, e.g. `['password', 'token', 'authorization']`.
    */
   redactKeys?: string[]
+  /** Clock for record timestamps and span timing (ms epoch). Default: ambient `Date.now()` — inject for deterministic tests. */
+  now?: () => number
+  /** RNG for sample-rate decisions. Default: ambient `Math.random` — inject for deterministic tests. */
+  random?: () => number
 }
 
 /** A logger bound to a context. Child loggers inherit + extend that context. */

--- a/packages/toast/__tests__/toast.test.ts
+++ b/packages/toast/__tests__/toast.test.ts
@@ -398,3 +398,33 @@ describe('toastVariants – all 4 variants produce distinct classes', () => {
     }
   })
 })
+
+
+describe('determinism (injected now)', () => {
+  it('pause/resume math uses the injected clock', () => {
+    let tick = 10_000
+    const onOpenChange = vi.fn()
+    const api = createToast({ duration: 3000, onOpenChange, now: () => tick })
+    api.startTimer()
+
+    tick += 1000 // 1s elapsed on the injected clock
+    api.pauseTimer()
+
+    tick += 60_000 // injected clock jumps while paused — must not count
+    api.resumeTimer()
+    vi.advanceTimersByTime(1999)
+    expect(onOpenChange).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('manager stamps createdAt from the injected clock', () => {
+    let tick = 123_456
+    const manager = createToastManager({ now: () => tick })
+    manager.toast('one')
+    tick = 789_012
+    manager.toast('two')
+    expect(manager.toasts[0]!.createdAt).toBe(123_456)
+    expect(manager.toasts[1]!.createdAt).toBe(789_012)
+  })
+})

--- a/packages/toast/src/toast.ts
+++ b/packages/toast/src/toast.ts
@@ -25,6 +25,8 @@ export interface ToastProps {
   open?: boolean
   /** Callback when open state changes */
   onOpenChange?: (open: boolean) => void
+  /** Elapsed-time clock for timer pause/resume math (ms). Default: ambient `Date.now()` — inject for deterministic tests. */
+  now?: () => number
 }
 
 export interface ToastState {
@@ -55,6 +57,8 @@ export function createToast(props: ToastProps = {}): ToastAPI {
     onOpenChange,
   } = props
 
+  // Injection boundary: ambient time is the default; inject `now` for deterministic timer math.
+  const now = props.now ?? (() => Date.now())
   let isOpen = controlledOpen ?? true
   let timerId: ReturnType<typeof setTimeout> | null = null
   let remaining = duration
@@ -77,21 +81,21 @@ export function createToast(props: ToastProps = {}): ToastAPI {
     if (duration <= 0) return
     clearTimer()
     remaining = duration
-    startedAt = Date.now()
+    startedAt = now()
     timerId = setTimeout(dismiss, remaining)
   }
 
   function pauseTimer(): void {
     if (timerId === null) return
     clearTimer()
-    remaining = remaining - (Date.now() - startedAt)
+    remaining = remaining - (now() - startedAt)
     if (remaining < 0) remaining = 0
   }
 
   function resumeTimer(): void {
     if (duration <= 0 || remaining <= 0) return
     clearTimer()
-    startedAt = Date.now()
+    startedAt = now()
     timerId = setTimeout(dismiss, remaining)
   }
 
@@ -136,7 +140,14 @@ export interface ToastManagerAPI {
   subscribe(fn: (toasts: ReadonlyArray<ToastEntry>) => void): () => void
 }
 
-export function createToastManager(): ToastManagerAPI {
+export interface ToastManagerConfig {
+  /** Clock for entry `createdAt` stamps (ms). Default: ambient `Date.now()` — inject for deterministic tests. */
+  now?: () => number
+}
+
+export function createToastManager(config: ToastManagerConfig = {}): ToastManagerAPI {
+  // Injection boundary: ambient time is the default; inject `now` for deterministic createdAt.
+  const now = config.now ?? (() => Date.now())
   let toasts: ToastEntry[] = []
   const listeners = new Set<(toasts: ReadonlyArray<ToastEntry>) => void>()
   const timers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -171,7 +182,7 @@ export function createToastManager(): ToastManagerAPI {
       message,
       variant,
       duration,
-      createdAt: Date.now(),
+      createdAt: now(),
     }
 
     toasts = [...toasts, entry]


### PR DESCRIPTION
## Summary
Cores must be deterministic per the project rulebook; ambient `Date.now()`/`new Date()`/`Math.random()` is now behind optional injected seams (ambient defaults preserved — fully backward compatible), mirroring the existing composer/session idiom. 332 core tests pass; react+astro metas build green.

- **calendar** (`today?`) and **date-picker** (`today?`): fixes real SSR/client hydration-mismatch risk when server and client 'today' differ; calendar ARIA types also narrowed
- **conversation** (`now?`): message/conversation timestamps
- **toast** (`now?`): pause/resume timer math + createdAt
- **analytics** (`now?`, `random?`): sampling + event timestamps, cascades to the HTTP sink's sentAt
- **logger** (`now?`, `random?`): sampling, record timestamps, span timing
- **footer** (`year?`): copyright year no longer baked at render; tests now assert fixed years

## Checklist
- [x] Tests added or updated (determinism describe-blocks per core)
- [x] Axe/Accessibility checks pass
- [x] Docs updated (n/a)
- [x] Changeset added if package API changed (patch @refraction-ui/react + @refraction-ui/astro)

## Breaking changes?
None — all seams optional with ambient defaults.