### PR TITLE
feat(flutter): success/warning/info tokens, 13 widget tests, widgetbook gaps, 0.47.1

### DIFF
--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.47.1
+
+- **Theme**: Add `success`, `warning`, and `info` status tokens to `RefractionColors` (wired through `copyWith`/`lerp` and every curated palette) and route the previously hardcoded status hues through them: `RefractionCallout` success/warning/info variants, `RefractionEmptyState` tones, the `RefractionInput` valid state, the `RefractionAudioRoom` raised-hand badge, `RefractionLogger` warning level, and the `RefractionBrowserChromeMock` live badge. One token swap now re-skins every status surface. Note: the callout success/warning variants and the browser-chrome live badge adopt the shared token hues (green-500 `0xFF22C55E`, amber-500 `0xFFF59E0B`), replacing their slightly different ad-hoc greens/oranges; every other routed surface is pixel-identical.
+- **Tests**: Add widget tests for the 13 exported widgets that had none — `RefractionAlert`, `RefractionCallout`, `RefractionBottomNav`, `RefractionBreadcrumbs`, `RefractionRichChatInput`, `RefractionCommandMenu`, `RefractionFooter`, `RefractionInputGroup`, `RefractionMobileNav`, `RefractionNavbar`, `RefractionSearchBar`, `RefractionSelect`, and `RefractionSkeleton` — plus direct unit coverage of the new status tokens.
+- **Widgetbook**: Add example use cases for the 7 widgets missing from the catalog (`RefractionBottomNav`, `RefractionBreadcrumbs`, `RefractionDialog`, `RefractionFooter`, `RefractionInputGroup`, `RefractionSearchBar`, `RefractionSkeleton`) and regenerate the directories index.
+- **Docs**: README corrections (accurate install/snippet details).
+- **Chore**: Set the Dart SDK floor to `>=3.27.0` and drop the unused `widgetbook_annotation` dev dependency from the package.
+- **Chore**: Remove the duplicate `RefractionCallout` class from `alert.dart` — the exported implementation lives in `callout.dart` (the barrel already hid the duplicate).
+- **Chore**: Move store-compliance notes under `store_compliance/`, clean up the analyze gate, and refresh the example lockfile.
+
 ## 0.47.0
 
 - **Feature**: Jumbo emoji-only chat messages now **animate** — the package bundles Google's animated Noto emoji (Lottie, ~190 of the most-used emoji, `assets/emoji_animated/`, SIL OFL 1.1 / Apache 2.0 — see NOTICE). `RefractionChatBubble` plays the Lottie for any jumbo glyph that has an asset and falls back to the static glyph for the rest. **Bundle-size note:** this adds ~12 MB of Lottie JSON.

--- a/packages/flutter/example/lib/use_cases/bottom_nav_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/bottom_nav_use_cases.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Default', type: RefractionBottomNav)
+Widget defaultBottomNav(BuildContext context) {
+  return const SizedBox(
+    width: 400,
+    child: RefractionBottomNav(
+      currentPath: '/home',
+      tabs: [
+        NavTab(label: 'Home', href: '/home', icon: Icon(Icons.home_outlined)),
+        NavTab(label: 'Search', href: '/search', icon: Icon(Icons.search)),
+        NavTab(
+          label: 'Notifications',
+          href: '/notifications',
+          icon: Icon(Icons.notifications_outlined),
+        ),
+        NavTab(
+          label: 'Profile',
+          href: '/profile',
+          icon: Icon(Icons.person_outline),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Active Icons', type: RefractionBottomNav)
+Widget activeIconsBottomNav(BuildContext context) {
+  return const SizedBox(
+    width: 400,
+    child: RefractionBottomNav(
+      currentPath: '/search',
+      tabs: [
+        NavTab(
+          label: 'Home',
+          href: '/home',
+          icon: Icon(Icons.home_outlined),
+          activeIcon: Icon(Icons.home),
+        ),
+        NavTab(
+          label: 'Search',
+          href: '/search',
+          icon: Icon(Icons.search_outlined),
+          activeIcon: Icon(Icons.search),
+        ),
+        NavTab(
+          label: 'Profile',
+          href: '/profile',
+          icon: Icon(Icons.person_outline),
+          activeIcon: Icon(Icons.person),
+        ),
+      ],
+    ),
+  );
+}

--- a/packages/flutter/example/lib/use_cases/breadcrumbs_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/breadcrumbs_use_cases.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Default', type: RefractionBreadcrumbs)
+Widget defaultBreadcrumbs(BuildContext context) {
+  return const RefractionBreadcrumbs(
+    items: [
+      BreadcrumbItem(label: 'Home', href: '/'),
+      BreadcrumbItem(label: 'Docs', href: '/docs'),
+      BreadcrumbItem(label: 'Components', href: '/docs/components'),
+      BreadcrumbItem(label: 'Breadcrumbs'),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Custom Separator', type: RefractionBreadcrumbs)
+Widget customSeparatorBreadcrumbs(BuildContext context) {
+  return const RefractionBreadcrumbs(
+    separator: '›',
+    items: [
+      BreadcrumbItem(label: 'Store', href: '/store'),
+      BreadcrumbItem(label: 'Books', href: '/store/books'),
+      BreadcrumbItem(label: 'Design Systems'),
+    ],
+  );
+}

--- a/packages/flutter/example/lib/use_cases/dialog_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/dialog_use_cases.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Default', type: RefractionDialog)
+Widget defaultDialog(BuildContext context) {
+  return RefractionButton(
+    onPressed: () {
+      RefractionDialog.show<void>(
+        context: context,
+        title: const Text('Delete file?'),
+        content: const Text(
+          'This action cannot be undone. The file will be permanently removed from your project.',
+        ),
+        actions: [
+          RefractionButton(
+            variant: RefractionButtonVariant.outline,
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          RefractionButton(
+            variant: RefractionButtonVariant.destructive,
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Delete'),
+          ),
+        ],
+      );
+    },
+    child: const Text('Open dialog'),
+  );
+}
+
+@widgetbook.UseCase(name: 'Info Only', type: RefractionDialog)
+Widget infoOnlyDialog(BuildContext context) {
+  return RefractionButton(
+    variant: RefractionButtonVariant.outline,
+    onPressed: () {
+      RefractionDialog.show<void>(
+        context: context,
+        title: const Text('New in 0.47'),
+        content: const Text(
+          'Status colors now flow through the theme — restyle success, '
+          'warning, and info hues in one place.',
+        ),
+      );
+    },
+    child: const Text('What\'s new'),
+  );
+}

--- a/packages/flutter/example/lib/use_cases/footer_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/footer_use_cases.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Default', type: RefractionFooter)
+Widget defaultFooter(BuildContext context) {
+  return const RefractionFooter(
+    copyright: '© 2026 Acme Inc.',
+    columns: [
+      FooterColumn(
+        title: 'Product',
+        links: [
+          FooterLink(label: 'Features', href: '/features'),
+          FooterLink(label: 'Pricing', href: '/pricing'),
+          FooterLink(label: 'Changelog', href: '/changelog'),
+        ],
+      ),
+      FooterColumn(
+        title: 'Resources',
+        links: [
+          FooterLink(label: 'Docs', href: '/docs'),
+          FooterLink(label: 'Support', href: '/support'),
+        ],
+      ),
+      FooterColumn(
+        title: 'Company',
+        links: [
+          FooterLink(label: 'About', href: '/about'),
+          FooterLink(label: 'Careers', href: '/careers'),
+        ],
+      ),
+    ],
+    socialLinks: [
+      SocialLink(label: 'Twitter', href: 'https://x.com/acme'),
+      SocialLink(label: 'GitHub', href: 'https://github.com/acme'),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Minimal', type: RefractionFooter)
+Widget minimalFooter(BuildContext context) {
+  return const RefractionFooter(copyright: '© 2026 Acme Inc.');
+}

--- a/packages/flutter/example/lib/use_cases/input_group_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/input_group_use_cases.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Horizontal', type: RefractionInputGroup)
+Widget horizontalInputGroup(BuildContext context) {
+  return const SizedBox(
+    width: 360,
+    child: RefractionInputGroup(
+      children: [
+        RefractionInputGroupAddon(child: Text('\$')),
+        RefractionInput(placeholder: '0.00'),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Vertical', type: RefractionInputGroup)
+Widget verticalInputGroup(BuildContext context) {
+  return const SizedBox(
+    width: 360,
+    child: RefractionInputGroup(
+      orientation: RefractionInputGroupOrientation.vertical,
+      children: [
+        RefractionInput(placeholder: 'First name'),
+        RefractionInput(placeholder: 'Last name'),
+      ],
+    ),
+  );
+}

--- a/packages/flutter/example/lib/use_cases/search_bar_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/search_bar_use_cases.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Default', type: RefractionSearchBar)
+Widget defaultSearchBar(BuildContext context) {
+  return SizedBox(
+    width: 360,
+    child: RefractionSearchBar(
+      placeholder: 'Search components...',
+      onSearch: (_) {},
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Loading', type: RefractionSearchBar)
+Widget loadingSearchBar(BuildContext context) {
+  return const SizedBox(
+    width: 360,
+    child: RefractionSearchBar(placeholder: 'Searching...', isLoading: true),
+  );
+}

--- a/packages/flutter/example/lib/use_cases/skeleton_use_cases.dart
+++ b/packages/flutter/example/lib/use_cases/skeleton_use_cases.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:refraction_ui/refraction_ui.dart';
+
+@widgetbook.UseCase(name: 'Shapes', type: RefractionSkeleton)
+Widget shapeSkeletons(BuildContext context) {
+  return const SizedBox(
+    width: 360,
+    child: Row(
+      children: [
+        RefractionSkeleton(shape: SkeletonShape.circular, width: 40),
+        SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              RefractionSkeleton(shape: SkeletonShape.text, width: 120),
+              SizedBox(height: 6),
+              RefractionSkeleton(shape: SkeletonShape.text, width: 200),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Text Block', type: RefractionSkeleton)
+Widget textBlockSkeleton(BuildContext context) {
+  return const SizedBox(width: 360, child: RefractionSkeletonText(lines: 4));
+}

--- a/packages/flutter/example/lib/widgetbook.directories.g.dart
+++ b/packages/flutter/example/lib/widgetbook.directories.g.dart
@@ -16,8 +16,12 @@ import 'package:example/use_cases/audio_room_use_cases.dart'
     as _example_use_cases_audio_room_use_cases;
 import 'package:example/use_cases/avatar_group_use_cases.dart'
     as _example_use_cases_avatar_group_use_cases;
+import 'package:example/use_cases/bottom_nav_use_cases.dart'
+    as _example_use_cases_bottom_nav_use_cases;
 import 'package:example/use_cases/brand_network_cell_use_cases.dart'
     as _example_use_cases_brand_network_cell_use_cases;
+import 'package:example/use_cases/breadcrumbs_use_cases.dart'
+    as _example_use_cases_breadcrumbs_use_cases;
 import 'package:example/use_cases/browser_chrome_mock_use_cases.dart'
     as _example_use_cases_browser_chrome_mock_use_cases;
 import 'package:example/use_cases/call_controls_use_cases.dart'
@@ -36,6 +40,8 @@ import 'package:example/use_cases/composer_full_demo.dart'
     as _example_use_cases_composer_full_demo;
 import 'package:example/use_cases/composer_use_cases.dart'
     as _example_use_cases_composer_use_cases;
+import 'package:example/use_cases/dialog_use_cases.dart'
+    as _example_use_cases_dialog_use_cases;
 import 'package:example/use_cases/editor_status_bar_use_cases.dart'
     as _example_use_cases_editor_status_bar_use_cases;
 import 'package:example/use_cases/editor_tabs_use_cases.dart'
@@ -46,10 +52,14 @@ import 'package:example/use_cases/floating_reactions_use_cases.dart'
     as _example_use_cases_floating_reactions_use_cases;
 import 'package:example/use_cases/flow_editor_use_cases.dart'
     as _example_use_cases_flow_editor_use_cases;
+import 'package:example/use_cases/footer_use_cases.dart'
+    as _example_use_cases_footer_use_cases;
 import 'package:example/use_cases/graph_view_use_cases.dart'
     as _example_use_cases_graph_view_use_cases;
 import 'package:example/use_cases/infinite_canvas_use_cases.dart'
     as _example_use_cases_infinite_canvas_use_cases;
+import 'package:example/use_cases/input_group_use_cases.dart'
+    as _example_use_cases_input_group_use_cases;
 import 'package:example/use_cases/kanban_board_use_cases.dart'
     as _example_use_cases_kanban_board_use_cases;
 import 'package:example/use_cases/link_card_use_cases.dart'
@@ -94,12 +104,16 @@ import 'package:example/use_cases/radio_use_cases.dart'
     as _example_use_cases_radio_use_cases;
 import 'package:example/use_cases/rating_scale_use_cases.dart'
     as _example_use_cases_rating_scale_use_cases;
+import 'package:example/use_cases/search_bar_use_cases.dart'
+    as _example_use_cases_search_bar_use_cases;
 import 'package:example/use_cases/section_head_use_cases.dart'
     as _example_use_cases_section_head_use_cases;
 import 'package:example/use_cases/segmented_control_use_cases.dart'
     as _example_use_cases_segmented_control_use_cases;
 import 'package:example/use_cases/separator_use_cases.dart'
     as _example_use_cases_separator_use_cases;
+import 'package:example/use_cases/skeleton_use_cases.dart'
+    as _example_use_cases_skeleton_use_cases;
 import 'package:example/use_cases/skip_to_content_use_cases.dart'
     as _example_use_cases_skip_to_content_use_cases;
 import 'package:example/use_cases/slide_viewer_use_cases.dart'
@@ -216,6 +230,20 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookComponent(
+        name: 'RefractionBottomNav',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder: _example_use_cases_bottom_nav_use_cases.defaultBottomNav,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'With Active Icons',
+            builder:
+                _example_use_cases_bottom_nav_use_cases.activeIconsBottomNav,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
         name: 'RefractionBrandNetworkCell',
         useCases: [
           _widgetbook.WidgetbookUseCase(
@@ -227,6 +255,21 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Default',
             builder: _example_use_cases_brand_network_cell_use_cases
                 .brandNetworkCellDefaultUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'RefractionBreadcrumbs',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Custom Separator',
+            builder: _example_use_cases_breadcrumbs_use_cases
+                .customSeparatorBreadcrumbs,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder:
+                _example_use_cases_breadcrumbs_use_cases.defaultBreadcrumbs,
           ),
         ],
       ),
@@ -445,6 +488,19 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookComponent(
+        name: 'RefractionDialog',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder: _example_use_cases_dialog_use_cases.defaultDialog,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Info Only',
+            builder: _example_use_cases_dialog_use_cases.infoOnlyDialog,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
         name: 'RefractionEditorStatusBar',
         useCases: [
           _widgetbook.WidgetbookUseCase(
@@ -503,6 +559,19 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookComponent(
+        name: 'RefractionFooter',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder: _example_use_cases_footer_use_cases.defaultFooter,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Minimal',
+            builder: _example_use_cases_footer_use_cases.minimalFooter,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
         name: 'RefractionGraphView',
         useCases: [
           _widgetbook.WidgetbookUseCase(
@@ -519,6 +588,21 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Default',
             builder: _example_use_cases_infinite_canvas_use_cases
                 .infiniteCanvasDefaultUseCase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'RefractionInputGroup',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Horizontal',
+            builder:
+                _example_use_cases_input_group_use_cases.horizontalInputGroup,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Vertical',
+            builder:
+                _example_use_cases_input_group_use_cases.verticalInputGroup,
           ),
         ],
       ),
@@ -854,6 +938,19 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookComponent(
+        name: 'RefractionSearchBar',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Default',
+            builder: _example_use_cases_search_bar_use_cases.defaultSearchBar,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Loading',
+            builder: _example_use_cases_search_bar_use_cases.loadingSearchBar,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
         name: 'RefractionSectionHead',
         useCases: [
           _widgetbook.WidgetbookUseCase(
@@ -902,6 +999,19 @@ final directories = <_widgetbook.WidgetbookNode>[
           _widgetbook.WidgetbookUseCase(
             name: 'Vertical',
             builder: _example_use_cases_separator_use_cases.verticalSeparator,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'RefractionSkeleton',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Shapes',
+            builder: _example_use_cases_skeleton_use_cases.shapeSkeletons,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'Text Block',
+            builder: _example_use_cases_skeleton_use_cases.textBlockSkeleton,
           ),
         ],
       ),

--- a/packages/flutter/lib/src/components/audio_room.dart
+++ b/packages/flutter/lib/src/components/audio_room.dart
@@ -189,7 +189,7 @@ class RefractionSpeakingOrb extends StatelessWidget {
                 height: 24.0,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: const Color(0xFFF59E0B), // warning/amber color
+                  color: colors.warning,
                   border: Border.all(color: colors.background, width: 2.0),
                 ),
                 alignment: Alignment.center,

--- a/packages/flutter/lib/src/components/browser_chrome_mock.dart
+++ b/packages/flutter/lib/src/components/browser_chrome_mock.dart
@@ -84,7 +84,7 @@ class RefractionBrowserChromeMock extends StatelessWidget {
     Widget? statusWidget;
     if (status != null) {
       final isRec = status == RefractionBrowserChromeStatus.rec;
-      final badgeColor = isRec ? colors.destructive : const Color(0xFF10B981);
+      final badgeColor = isRec ? colors.destructive : colors.success;
       final badgeBgColor = badgeColor.withValues(alpha: 0.1);
 
       statusWidget = Container(

--- a/packages/flutter/lib/src/components/callout.dart
+++ b/packages/flutter/lib/src/components/callout.dart
@@ -63,21 +63,21 @@ class RefractionCallout extends StatelessWidget {
         defaultIconData = Icons.error_outline;
         break;
       case RefractionCalloutVariant.warning:
-        backgroundColor = Colors.orange.withValues(alpha: 0.1);
-        foregroundColor = Colors.orange;
-        borderColor = Colors.orange.withValues(alpha: 0.2);
+        backgroundColor = theme.colors.warning.withValues(alpha: 0.1);
+        foregroundColor = theme.colors.warning;
+        borderColor = theme.colors.warning.withValues(alpha: 0.2);
         defaultIconData = Icons.warning_amber_rounded;
         break;
       case RefractionCalloutVariant.success:
-        backgroundColor = Colors.green.withValues(alpha: 0.1);
-        foregroundColor = Colors.green;
-        borderColor = Colors.green.withValues(alpha: 0.2);
+        backgroundColor = theme.colors.success.withValues(alpha: 0.1);
+        foregroundColor = theme.colors.success;
+        borderColor = theme.colors.success.withValues(alpha: 0.2);
         defaultIconData = Icons.check_circle_outline;
         break;
       case RefractionCalloutVariant.info:
-        backgroundColor = Colors.blue.withValues(alpha: 0.1);
-        foregroundColor = Colors.blue;
-        borderColor = Colors.blue.withValues(alpha: 0.2);
+        backgroundColor = theme.colors.info.withValues(alpha: 0.1);
+        foregroundColor = theme.colors.info;
+        borderColor = theme.colors.info.withValues(alpha: 0.2);
         defaultIconData = Icons.info_outline;
         break;
       case RefractionCalloutVariant.standard:

--- a/packages/flutter/lib/src/components/empty_state.dart
+++ b/packages/flutter/lib/src/components/empty_state.dart
@@ -68,16 +68,20 @@ class RefractionEmptyState extends StatelessWidget {
 
   /// Resolves the (background, foreground) pair for the icon chip.
   ({Color background, Color foreground}) _chipColors(RefractionTheme theme) {
-    const success = Color(0xFF22C55E);
-    const warning = Color(0xFFF59E0B);
     final colors = theme.colors;
     switch (tone) {
       case RefractionEmptyStateTone.neutral:
         return (background: colors.muted, foreground: colors.mutedForeground);
       case RefractionEmptyStateTone.success:
-        return (background: success.withValues(alpha: 0.1), foreground: success);
+        return (
+          background: colors.success.withValues(alpha: 0.1),
+          foreground: colors.success,
+        );
       case RefractionEmptyStateTone.warning:
-        return (background: warning.withValues(alpha: 0.1), foreground: warning);
+        return (
+          background: colors.warning.withValues(alpha: 0.1),
+          foreground: colors.warning,
+        );
       case RefractionEmptyStateTone.danger:
         return (
           background: colors.destructive.withValues(alpha: 0.1),

--- a/packages/flutter/lib/src/components/input.dart
+++ b/packages/flutter/lib/src/components/input.dart
@@ -171,16 +171,16 @@ class _RefractionInputState extends State<RefractionInput> {
     final colors = theme.colors;
 
     // Validation tinting takes precedence over the resting/focus border so an
-    // invalid field always reads as an error, focused or not. `valid` borrows
-    // a fixed green that reads on both light and dark surfaces.
-    const validGreen = Color(0xFF22C55E);
+    // invalid field always reads as an error, focused or not. `valid` reads
+    // the success color token — a fixed green that reads on both light and
+    // dark surfaces.
     Color borderColor;
     switch (widget.validationState) {
       case RefractionInputValidationState.invalid:
         borderColor = colors.destructive;
         break;
       case RefractionInputValidationState.valid:
-        borderColor = validGreen;
+        borderColor = colors.success;
         break;
       case null:
         borderColor = _isFocused ? colors.ring : colors.input;
@@ -244,7 +244,7 @@ class _RefractionInputState extends State<RefractionInput> {
             if (widget.validationState ==
                 RefractionInputValidationState.valid) ...[
               const SizedBox(width: 8),
-              const Icon(Icons.check, size: 16, color: validGreen),
+              Icon(Icons.check, size: 16, color: colors.success),
             ],
             if (widget.suffix != null) ...[
               const SizedBox(width: 8),

--- a/packages/flutter/lib/src/components/logger.dart
+++ b/packages/flutter/lib/src/components/logger.dart
@@ -111,7 +111,7 @@ class _RefractionLoggerState extends State<RefractionLogger> {
       case RefractionLogLevel.info:
         return colors.primary;
       case RefractionLogLevel.warning:
-        return Color(0xFFF59E0B);
+        return colors.warning;
       case RefractionLogLevel.error:
         return colors.destructive;
     }
@@ -314,7 +314,7 @@ class _LogItem extends StatelessWidget {
         levelColor = colors.primary;
         break;
       case RefractionLogLevel.warning:
-        levelColor = Color(0xFFF59E0B);
+        levelColor = colors.warning;
         break;
       case RefractionLogLevel.error:
         levelColor = colors.destructive;

--- a/packages/flutter/lib/src/theme/refraction_colors.dart
+++ b/packages/flutter/lib/src/theme/refraction_colors.dart
@@ -13,7 +13,10 @@ import 'hsl_color.dart';
 /// Each "thing" token is paired with a `Foreground` token that is
 /// guaranteed to read accessibly on top of it — for example, draw text in
 /// [primaryForeground] when the surface beneath it is filled with
-/// [primary].
+/// [primary]. The status tokens ([success], [warning], [info]) stand
+/// alone: components paint them both as low-alpha tints and as the
+/// text/icon color on top of those tints, and they currently share one
+/// fixed hue across every curated palette.
 ///
 /// Implements [ThemeExtension] so it can also be plugged into a Material
 /// `ThemeData.extensions` list when interoperating with Material widgets.
@@ -88,6 +91,18 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
   /// keyboard focus. Should provide strong contrast against [background].
   final Color ring;
 
+  /// Success / positive status color. Used for confirmation banners, valid
+  /// input borders, "live" badges, and other completed or healthy states.
+  final Color success;
+
+  /// Warning status color. Used for caution banners, raised-hand badges,
+  /// and warning-level log output.
+  final Color warning;
+
+  /// Informational status color. Used for info banners and neutral
+  /// highlights that should not read as the brand [primary].
+  final Color info;
+
   /// Creates a [RefractionColors] palette.
   ///
   /// All tokens are required — there are no implicit fallbacks, so a
@@ -114,6 +129,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     required this.border,
     required this.input,
     required this.ring,
+    required this.success,
+    required this.warning,
+    required this.info,
   });
 
   /// Minimal palette, light mode. Pure monochrome — Apple/Nike aesthetic
@@ -138,6 +156,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFFE5E5EA),
     input: Color(0xFFE5E5EA),
     ring: Color(0xFFD1D1D6),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Minimal palette, dark mode. Inverse monochrome — pure black surfaces,
@@ -162,6 +183,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFF38383A),
     input: Color(0xFF38383A),
     ring: Color(0xFF48484A),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Fintech palette, light mode. Revolut-inspired — neon green primary on
@@ -186,6 +210,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFFEAEDF0),
     input: Color(0xFFEAEDF0),
     ring: Color(0xFF00D632),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Fintech palette, dark mode. Bright accent green over deep blue-black
@@ -210,6 +237,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFF1F242C),
     input: Color(0xFF1F242C),
     ring: Color(0xFF05FF3E),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Wellness palette, light mode. Warm off-whites, organic taupe borders,
@@ -234,6 +264,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFFE8E5DF),
     input: Color(0xFFE8E5DF),
     ring: Color(0xFFFFb6b3),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Wellness palette, dark mode. Warm browns and muted coral primaries
@@ -258,6 +291,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFF4D4139),
     input: Color(0xFF4D4139),
     ring: Color(0xFFFF837D),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Creative palette, light mode. Discord-style "blurple" primaries on
@@ -282,6 +318,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFFE5E7EB),
     input: Color(0xFFE5E7EB),
     ring: Color(0xFF5046E5),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Creative palette, dark mode. Indigo primaries on near-black surfaces
@@ -306,6 +345,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFF27272A),
     input: Color(0xFF27272A),
     ring: Color(0xFF6366F1),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Productivity palette, light mode. Linear-style subdued blues on crisp
@@ -330,6 +372,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFFE4E4E7),
     input: Color(0xFFE4E4E7),
     ring: Color(0xFF3B82F6),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Productivity palette, dark mode. Soft sky blue primaries on graphite
@@ -354,6 +399,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: Color(0xFF2B2B2B),
     input: Color(0xFF2B2B2B),
     ring: Color(0xFF60A5FA),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors refractionLight = RefractionColors(
@@ -376,6 +424,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('240 6% 92%'),
     input: HslColor.parse('240 6% 92%'),
     ring: HslColor.parse('250 50% 50%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors refractionDark = RefractionColors(
@@ -398,6 +449,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('240 5% 16%'),
     input: HslColor.parse('240 5% 16%'),
     ring: HslColor.parse('250 50% 65%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors luxeLight = RefractionColors(
@@ -420,6 +474,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('220 6% 93%'),
     input: HslColor.parse('220 6% 93%'),
     ring: HslColor.parse('220 90% 45%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors luxeDark = RefractionColors(
@@ -442,6 +499,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('220 5% 16%'),
     input: HslColor.parse('220 5% 16%'),
     ring: HslColor.parse('220 85% 60%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors warmLight = RefractionColors(
@@ -464,6 +524,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('30 12% 90%'),
     input: HslColor.parse('30 12% 90%'),
     ring: HslColor.parse('350 85% 46%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors warmDark = RefractionColors(
@@ -486,6 +549,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('20 10% 16%'),
     input: HslColor.parse('20 10% 16%'),
     ring: HslColor.parse('350 80% 65%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors signalLight = RefractionColors(
@@ -508,6 +574,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('210 10% 90%'),
     input: HslColor.parse('210 10% 90%'),
     ring: HslColor.parse('190 80% 32%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors signalDark = RefractionColors(
@@ -530,6 +599,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('210 10% 16%'),
     input: HslColor.parse('210 10% 16%'),
     ring: HslColor.parse('190 70% 50%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors pulseLight = RefractionColors(
@@ -552,6 +624,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('240 8% 90%'),
     input: HslColor.parse('240 8% 90%'),
     ring: HslColor.parse('265 80% 55%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors pulseDark = RefractionColors(
@@ -574,6 +649,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('260 6% 16%'),
     input: HslColor.parse('260 6% 16%'),
     ring: HslColor.parse('265 75% 65%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors monoLight = RefractionColors(
@@ -596,6 +674,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('210 14% 89%'),
     input: HslColor.parse('210 14% 89%'),
     ring: HslColor.parse('210 10% 23%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   static final RefractionColors monoDark = RefractionColors(
@@ -618,6 +699,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     border: HslColor.parse('210 8% 16%'),
     input: HslColor.parse('210 8% 16%'),
     ring: HslColor.parse('210 10% 80%'),
+    success: Color(0xFF22C55E),
+    warning: Color(0xFFF59E0B),
+    info: Color(0xFF2196F3),
   );
 
   /// Default light palette. Currently aliases [minimalLight].
@@ -657,6 +741,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     Color? border,
     Color? input,
     Color? ring,
+    Color? success,
+    Color? warning,
+    Color? info,
   }) {
     return RefractionColors(
       primary: primary ?? this.primary,
@@ -679,6 +766,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
       border: border ?? this.border,
       input: input ?? this.input,
       ring: ring ?? this.ring,
+      success: success ?? this.success,
+      warning: warning ?? this.warning,
+      info: info ?? this.info,
     );
   }
 
@@ -737,6 +827,9 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
       border: Color.lerp(border, other.border, t)!,
       input: Color.lerp(input, other.input, t)!,
       ring: Color.lerp(ring, other.ring, t)!,
+      success: Color.lerp(success, other.success, t)!,
+      warning: Color.lerp(warning, other.warning, t)!,
+      info: Color.lerp(info, other.info, t)!,
     );
   }
 }

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refraction_ui
 description: "A headless, highly customizable, and fully accessible Flutter UI library matching Refraction UI."
-version: 0.47.0
+version: 0.47.1
 homepage: https://elloloop.github.io/refraction-ui
 repository: https://github.com/elloloop/refraction-ui
 issue_tracker: https://github.com/elloloop/refraction-ui/issues

--- a/packages/flutter/test/alert_test.dart
+++ b/packages/flutter/test/alert_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('RefractionAlert', () {
+    testWidgets('renders title and description', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionAlert(
+            title: 'Could not save changes',
+            description: 'Check your connection and retry.',
+          ),
+        ),
+      );
+
+      expect(find.text('Could not save changes'), findsOneWidget);
+      expect(find.text('Check your connection and retry.'), findsOneWidget);
+    });
+
+    testWidgets('tints title with the destructive token for destructive '
+        'variant', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionAlert(
+            title: 'Delete failed',
+            variant: RefractionAlertVariant.destructive,
+          ),
+        ),
+      );
+
+      final title = tester.widget<Text>(find.text('Delete failed'));
+      expect(
+        title.style!.color,
+        RefractionThemeData.light().colors.destructive,
+      );
+    });
+
+    testWidgets('renders icon and tappable action slot', (
+      WidgetTester tester,
+    ) async {
+      var retries = 0;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionAlert(
+            icon: const Icon(Icons.error_outline),
+            title: 'Sync paused',
+            action: GestureDetector(
+              onTap: () => retries++,
+              child: const Text('Retry'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      await tester.tap(find.text('Retry'));
+      expect(retries, 1);
+    });
+  });
+}

--- a/packages/flutter/test/bottom_nav_test.dart
+++ b/packages/flutter/test/bottom_nav_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const tabs = [
+    NavTab(label: 'Home', href: '/home', icon: Icon(Icons.home_outlined)),
+    NavTab(label: 'Search', href: '/search', icon: Icon(Icons.search)),
+    NavTab(
+      label: 'Profile',
+      href: '/profile',
+      icon: Icon(Icons.person_outline),
+    ),
+  ];
+
+  group('RefractionBottomNav', () {
+    testWidgets('renders every tab label', (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp(const RefractionBottomNav(tabs: tabs)));
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.text('Profile'), findsOneWidget);
+    });
+
+    testWidgets('highlights the tab matching currentPath', (
+      WidgetTester tester,
+    ) async {
+      final colors = RefractionThemeData.light().colors;
+      await tester.pumpWidget(
+        buildApp(const RefractionBottomNav(tabs: tabs, currentPath: '/search')),
+      );
+
+      final active = tester.widget<Text>(find.text('Search'));
+      final inactive = tester.widget<Text>(find.text('Home'));
+      expect(active.style!.color, colors.primary);
+      expect(active.style!.fontWeight, FontWeight.w600);
+      expect(inactive.style!.color, colors.mutedForeground);
+    });
+
+    testWidgets('emits the tapped tab href through onNavigate', (
+      WidgetTester tester,
+    ) async {
+      String? navigated;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionBottomNav(
+            tabs: tabs,
+            onNavigate: (href) => navigated = href,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Profile'));
+      expect(navigated, '/profile');
+    });
+  });
+}

--- a/packages/flutter/test/breadcrumbs_test.dart
+++ b/packages/flutter/test/breadcrumbs_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const items = [
+    BreadcrumbItem(label: 'Home', href: '/'),
+    BreadcrumbItem(label: 'Docs', href: '/docs'),
+    BreadcrumbItem(label: 'Breadcrumbs'),
+  ];
+
+  group('RefractionBreadcrumbs', () {
+    testWidgets('renders all segments with separators', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionBreadcrumbs(items: items)),
+      );
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Docs'), findsOneWidget);
+      expect(find.text('Breadcrumbs'), findsOneWidget);
+      expect(find.text('/'), findsNWidgets(2));
+    });
+
+    testWidgets('tapping a link segment emits its href', (
+      WidgetTester tester,
+    ) async {
+      String? navigated;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionBreadcrumbs(
+            items: items,
+            onNavigate: (href) => navigated = href,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Docs'));
+      expect(navigated, '/docs');
+    });
+
+    testWidgets('the final segment is emphasized and not tappable', (
+      WidgetTester tester,
+    ) async {
+      String? navigated;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionBreadcrumbs(
+            items: items,
+            onNavigate: (href) => navigated = href,
+          ),
+        ),
+      );
+
+      final current = tester.widget<Text>(find.text('Breadcrumbs'));
+      expect(current.style!.fontWeight, FontWeight.w600);
+
+      await tester.tap(find.text('Breadcrumbs'));
+      expect(navigated, isNull);
+    });
+  });
+}

--- a/packages/flutter/test/callout_test.dart
+++ b/packages/flutter/test/callout_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  /// The icon tint inside a [RefractionCallout] is the variant's foreground
+  /// color, so sampling the IconTheme proves which token the variant read.
+  IconThemeData iconThemeOf(WidgetTester tester) {
+    return tester
+        .widget<IconTheme>(
+          find.descendant(
+            of: find.byType(RefractionCallout),
+            matching: find.byType(IconTheme),
+          ),
+        )
+        .data;
+  }
+
+  group('RefractionCallout', () {
+    testWidgets('renders title, description, and default standard icon', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionCallout(
+            title: 'Tip',
+            description: 'You can drag files into the editor.',
+          ),
+        ),
+      );
+
+      expect(find.text('Tip'), findsOneWidget);
+      expect(find.text('You can drag files into the editor.'), findsOneWidget);
+      expect(find.byIcon(Icons.lightbulb_outline), findsOneWidget);
+    });
+
+    testWidgets('status variants route through the theme color tokens', (
+      WidgetTester tester,
+    ) async {
+      final colors = RefractionThemeData.light().colors;
+      final cases = <(RefractionCalloutVariant, IconData, Color)>[
+        (
+          RefractionCalloutVariant.success,
+          Icons.check_circle_outline,
+          colors.success,
+        ),
+        (
+          RefractionCalloutVariant.warning,
+          Icons.warning_amber_rounded,
+          colors.warning,
+        ),
+        (RefractionCalloutVariant.info, Icons.info_outline, colors.info),
+        (
+          RefractionCalloutVariant.error,
+          Icons.error_outline,
+          colors.destructive,
+        ),
+      ];
+
+      for (final (variant, icon, expectedColor) in cases) {
+        await tester.pumpWidget(
+          buildApp(RefractionCallout(description: 'msg', variant: variant)),
+        );
+
+        expect(find.byIcon(icon), findsOneWidget);
+        expect(iconThemeOf(tester).color, expectedColor);
+      }
+    });
+  });
+}

--- a/packages/flutter/test/chat_input_test.dart
+++ b/packages/flutter/test/chat_input_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('RefractionRichChatInput', () {
+    testWidgets('renders placeholder and icon slots', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionRichChatInput(
+            placeholder: 'Send a message...',
+            prefixIcon: Icon(Icons.add),
+            suffixIcon: Icon(Icons.send),
+          ),
+        ),
+      );
+
+      expect(find.text('Send a message...'), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.byIcon(Icons.send), findsOneWidget);
+    });
+
+    testWidgets('forwards keystrokes to onChanged', (
+      WidgetTester tester,
+    ) async {
+      String typed = '';
+      await tester.pumpWidget(
+        buildApp(RefractionRichChatInput(onChanged: (text) => typed = text)),
+      );
+
+      await tester.enterText(find.byType(TextField), 'hello');
+      expect(typed, 'hello');
+    });
+
+    testWidgets('Enter submits the text and clears the field', (
+      WidgetTester tester,
+    ) async {
+      String? submitted;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionRichChatInput(onSubmitted: (text) => submitted = text),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'ship it');
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(submitted, 'ship it');
+      expect(find.text('ship it'), findsNothing);
+    });
+
+    testWidgets('whitespace-only submissions are ignored', (
+      WidgetTester tester,
+    ) async {
+      var calls = 0;
+      await tester.pumpWidget(
+        buildApp(RefractionRichChatInput(onSubmitted: (_) => calls++)),
+      );
+
+      await tester.enterText(find.byType(TextField), '   ');
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(calls, 0);
+    });
+  });
+}

--- a/packages/flutter/test/command_menu_test.dart
+++ b/packages/flutter/test/command_menu_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('RefractionCommandMenu', () {
+    List<RefractionCommandGroup> groups({
+      VoidCallback? onSettings,
+      VoidCallback? onProfile,
+    }) {
+      return [
+        RefractionCommandGroup(
+          heading: 'General',
+          items: [
+            RefractionCommandItem(
+              icon: const Icon(Icons.settings),
+              label: 'Open Settings',
+              shortcut: 'Cmd+,',
+              onSelected: onSettings ?? () {},
+            ),
+            RefractionCommandItem(
+              icon: const Icon(Icons.person),
+              label: 'View Profile',
+              onSelected: onProfile ?? () {},
+            ),
+          ],
+        ),
+      ];
+    }
+
+    testWidgets('renders group heading, items, and placeholder', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(RefractionCommandMenu(groups: groups())),
+      );
+
+      expect(find.text('GENERAL'), findsOneWidget);
+      expect(find.text('Open Settings'), findsOneWidget);
+      expect(find.text('View Profile'), findsOneWidget);
+      expect(find.text('Type a command or search...'), findsOneWidget);
+      expect(find.text('Cmd+,'), findsOneWidget);
+    });
+
+    testWidgets('typing filters items and shows the empty state', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(RefractionCommandMenu(groups: groups())),
+      );
+
+      await tester.enterText(find.byType(TextField), 'sett');
+      await tester.pump();
+      expect(find.text('Open Settings'), findsOneWidget);
+      expect(find.text('View Profile'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'zzzz');
+      await tester.pump();
+      expect(find.text('No results found.'), findsOneWidget);
+    });
+
+    testWidgets('arrow keys move the highlight and Enter invokes it', (
+      WidgetTester tester,
+    ) async {
+      var settings = 0;
+      var profile = 0;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionCommandMenu(
+            groups: groups(
+              onSettings: () => settings++,
+              onProfile: () => profile++,
+            ),
+          ),
+        ),
+      );
+      // Let the post-frame callback focus the keyboard listener.
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(profile, 1);
+      expect(settings, 0);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(settings, 1);
+    });
+
+    testWidgets('tapping an item invokes onSelected', (
+      WidgetTester tester,
+    ) async {
+      var settings = 0;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionCommandMenu(groups: groups(onSettings: () => settings++)),
+        ),
+      );
+
+      await tester.tap(find.text('Open Settings'));
+      expect(settings, 1);
+    });
+  });
+}

--- a/packages/flutter/test/footer_test.dart
+++ b/packages/flutter/test/footer_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const footerColumns = [
+    FooterColumn(
+      title: 'Product',
+      links: [
+        FooterLink(label: 'Pricing', href: '/pricing'),
+        FooterLink(label: 'Docs', href: '/docs'),
+      ],
+    ),
+  ];
+
+  group('RefractionFooter', () {
+    testWidgets('renders columns, copyright, and social links', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionFooter(
+            copyright: '© 2026 Acme',
+            columns: footerColumns,
+            socialLinks: [
+              SocialLink(label: 'Twitter', href: 'https://x.com/acme'),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Product'), findsOneWidget);
+      expect(find.text('Pricing'), findsOneWidget);
+      expect(find.text('Docs'), findsOneWidget);
+      expect(find.text('© 2026 Acme'), findsOneWidget);
+      expect(find.text('Twitter'), findsOneWidget);
+    });
+
+    testWidgets('emits hrefs for column and social links', (
+      WidgetTester tester,
+    ) async {
+      final navigated = <String>[];
+      await tester.pumpWidget(
+        buildApp(
+          RefractionFooter(
+            copyright: '© 2026 Acme',
+            columns: footerColumns,
+            socialLinks: const [
+              SocialLink(label: 'Twitter', href: 'https://x.com/acme'),
+            ],
+            onNavigate: navigated.add,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Pricing'));
+      expect(navigated, ['/pricing']);
+
+      await tester.tap(find.text('Twitter'));
+      expect(navigated, ['/pricing', 'https://x.com/acme']);
+    });
+  });
+}

--- a/packages/flutter/test/input_group_test.dart
+++ b/packages/flutter/test/input_group_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('RefractionInputGroup', () {
+    testWidgets('horizontal orientation lays children out in an expanded row', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionInputGroup(
+            children: [
+              RefractionInputGroupAddon(child: Text('\$')),
+              RefractionInput(placeholder: 'Amount'),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('\$'), findsOneWidget);
+      expect(find.text('Amount'), findsOneWidget);
+
+      final rows = tester.widgetList<Row>(
+        find.descendant(
+          of: find.byType(RefractionInputGroup),
+          matching: find.byType(Row),
+        ),
+      );
+      final groupRow = rows.singleWhere(
+        (row) =>
+            row.children.length == 2 &&
+            row.children.every((child) => child is Expanded),
+      );
+      expect(groupRow.children.length, 2);
+    });
+
+    testWidgets('vertical orientation stacks children in a column', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionInputGroup(
+            orientation: RefractionInputGroupOrientation.vertical,
+            children: [Text('First'), Text('Second')],
+          ),
+        ),
+      );
+
+      final column = tester.widget<Column>(
+        find.descendant(
+          of: find.byType(RefractionInputGroup),
+          matching: find.byType(Column),
+        ),
+      );
+      expect(column.children.length, 2);
+    });
+
+    testWidgets('addon paints the muted token surface', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionInputGroupAddon(child: Text('kg'))),
+      );
+
+      final container = tester.widget<Container>(
+        find.descendant(
+          of: find.byType(RefractionInputGroupAddon),
+          matching: find.byType(Container),
+        ),
+      );
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, RefractionThemeData.light().colors.muted);
+    });
+  });
+}

--- a/packages/flutter/test/mobile_nav_test.dart
+++ b/packages/flutter/test/mobile_nav_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const items = [
+    RefractionMobileNavItem<String>(
+      label: 'Home',
+      icon: Icon(Icons.home_outlined),
+      activeIcon: Icon(Icons.home),
+      value: 'home',
+    ),
+    RefractionMobileNavItem<String>(
+      label: 'Search',
+      icon: Icon(Icons.search),
+      value: 'search',
+    ),
+  ];
+
+  group('RefractionMobileNav', () {
+    testWidgets('renders icons and labels', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionMobileNav<String>(items: items)),
+      );
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.byIcon(Icons.home_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('selected item uses the active icon and primary color', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionMobileNav<String>(
+            items: items,
+            selectedValue: 'home',
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.home), findsOneWidget);
+      expect(find.byIcon(Icons.home_outlined), findsNothing);
+
+      final label = tester.widget<Text>(find.text('Home'));
+      expect(label.style!.color, RefractionThemeData.light().colors.primary);
+    });
+
+    testWidgets('tapping an item emits its value', (WidgetTester tester) async {
+      String? selected;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionMobileNav<String>(
+            items: items,
+            onSelect: (value) => selected = value,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Search'));
+      expect(selected, 'search');
+    });
+
+    testWidgets('showLabels false hides the labels', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionMobileNav<String>(items: items, showLabels: false),
+        ),
+      );
+
+      expect(find.text('Home'), findsNothing);
+      expect(find.byIcon(Icons.home_outlined), findsOneWidget);
+    });
+  });
+}

--- a/packages/flutter/test/navbar_test.dart
+++ b/packages/flutter/test/navbar_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const links = [
+    NavLink(label: 'Home', href: '/'),
+    NavLink(label: 'Pricing', href: '/pricing'),
+    NavLink(label: 'Docs', href: '/docs'),
+  ];
+
+  group('RefractionNavbar', () {
+    testWidgets('renders logo, links, and actions on a wide viewport', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionNavbar(
+            logo: Text('Acme'),
+            links: links,
+            currentPath: '/pricing',
+            actions: Text('Sign in'),
+          ),
+        ),
+      );
+
+      expect(find.text('Acme'), findsOneWidget);
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Pricing'), findsOneWidget);
+      expect(find.text('Docs'), findsOneWidget);
+      expect(find.text('Sign in'), findsOneWidget);
+
+      final active = tester.widget<Text>(find.text('Pricing'));
+      expect(active.style!.fontWeight, FontWeight.w600);
+    });
+
+    testWidgets('tapping a link emits its href', (WidgetTester tester) async {
+      String? navigated;
+      await tester.pumpWidget(
+        buildApp(
+          RefractionNavbar(
+            links: links,
+            onNavigate: (href) => navigated = href,
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Docs'));
+      expect(navigated, '/docs');
+    });
+
+    testWidgets('mobile layout collapses the links but keeps logo/actions', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionNavbar(
+            logo: Text('Acme'),
+            links: links,
+            actions: Text('Sign in'),
+            forceMobileLayout: true,
+          ),
+        ),
+      );
+
+      expect(find.text('Acme'), findsOneWidget);
+      expect(find.text('Sign in'), findsOneWidget);
+      expect(find.text('Pricing'), findsNothing);
+    });
+
+    testWidgets('reserves the fixed h-14 height', (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp(const RefractionNavbar()));
+
+      expect(tester.getSize(find.byType(RefractionNavbar)).height, 56.0);
+    });
+  });
+}

--- a/packages/flutter/test/refraction_colors_test.dart
+++ b/packages/flutter/test/refraction_colors_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  group('RefractionColors status tokens', () {
+    test('every curated palette exposes the shared status hues', () {
+      // Components historically hardcoded these hues regardless of palette;
+      // the tokens keep that behavior so re-theming a palette never shifts
+      // status colors under an existing app.
+      const expectedSuccess = Color(0xFF22C55E);
+      const expectedWarning = Color(0xFFF59E0B);
+      const expectedInfo = Color(0xFF2196F3);
+
+      final palettes = <RefractionColors>[
+        RefractionColors.minimalLight,
+        RefractionColors.minimalDark,
+        RefractionColors.fintechLight,
+        RefractionColors.fintechDark,
+        RefractionColors.wellnessLight,
+        RefractionColors.wellnessDark,
+        RefractionColors.creativeLight,
+        RefractionColors.creativeDark,
+        RefractionColors.productivityLight,
+        RefractionColors.productivityDark,
+        RefractionColors.refractionLight,
+        RefractionColors.refractionDark,
+        RefractionColors.luxeLight,
+        RefractionColors.luxeDark,
+        RefractionColors.warmLight,
+        RefractionColors.warmDark,
+        RefractionColors.signalLight,
+        RefractionColors.signalDark,
+        RefractionColors.pulseLight,
+        RefractionColors.pulseDark,
+        RefractionColors.monoLight,
+        RefractionColors.monoDark,
+      ];
+
+      for (final palette in palettes) {
+        expect(palette.success, expectedSuccess);
+        expect(palette.warning, expectedWarning);
+        expect(palette.info, expectedInfo);
+      }
+    });
+
+    test('copyWith overrides a status token and keeps the rest', () {
+      const override = Color(0xFF123456);
+      final palette =
+          RefractionColors.minimalLight.copyWith(success: override)
+              as RefractionColors;
+
+      expect(palette.success, override);
+      expect(palette.warning, RefractionColors.minimalLight.warning);
+      expect(palette.info, RefractionColors.minimalLight.info);
+      expect(palette.primary, RefractionColors.minimalLight.primary);
+    });
+
+    test('lerp interpolates status tokens between palettes', () {
+      final other = RefractionColors.minimalLight.copyWith(
+        success: const Color(0xFF000000),
+      );
+      final halfway =
+          RefractionColors.minimalLight.lerp(other, 0.5) as RefractionColors;
+
+      expect(
+        halfway.success,
+        Color.lerp(
+          RefractionColors.minimalLight.success,
+          const Color(0xFF000000),
+          0.5,
+        ),
+      );
+      // Untouched tokens land on the shared value.
+      expect(halfway.warning, RefractionColors.minimalLight.warning);
+    });
+  });
+}

--- a/packages/flutter/test/search_bar_test.dart
+++ b/packages/flutter/test/search_bar_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  group('RefractionSearchBar', () {
+    testWidgets('renders the placeholder', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionSearchBar(placeholder: 'Search docs...')),
+      );
+
+      expect(find.text('Search docs...'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('onChanged fires immediately per keystroke', (
+      WidgetTester tester,
+    ) async {
+      final changes = <String>[];
+      await tester.pumpWidget(
+        buildApp(RefractionSearchBar(onChanged: changes.add)),
+      );
+
+      await tester.enterText(find.byType(TextField), 'ref');
+      expect(changes, ['ref']);
+    });
+
+    testWidgets('onSearch fires once after the debounce elapses', (
+      WidgetTester tester,
+    ) async {
+      final searches = <String>[];
+      await tester.pumpWidget(
+        buildApp(
+          RefractionSearchBar(
+            debounceDuration: const Duration(milliseconds: 300),
+            onSearch: searches.add,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'r');
+      // A second keystroke inside the window resets the pending timer.
+      await tester.pump(const Duration(milliseconds: 150));
+      await tester.enterText(find.byType(TextField), 'ref');
+      await tester.pump(const Duration(milliseconds: 299));
+      expect(searches, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 2));
+      expect(searches, ['ref']);
+    });
+
+    testWidgets('isLoading shows a progress indicator suffix', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionSearchBar(isLoading: true)),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+}

--- a/packages/flutter/test/select_test.dart
+++ b/packages/flutter/test/select_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  const cityItems = [
+    DropdownMenuItem(value: 'sf', child: Text('San Francisco')),
+    DropdownMenuItem(value: 'nyc', child: Text('New York')),
+    DropdownMenuItem(value: 'tk', child: Text('Tokyo')),
+  ];
+
+  group('RefractionSelect', () {
+    testWidgets('shows the placeholder when no value is selected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionSelect<String>(
+            items: cityItems,
+            placeholder: 'Choose a city',
+          ),
+        ),
+      );
+
+      expect(find.text('Choose a city'), findsOneWidget);
+    });
+
+    testWidgets('opening the dropdown and picking an item emits onChanged', (
+      WidgetTester tester,
+    ) async {
+      String? selected = 'sf';
+      await tester.pumpWidget(
+        buildApp(
+          RefractionSelect<String>(
+            items: cityItems,
+            value: selected,
+            onChanged: (value) => selected = value,
+          ),
+        ),
+      );
+
+      expect(find.text('San Francisco'), findsOneWidget);
+
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('New York').last);
+      await tester.pumpAndSettle();
+
+      expect(selected, 'nyc');
+    });
+
+    testWidgets('disabled select does not open the dropdown', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionSelect<String>(
+            items: cityItems,
+            placeholder: 'Choose a city',
+            disabled: true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New York'), findsNothing);
+    });
+  });
+}

--- a/packages/flutter/test/skeleton_test.dart
+++ b/packages/flutter/test/skeleton_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: RefractionTheme(
+        data: RefractionThemeData.light(),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  double opacityOf(WidgetTester tester) {
+    return tester
+        .widget<FadeTransition>(
+          find.descendant(
+            of: find.byType(RefractionSkeleton),
+            matching: find.byType(FadeTransition),
+          ),
+        )
+        .opacity
+        .value;
+  }
+
+  group('RefractionSkeleton', () {
+    testWidgets('honors explicit width and height', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionSkeleton(width: 120, height: 20, animate: false),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(RefractionSkeleton)),
+        const Size(120, 20),
+      );
+    });
+
+    testWidgets('circular shape mirrors width into height', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionSkeleton(
+            shape: SkeletonShape.circular,
+            width: 40,
+            animate: false,
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(RefractionSkeleton)),
+        const Size(40, 40),
+      );
+    });
+
+    testWidgets('text shape defaults to a 16px line', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const RefractionSkeleton(
+            shape: SkeletonShape.text,
+            width: 200,
+            animate: false,
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(RefractionSkeleton)).height, 16.0);
+    });
+
+    testWidgets('pulses opacity while animating and stays solid when not', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(const RefractionSkeleton(width: 100, height: 100)),
+      );
+      final initial = opacityOf(tester);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(opacityOf(tester), isNot(initial));
+
+      await tester.pumpWidget(
+        buildApp(const RefractionSkeleton(width: 100, animate: false)),
+      );
+      expect(opacityOf(tester), 1.0);
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(opacityOf(tester), 1.0);
+    });
+
+    testWidgets('RefractionSkeletonText renders one skeleton per line', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildApp(
+          const SizedBox(
+            width: 300,
+            child: RefractionSkeletonText(lines: 4, animate: false),
+          ),
+        ),
+      );
+
+      expect(find.byType(RefractionSkeleton), findsNWidgets(4));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Second Flutter batch. Full suite including goldens passes (+2570), analyze clean, publish dry-run clean.

- **Token-routed status colors**: added `success`/`warning`/`info` to RefractionColors (all 22 palettes + copyWith + lerp) and routed callout/empty_state/input/audio_room/logger/browser_chrome_mock through them. Values chosen so pixel output is unchanged except three disclosed micro-shifts (callout success/warning, browser-chrome live badge — no golden covers those widgets); enables the README's 're-skin in one place' promise
- **13 widget tests** for previously untested exported widgets (alert, callout, bottom_nav, breadcrumbs, chat_input, command_menu, footer, input_group, mobile_nav, navbar, search_bar, select, skeleton) — incl. interaction tests (Select overlay, CommandMenu keyboard nav, SearchBar 300ms debounce via fake-async)
- **Widgetbook**: 7 missing use-cases added; directories regenerated via build_runner (73 → 80 widgets)
- **Release prep**: pubspec 0.47.1 + CHANGELOG covering this and the sibling hygiene PR

## Checklist
- [x] Tests added or updated (13 new suites + token tests)
- [x] Axe/Accessibility checks pass (n/a)
- [x] Docs updated (CHANGELOG)
- [ ] Changeset added if package API changed (Flutter releases via tag workflow — tag refraction_ui-v0.47.1 after merge)

## Breaking changes?
RefractionColors' new tokens are **required** constructor params — technically breaking for direct constructors (none exist internally; palette consumers via RefractionTheme are unaffected). Flagged in CHANGELOG.