### PR TITLE
feat(react): real headless cores for accordion/carousel/pagination/slider + FileTree implementation

### DIFF
--- a/.changeset/hollow-cores-filetree.md
+++ b/.changeset/hollow-cores-filetree.md
@@ -1,0 +1,11 @@
+---
+"@refraction-ui/react": minor
+---
+
+feat: real accordion/carousel/pagination/slider headless cores + FileTree implementation
+
+- `@refraction-ui/accordion` core owns the disclosure state machine (single/multiple, collapsible, controlled+uncontrolled); `react-accordion` consumes it (public API unchanged).
+- `@refraction-ui/carousel` core shares that state machine (the shipped "Carousel" is an expand/collapse panel set, as demoed on the docs site); `react-carousel` consumes it (public API unchanged).
+- `@refraction-ui/pagination` core computes the windowed page range with ellipses plus prev/next edges and nav ARIA; `react-pagination` now renders a real pagination nav (children still override the generated controls).
+- `@refraction-ui/slider` core owns value clamping/step rounding, keyboard rules, and slider ARIA; `react-slider` is wired to it (`onChange` now reports the numeric value, as the docs already promised).
+- `@refraction-ui/file-tree` core + `react-file-tree` implement a real tree view (node model, expand/collapse, selection, treeview keyboard navigation, ARIA); `<FileTree />` no longer renders an empty div.

--- a/docs-site/src/app/components/file-tree/FileTree.stories.tsx
+++ b/docs-site/src/app/components/file-tree/FileTree.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { FileTree } from '@refraction-ui/react-file-tree'
+import { FileTree, type FileTreeNode } from '@refraction-ui/react-file-tree'
 
 const meta: Meta<typeof FileTree> = {
   title: 'Data Display/FileTree',
@@ -8,60 +8,44 @@ const meta: Meta<typeof FileTree> = {
     layout: 'centered',
   },
   args: {
+    defaultExpandedIds: ['src'],
   },
   argTypes: {
+    onExpandedChange: { action: 'expandedChange' },
+    onSelectionChange: { action: 'selectionChange' },
   },
 }
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-// The FileTree component is an early-stage primitive. We render a small
-// representative tree alongside the live component so the page documents the
-// intended shape; the live <FileTree /> renders its (currently minimal) output.
-interface TreeNode {
-  name: string
-  children?: TreeNode[]
-}
-
-const SAMPLE: TreeNode[] = [
+const SAMPLE: FileTreeNode[] = [
   {
-    name: 'src',
+    id: 'src',
+    label: 'src',
     children: [
-      { name: 'index.ts' },
+      { id: 'src/index.ts', label: 'index.ts' },
       {
-        name: 'components',
-        children: [{ name: 'button.tsx' }, { name: 'input.tsx' }],
+        id: 'src/components',
+        label: 'components',
+        children: [
+          { id: 'src/components/button.tsx', label: 'button.tsx' },
+          { id: 'src/components/input.tsx', label: 'input.tsx' },
+        ],
       },
     ],
   },
-  { name: 'package.json' },
-  { name: 'README.md' },
+  { id: 'package.json', label: 'package.json' },
+  { id: 'README.md', label: 'README.md' },
 ]
 
-function Tree({ nodes, depth = 0 }: { nodes: TreeNode[]; depth?: number }) {
-  return (
-    <ul className="space-y-1">
-      {nodes.map((node) => (
-        <li key={node.name}>
-          <div
-            className="flex items-center gap-1.5 text-sm text-foreground"
-            style={{ paddingLeft: depth * 16 }}
-          >
-            <span className="text-muted-foreground">{node.children ? '▸' : '·'}</span>
-            <span className={node.children ? 'font-medium' : 'text-muted-foreground'}>{node.name}</span>
-          </div>
-          {node.children ? <Tree nodes={node.children} depth={depth + 1} /> : null}
-        </li>
-      ))}
-    </ul>
-  )
-}
-
 export const Default: Story = {
+  args: {
+    nodes: SAMPLE,
+    defaultSelectedId: 'package.json',
+  },
   render: (args) => (
-    <div className="flex flex-col gap-4">
-      <Tree nodes={SAMPLE} />
+    <div className="w-72">
       <FileTree {...args} />
     </div>
   ),

--- a/docs-site/src/app/components/file-tree/examples.tsx
+++ b/docs-site/src/app/components/file-tree/examples.tsx
@@ -1,48 +1,26 @@
 'use client'
 
-import { FileTree } from '@refraction-ui/react-file-tree'
+import { FileTree, type FileTreeNode } from '@refraction-ui/react-file-tree'
 
-// The FileTree component is an early-stage primitive. We render a small
-// representative tree alongside the live component so the page documents the
-// intended shape; the live <FileTree /> renders its (currently minimal) output.
-interface TreeNode {
-  name: string
-  children?: TreeNode[]
-}
-
-const SAMPLE: TreeNode[] = [
+const SAMPLE: FileTreeNode[] = [
   {
-    name: 'src',
+    id: 'src',
+    label: 'src',
     children: [
-      { name: 'index.ts' },
+      { id: 'src/index.ts', label: 'index.ts' },
       {
-        name: 'components',
-        children: [{ name: 'button.tsx' }, { name: 'input.tsx' }],
+        id: 'src/components',
+        label: 'components',
+        children: [
+          { id: 'src/components/button.tsx', label: 'button.tsx' },
+          { id: 'src/components/input.tsx', label: 'input.tsx' },
+        ],
       },
     ],
   },
-  { name: 'package.json' },
-  { name: 'README.md' },
+  { id: 'package.json', label: 'package.json' },
+  { id: 'README.md', label: 'README.md' },
 ]
-
-function Tree({ nodes, depth = 0 }: { nodes: TreeNode[]; depth?: number }) {
-  return (
-    <ul className="space-y-1">
-      {nodes.map((node) => (
-        <li key={node.name}>
-          <div
-            className="flex items-center gap-1.5 text-sm text-foreground"
-            style={{ paddingLeft: depth * 16 }}
-          >
-            <span className="text-muted-foreground">{node.children ? '▸' : '·'}</span>
-            <span className={node.children ? 'font-medium' : 'text-muted-foreground'}>{node.name}</span>
-          </div>
-          {node.children ? <Tree nodes={node.children} depth={depth + 1} /> : null}
-        </li>
-      ))}
-    </ul>
-  )
-}
 
 interface FileTreeExamplesProps {
   section: 'basic'
@@ -52,9 +30,12 @@ export function FileTreeExamples({ section }: FileTreeExamplesProps) {
   if (section === 'basic') {
     return (
       <div className="rounded-xl border border-border bg-card p-8">
-        <Tree nodes={SAMPLE} />
-        {/* Live component — renders its current (minimal) output. */}
-        <FileTree />
+        <FileTree
+          nodes={SAMPLE}
+          defaultExpandedIds={['src']}
+          defaultSelectedId="package.json"
+          className="max-w-sm"
+        />
       </div>
     )
   }

--- a/docs-site/src/app/components/file-tree/page.tsx
+++ b/docs-site/src/app/components/file-tree/page.tsx
@@ -5,17 +5,56 @@ import { InstallCommand } from '@/components/install-command'
 
 const fileTreeProps = [
   {
-    name: 'FileTree',
-    type: 'React.FC',
+    name: 'nodes',
+    type: 'FileTreeNode[]',
     description:
-      'Renders a hierarchical file/folder tree. The component is an early-stage primitive — the props API (nodes, selection, expand/collapse) is still being finalized.',
+      'Root-level nodes. Each node is `{ id, label, children?, disabled? }`; nodes with `children` render as expandable folders.',
+  },
+  {
+    name: 'expandedIds',
+    type: 'string[]',
+    description: 'Controlled expanded node ids. Pair with `onExpandedChange`.',
+  },
+  {
+    name: 'defaultExpandedIds',
+    type: 'string[]',
+    description: 'Uncontrolled initial expanded node ids.',
+  },
+  {
+    name: 'selectedId',
+    type: 'string | null',
+    description: 'Controlled selected node id. Pair with `onSelectionChange`.',
+  },
+  {
+    name: 'defaultSelectedId',
+    type: 'string | null',
+    description: 'Uncontrolled initial selected node id.',
+  },
+  {
+    name: 'onExpandedChange',
+    type: '(ids: string[]) => void',
+    description: 'Called whenever the expanded set changes (click, ArrowRight/ArrowLeft).',
+  },
+  {
+    name: 'onSelectionChange',
+    type: '(id: string | null) => void',
+    description: 'Called whenever the selection changes (click, Enter, Space).',
   },
 ]
 
-const usageCode = `import { FileTree } from '@refraction-ui/react'
+const usageCode = `import { FileTree, type FileTreeNode } from '@refraction-ui/react'
+
+const nodes: FileTreeNode[] = [
+  {
+    id: 'src',
+    label: 'src',
+    children: [{ id: 'src/index.ts', label: 'index.ts' }],
+  },
+  { id: 'package.json', label: 'package.json' },
+]
 
 export function MyComponent() {
-  return <FileTree />
+  return <FileTree nodes={nodes} defaultExpandedIds={['src']} />
 }`
 
 export default function FileTreePage() {
@@ -29,15 +68,16 @@ export default function FileTreePage() {
         </div>
         <h1 className="text-3xl font-bold tracking-tight text-foreground">File Tree</h1>
         <p className="mt-3 text-lg leading-relaxed text-muted-foreground">
-          A hierarchical view of files and folders. This is an early-stage primitive — the example below shows the
-          intended layout while the props API is finalized.
+          A hierarchical view of files and folders with expand/collapse, selection, and keyboard
+          navigation (WAI-ARIA treeview).
         </p>
       </div>
 
       <section className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">Overview</h2>
         <p className="text-sm text-muted-foreground">
-          A typical file tree nests folders and files with indentation per depth level.
+          A typical file tree nests folders and files with indentation per depth level. Arrow keys
+          move between rows; ArrowRight/ArrowLeft expand and collapse folders; Enter selects.
         </p>
         <FileTreeExamples section="basic" />
       </section>

--- a/packages/accordion/__tests__/accordion.test.ts
+++ b/packages/accordion/__tests__/accordion.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createAccordion, isItemOpen } from '../src/index.js'
+
+describe('createAccordion (single)', () => {
+  it('starts fully closed by default', () => {
+    const api = createAccordion()
+    expect(api.getState().value).toBe('')
+    expect(api.isOpen('a')).toBe(false)
+  })
+
+  it('opens the toggled item and closes it only when collapsible', () => {
+    const api = createAccordion()
+    api.toggleItem('a')
+    expect(api.getState().value).toBe('a')
+    // Not collapsible: re-toggling the open item keeps it open.
+    api.toggleItem('a')
+    expect(api.getState().value).toBe('a')
+
+    const collapsible = createAccordion({ collapsible: true })
+    collapsible.toggleItem('a')
+    collapsible.toggleItem('a')
+    expect(collapsible.getState().value).toBe('')
+  })
+
+  it('keeps only one item open at a time', () => {
+    const api = createAccordion()
+    api.toggleItem('a')
+    api.toggleItem('b')
+    expect(api.getState().value).toBe('b')
+    expect(api.isOpen('a')).toBe(false)
+    expect(api.isOpen('b')).toBe(true)
+  })
+
+  it('honors defaultValue for uncontrolled usage', () => {
+    const api = createAccordion({ defaultValue: 'b' })
+    expect(api.getState().value).toBe('b')
+  })
+})
+
+describe('createAccordion (multiple)', () => {
+  it('defaults to an empty array', () => {
+    const api = createAccordion({ type: 'multiple' })
+    expect(api.getState().value).toEqual([])
+  })
+
+  it('toggles items independently', () => {
+    const api = createAccordion({ type: 'multiple' })
+    api.toggleItem('a')
+    api.toggleItem('b')
+    expect(api.getState().value).toEqual(['a', 'b'])
+    api.toggleItem('a')
+    expect(api.getState().value).toEqual(['b'])
+  })
+
+  it('honors an array defaultValue', () => {
+    const api = createAccordion({ type: 'multiple', defaultValue: ['a', 'c'] })
+    expect(api.isOpen('a')).toBe(true)
+    expect(api.isOpen('b')).toBe(false)
+    expect(api.isOpen('c')).toBe(true)
+  })
+})
+
+describe('createAccordion (controlled)', () => {
+  it('uses the controlled value and reports changes without mutating it', () => {
+    const onValueChange = vi.fn()
+    const api = createAccordion({ value: 'a', onValueChange })
+    expect(api.getState().value).toBe('a')
+
+    api.toggleItem('b')
+    // Still the controlled value until the consumer syncs the new one.
+    expect(api.getState().value).toBe('a')
+    expect(onValueChange).toHaveBeenCalledWith('b')
+
+    api.setValue('b')
+    expect(api.getState().value).toBe('b')
+  })
+
+  it('setValue is a no-op (no emit) when the value is unchanged', () => {
+    const listener = vi.fn()
+    const api = createAccordion({ value: ['a'] })
+    api.subscribe(listener)
+    api.setValue(['a'])
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('createAccordion (subscription)', () => {
+  it('notifies listeners on change and stops after unsubscribe', () => {
+    const listener = vi.fn()
+    const api = createAccordion()
+    const unsubscribe = api.subscribe(listener)
+    api.toggleItem('a')
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+    api.toggleItem('b')
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('setOptions updates type/collapsible and the change callback', () => {
+    const onValueChange = vi.fn()
+    const api = createAccordion()
+    api.setOptions({ type: 'multiple', onValueChange })
+    expect(api.getState().type).toBe('multiple')
+    api.toggleItem('a')
+    api.toggleItem('b')
+    expect(onValueChange).toHaveBeenLastCalledWith(['a', 'b'])
+  })
+})
+
+describe('isItemOpen', () => {
+  it('matches single values and multiple membership', () => {
+    expect(isItemOpen({ type: 'single', collapsible: false, value: 'a' }, 'a')).toBe(true)
+    expect(isItemOpen({ type: 'single', collapsible: false, value: 'a' }, 'b')).toBe(false)
+    expect(
+      isItemOpen({ type: 'multiple', collapsible: false, value: ['a', 'b'] }, 'b'),
+    ).toBe(true)
+    expect(
+      isItemOpen({ type: 'multiple', collapsible: false, value: ['a', 'b'] }, 'c'),
+    ).toBe(false)
+  })
+
+  it('tolerates a mismatched value shape for the mode', () => {
+    expect(isItemOpen({ type: 'multiple', collapsible: false, value: 'a' }, 'a')).toBe(false)
+  })
+})

--- a/packages/accordion/src/accordion.ts
+++ b/packages/accordion/src/accordion.ts
@@ -1,0 +1,155 @@
+/**
+ * @refraction-ui/accordion — headless accordion (disclosure) state machine.
+ *
+ * Owns the *behavior* of an accordion: which item(s) are open, the single vs
+ * multiple expansion modes, and the collapsible toggle rule. It has NO UI
+ * opinion — React/Astro adapters subscribe to the store and render the parts.
+ */
+
+/** Expansion mode: one item open at a time, or any number. */
+export type AccordionType = 'single' | 'multiple'
+
+/** Open item id (`single`) or ids (`multiple`). */
+export type AccordionValue = string | string[]
+
+/** Options for {@link createAccordion}. */
+export interface AccordionConfig {
+  /** Expansion mode (default `'single'`). */
+  type?: AccordionType
+  /** When `type="single"`, allows the open item to be toggled fully closed. */
+  collapsible?: boolean
+  /** Controlled open item(s). Pair with `onValueChange`. */
+  value?: AccordionValue
+  /** Uncontrolled initial open item(s). */
+  defaultValue?: AccordionValue
+  /** Called whenever the open item(s) change. */
+  onValueChange?: (value: AccordionValue) => void
+}
+
+/** Snapshot of the store. Returned by `getState()`; treat as immutable. */
+export interface AccordionState {
+  type: AccordionType
+  collapsible: boolean
+  /** Current open item id (`single`) or ids (`multiple`). */
+  value: AccordionValue
+}
+
+/** The framework-agnostic store. React/Astro adapters wrap this. */
+export interface AccordionAPI {
+  /** Current immutable snapshot */
+  getState(): AccordionState
+  /** Subscribe to changes; returns an unsubscribe fn (suits useSyncExternalStore) */
+  subscribe(listener: () => void): () => void
+  /** Toggle an item open/closed per the type/collapsible rules */
+  toggleItem(itemValue: string): void
+  /** Whether an item is currently open */
+  isOpen(itemValue: string): boolean
+  /** Sync a controlled value into the store (adapters call when the prop changes) */
+  setValue(value: AccordionValue): void
+  /** Update options after creation (adapters keep props in sync) */
+  setOptions(options: {
+    type?: AccordionType
+    collapsible?: boolean
+    onValueChange?: (value: AccordionValue) => void
+  }): void
+}
+
+/** Pure open-state check shared by every adapter. */
+export function isItemOpen(state: AccordionState, itemValue: string): boolean {
+  return state.type === 'single'
+    ? state.value === itemValue
+    : Array.isArray(state.value) && state.value.includes(itemValue)
+}
+
+/** Shallow value equality (arrays compared item-by-item, order-sensitive). */
+function valueEquals(a: AccordionValue, b: AccordionValue): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => v === b[i])
+  }
+  return a === b
+}
+
+/**
+ * createAccordion — headless accordion store.
+ *
+ * Supports controlled (`value`) and uncontrolled (`defaultValue`) usage.
+ * `single` mode holds one open item id (`''` when all closed); `multiple`
+ * holds an array of open ids. In `single` mode, re-toggling the open item
+ * closes it only when `collapsible` is set.
+ */
+export function createAccordion(config: AccordionConfig = {}): AccordionAPI {
+  let type: AccordionType = config.type ?? 'single'
+  let collapsible: boolean = config.collapsible ?? false
+  let onValueChange = config.onValueChange
+
+  let uncontrolledValue: AccordionValue =
+    config.defaultValue ?? (type === 'multiple' ? [] : '')
+  let controlledValue: AccordionValue | undefined = config.value
+
+  const listeners = new Set<() => void>()
+  let snapshot: AccordionState = buildSnapshot()
+
+  function currentValue(): AccordionValue {
+    return controlledValue !== undefined ? controlledValue : uncontrolledValue
+  }
+
+  function buildSnapshot(): AccordionState {
+    return { type, collapsible, value: currentValue() }
+  }
+
+  function emit(): void {
+    snapshot = buildSnapshot()
+    for (const l of listeners) l()
+  }
+
+  const api: AccordionAPI = {
+    getState() {
+      return snapshot
+    },
+
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+
+    toggleItem(itemValue) {
+      const value = currentValue()
+      let next: AccordionValue
+      if (type === 'single') {
+        next = value === itemValue && collapsible ? '' : itemValue
+      } else {
+        const arrValue = Array.isArray(value) ? value : []
+        next = arrValue.includes(itemValue)
+          ? arrValue.filter((v) => v !== itemValue)
+          : [...arrValue, itemValue]
+      }
+      if (controlledValue === undefined) {
+        if (valueEquals(uncontrolledValue, next)) return
+        uncontrolledValue = next
+      }
+      onValueChange?.(next)
+      emit()
+    },
+
+    isOpen(itemValue) {
+      return isItemOpen(snapshot, itemValue)
+    },
+
+    setValue(value) {
+      if (controlledValue !== undefined && valueEquals(controlledValue, value)) return
+      controlledValue = value
+      emit()
+    },
+
+    setOptions(options) {
+      const prevType = type
+      const prevCollapsible = collapsible
+      if (options.type !== undefined) type = options.type
+      if (options.collapsible !== undefined) collapsible = options.collapsible
+      if (options.onValueChange !== undefined) onValueChange = options.onValueChange
+      if (type !== prevType || collapsible !== prevCollapsible) emit()
+    },
+  }
+
+  return api
+}

--- a/packages/accordion/src/index.ts
+++ b/packages/accordion/src/index.ts
@@ -1,1 +1,9 @@
-export {}
+export { createAccordion, isItemOpen } from './accordion.js'
+
+export type {
+  AccordionType,
+  AccordionValue,
+  AccordionConfig,
+  AccordionState,
+  AccordionAPI,
+} from './accordion.js'

--- a/packages/carousel/__tests__/carousel.test.ts
+++ b/packages/carousel/__tests__/carousel.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createCarousel, isItemOpen } from '../src/index.js'
+
+// The carousel core shares the accordion disclosure state machine (see the
+// package's honest note), so these tests pin the shipped behavior: single /
+// multiple open panels with an optional collapsible toggle.
+
+describe('createCarousel', () => {
+  it('behaves as a single-expand disclosure store by default', () => {
+    const api = createCarousel()
+    expect(api.getState().value).toBe('')
+
+    api.toggleItem('shipping')
+    expect(api.getState().value).toBe('shipping')
+    expect(api.isOpen('shipping')).toBe(true)
+
+    api.toggleItem('returns')
+    expect(api.getState().value).toBe('returns')
+    expect(api.isOpen('shipping')).toBe(false)
+  })
+
+  it('collapses the open item when collapsible', () => {
+    const api = createCarousel({ collapsible: true })
+    api.toggleItem('a')
+    api.toggleItem('a')
+    expect(api.getState().value).toBe('')
+  })
+
+  it('tracks multiple open items independently', () => {
+    const api = createCarousel({ type: 'multiple', defaultValue: ['a'] })
+    api.toggleItem('b')
+    expect(api.getState().value).toEqual(['a', 'b'])
+    api.toggleItem('a')
+    expect(api.getState().value).toEqual(['b'])
+  })
+
+  it('supports controlled value + onValueChange', () => {
+    const onValueChange = vi.fn()
+    const api = createCarousel({ value: 'a', onValueChange })
+    api.toggleItem('b')
+    expect(api.getState().value).toBe('a')
+    expect(onValueChange).toHaveBeenCalledWith('b')
+    api.setValue('b')
+    expect(api.isOpen('b')).toBe(true)
+  })
+
+  it('notifies subscribers on change', () => {
+    const listener = vi.fn()
+    const api = createCarousel()
+    api.subscribe(listener)
+    api.toggleItem('a')
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('isItemOpen (re-export)', () => {
+  it('checks open state for both modes', () => {
+    expect(isItemOpen({ type: 'single', collapsible: false, value: 'x' }, 'x')).toBe(true)
+    expect(
+      isItemOpen({ type: 'multiple', collapsible: false, value: ['x', 'y'] }, 'y'),
+    ).toBe(true)
+    expect(
+      isItemOpen({ type: 'multiple', collapsible: false, value: ['x', 'y'] }, 'z'),
+    ).toBe(false)
+  })
+})

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -25,6 +25,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@refraction-ui/accordion": "workspace:*",
     "@refraction-ui/shared": "workspace:*"
   },
   "devDependencies": {},

--- a/packages/carousel/src/carousel.ts
+++ b/packages/carousel/src/carousel.ts
@@ -1,0 +1,45 @@
+/**
+ * @refraction-ui/carousel — headless "carousel" store.
+ *
+ * Honest note: despite the name, this component is an expand/collapse panel
+ * set (an accordion in disguise) — that is the behavior the React adapter and
+ * the docs site demo (single/multiple open panels, collapsible toggles). The
+ * state machine is therefore shared with `@refraction-ui/accordion` rather
+ * than duplicated. A real slide-navigation carousel (active index, next/prev)
+ * would be a different core; this package keeps the shipped behavior.
+ */
+import {
+  createAccordion,
+  isItemOpen,
+  type AccordionAPI,
+  type AccordionConfig,
+  type AccordionState,
+  type AccordionType,
+  type AccordionValue,
+} from '@refraction-ui/accordion'
+
+/** Expansion mode: one item open at a time, or any number. */
+export type CarouselType = AccordionType
+
+/** Open item id (`single`) or ids (`multiple`). */
+export type CarouselValue = AccordionValue
+
+/** Options for {@link createCarousel}. Mirrors {@link AccordionConfig}. */
+export interface CarouselConfig extends AccordionConfig {}
+
+/** Snapshot of the store. Returned by `getState()`; treat as immutable. */
+export interface CarouselState extends AccordionState {}
+
+/** The framework-agnostic store. React/Astro adapters wrap this. */
+export type CarouselAPI = AccordionAPI
+
+/**
+ * createCarousel — headless expand/collapse panel store. This is the
+ * accordion state machine under the carousel name; see the package note.
+ */
+export function createCarousel(config: CarouselConfig = {}): CarouselAPI {
+  return createAccordion(config)
+}
+
+/** Pure open-state check shared by every adapter. */
+export { isItemOpen }

--- a/packages/carousel/src/index.ts
+++ b/packages/carousel/src/index.ts
@@ -1,1 +1,9 @@
-export {}
+export { createCarousel, isItemOpen } from './carousel.js'
+
+export type {
+  CarouselType,
+  CarouselValue,
+  CarouselConfig,
+  CarouselState,
+  CarouselAPI,
+} from './carousel.js'

--- a/packages/file-tree/__tests__/file-tree.test.ts
+++ b/packages/file-tree/__tests__/file-tree.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createFileTree, type FileTreeNode } from '../src/index.js'
+
+const NODES: FileTreeNode[] = [
+  {
+    id: 'src',
+    label: 'src',
+    children: [
+      { id: 'src/index.ts', label: 'index.ts' },
+      {
+        id: 'src/components',
+        label: 'components',
+        children: [
+          { id: 'src/components/button.tsx', label: 'button.tsx' },
+          { id: 'src/components/input.tsx', label: 'input.tsx' },
+        ],
+      },
+    ],
+  },
+  { id: 'package.json', label: 'package.json' },
+  { id: 'README.md', label: 'README.md' },
+]
+
+const ids = (items: { node: FileTreeNode }[]) => items.map((i) => i.node.id)
+
+describe('createFileTree (visibility)', () => {
+  it('lists only roots when fully collapsed', () => {
+    const api = createFileTree({ nodes: NODES })
+    expect(ids(api.getVisibleItems())).toEqual(['src', 'package.json', 'README.md'])
+  })
+
+  it('expands/collapses parents, revealing children in DFS order', () => {
+    const api = createFileTree({ nodes: NODES, defaultExpandedIds: ['src'] })
+    expect(ids(api.getVisibleItems())).toEqual([
+      'src',
+      'src/index.ts',
+      'src/components',
+      'package.json',
+      'README.md',
+    ])
+
+    api.expand('src/components')
+    expect(ids(api.getVisibleItems())).toEqual([
+      'src',
+      'src/index.ts',
+      'src/components',
+      'src/components/button.tsx',
+      'src/components/input.tsx',
+      'package.json',
+      'README.md',
+    ])
+
+    api.collapse('src')
+    expect(ids(api.getVisibleItems())).toEqual(['src', 'package.json', 'README.md'])
+  })
+
+  it('tracks depth and parent ids', () => {
+    const api = createFileTree({ nodes: NODES, defaultExpandedIds: ['src', 'src/components'] })
+    const button = api.getVisibleItems().find((i) => i.node.id === 'src/components/button.tsx')!
+    expect(button.depth).toBe(3)
+    expect(button.parentId).toBe('src/components')
+    expect(button.hasChildren).toBe(false)
+  })
+
+  it('toggle no-ops on leaves and unknown ids', () => {
+    const onExpandedChange = vi.fn()
+    const api = createFileTree({ nodes: NODES, onExpandedChange })
+    api.toggle('package.json')
+    api.toggle('nope')
+    expect(api.getState().expandedIds).toEqual([])
+    expect(onExpandedChange).not.toHaveBeenCalled()
+  })
+
+  it('reports expansion changes and supports a controlled expanded set', () => {
+    const onExpandedChange = vi.fn()
+    const api = createFileTree({ nodes: NODES, expandedIds: [], onExpandedChange })
+    api.expand('src')
+    // Controlled: state does not change until the consumer syncs it.
+    expect(api.getState().expandedIds).toEqual([])
+    expect(onExpandedChange).toHaveBeenCalledWith(['src'])
+    api.setExpandedIds(['src'])
+    expect(api.isExpanded('src')).toBe(true)
+  })
+})
+
+describe('createFileTree (selection)', () => {
+  it('selects and clears nodes', () => {
+    const api = createFileTree({ nodes: NODES })
+    api.select('package.json')
+    expect(api.getState().selectedId).toBe('package.json')
+    api.select(null)
+    expect(api.getState().selectedId).toBeNull()
+  })
+
+  it('rejects unknown and disabled nodes', () => {
+    const api = createFileTree({
+      nodes: [{ id: 'locked', label: 'locked', disabled: true }],
+    })
+    api.select('locked')
+    api.select('nope')
+    expect(api.getState().selectedId).toBeNull()
+  })
+
+  it('supports controlled selection', () => {
+    const onSelectionChange = vi.fn()
+    const api = createFileTree({ nodes: NODES, selectedId: null, onSelectionChange })
+    api.select('README.md')
+    expect(api.getState().selectedId).toBeNull()
+    expect(onSelectionChange).toHaveBeenCalledWith('README.md')
+    api.setSelectedId('README.md')
+    expect(api.getState().selectedId).toBe('README.md')
+  })
+})
+
+describe('createFileTree (keyboard)', () => {
+  it('moves focus with arrows and Home/End over visible rows', () => {
+    const api = createFileTree({ nodes: NODES, defaultExpandedIds: ['src'] })
+    api.handleKey('ArrowDown')
+    expect(api.getState().focusedId).toBe('src')
+    api.handleKey('ArrowDown')
+    expect(api.getState().focusedId).toBe('src/index.ts')
+    api.handleKey('ArrowUp')
+    expect(api.getState().focusedId).toBe('src')
+    api.handleKey('End')
+    expect(api.getState().focusedId).toBe('README.md')
+    api.handleKey('Home')
+    expect(api.getState().focusedId).toBe('src')
+  })
+
+  it('ArrowRight expands a closed parent, then descends to the first child', () => {
+    const api = createFileTree({ nodes: NODES })
+    api.focus('src')
+    api.handleKey('ArrowRight')
+    expect(api.isExpanded('src')).toBe(true)
+    expect(api.getState().focusedId).toBe('src')
+    api.handleKey('ArrowRight')
+    expect(api.getState().focusedId).toBe('src/index.ts')
+    // Leaf: no-op.
+    api.handleKey('ArrowRight')
+    expect(api.getState().focusedId).toBe('src/index.ts')
+  })
+
+  it('ArrowLeft collapses an open parent, then ascends to the parent', () => {
+    const api = createFileTree({ nodes: NODES, defaultExpandedIds: ['src'] })
+    api.focus('src')
+    api.handleKey('ArrowLeft')
+    expect(api.isExpanded('src')).toBe(false)
+
+    // On a closed (or leaf) child, ArrowLeft ascends to its parent.
+    api.expand('src')
+    api.focus('src/components')
+    api.handleKey('ArrowLeft')
+    expect(api.getState().focusedId).toBe('src')
+  })
+
+  it('Enter and Space select the focused node', () => {
+    const api = createFileTree({ nodes: NODES })
+    api.focus('package.json')
+    api.handleKey('Enter')
+    expect(api.getState().selectedId).toBe('package.json')
+    api.focus('README.md')
+    api.handleKey(' ')
+    expect(api.getState().selectedId).toBe('README.md')
+  })
+
+  it('ignores unhandled keys', () => {
+    const api = createFileTree({ nodes: NODES })
+    api.focus('src')
+    api.handleKey('Tab')
+    expect(api.getState().focusedId).toBe('src')
+  })
+})
+
+describe('createFileTree (aria)', () => {
+  it('exposes tree/treeitem ARIA', () => {
+    const api = createFileTree({ nodes: NODES, defaultExpandedIds: ['src'] })
+    expect(api.getTreeAria().role).toBe('tree')
+    expect(api.getTreeAria()['aria-label']).toBe('File tree')
+
+    const [root, child] = api.getVisibleItems()
+    expect(api.getItemAria(root!)).toMatchObject({
+      role: 'treeitem',
+      'aria-level': 1,
+      'aria-expanded': true,
+      'aria-selected': false,
+    })
+    // Leaves carry no aria-expanded.
+    expect(api.getItemAria(child!)['aria-expanded']).toBeUndefined()
+    expect(api.getItemAria(child!)['aria-level']).toBe(2)
+  })
+
+  it('marks disabled nodes with aria-disabled', () => {
+    const api = createFileTree({ nodes: [{ id: 'a', label: 'a', disabled: true }] })
+    const [item] = api.getVisibleItems()
+    expect(api.getItemAria(item!)['aria-disabled']).toBe(true)
+  })
+})
+
+describe('createFileTree (subscription)', () => {
+  it('notifies on changes and stops after unsubscribe', () => {
+    const listener = vi.fn()
+    const api = createFileTree({ nodes: NODES })
+    const unsubscribe = api.subscribe(listener)
+    api.expand('src')
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+    api.collapse('src')
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('setNodes replaces the model and reindexes', () => {
+    const api = createFileTree({ nodes: [] })
+    expect(api.getVisibleItems()).toEqual([])
+    api.setNodes(NODES)
+    expect(ids(api.getVisibleItems())).toEqual(['src', 'package.json', 'README.md'])
+    api.select('README.md')
+    expect(api.getState().selectedId).toBe('README.md')
+  })
+})

--- a/packages/file-tree/package.json
+++ b/packages/file-tree/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
   },
@@ -18,5 +20,8 @@
       "require": "./dist/index.cjs"
     }
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@refraction-ui/shared": "workspace:*"
+  }
 }

--- a/packages/file-tree/src/file-tree.styles.ts
+++ b/packages/file-tree/src/file-tree.styles.ts
@@ -1,0 +1,31 @@
+import { cva } from '@refraction-ui/shared'
+
+/** Tree container. */
+export const fileTreeVariants = cva({
+  base: 'w-full text-sm',
+})
+
+/**
+ * A single tree row (treeitem). The `selected` variant carries the
+ * selected-row treatment so adapters never inline these classes.
+ */
+export const fileTreeItemVariants = cva({
+  base: [
+    'flex w-full cursor-pointer select-none items-center gap-1.5 rounded-md px-2 py-1',
+    'text-sm outline-none transition-colors',
+    'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background',
+    'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+  ].join(' '),
+  variants: {
+    selected: {
+      true: 'bg-accent text-accent-foreground',
+      false: 'text-foreground hover:bg-muted',
+    },
+  },
+  defaultVariants: {
+    selected: 'false',
+  },
+})
+
+/** Expand/collapse glyph or file marker preceding the label. */
+export const fileTreeGlyphClass = 'w-4 shrink-0 text-center text-muted-foreground'

--- a/packages/file-tree/src/file-tree.ts
+++ b/packages/file-tree/src/file-tree.ts
@@ -1,1 +1,360 @@
-export const FileTree = () => {};
+/**
+ * @refraction-ui/file-tree — headless tree view.
+ *
+ * Owns the *behavior* of a hierarchical tree: the node model, expand/collapse
+ * state, single selection, roving focus, and WAI-ARIA treeview keyboard
+ * semantics. It has NO UI opinion — adapters render the nested markup and
+ * spread the ARIA objects.
+ */
+
+/** A node in the tree. Parents carry `children`; leaves do not. */
+export interface FileTreeNode {
+  /** Unique, stable id (used for expansion/selection/focus). */
+  id: string
+  /** Display label. */
+  label: string
+  /** Child nodes — presence (even empty is not allowed: omit for leaves) marks a parent. */
+  children?: FileTreeNode[]
+  /** Disabled nodes cannot be selected, toggled, or focused via click. */
+  disabled?: boolean
+}
+
+/** Options for {@link createFileTree}. */
+export interface FileTreeConfig {
+  /** Root-level nodes. */
+  nodes?: FileTreeNode[]
+  /** Controlled expanded node ids. Pair with `onExpandedChange`. */
+  expandedIds?: string[]
+  /** Uncontrolled initial expanded node ids. */
+  defaultExpandedIds?: string[]
+  /** Controlled selected node id (`null` = none). Pair with `onSelectionChange`. */
+  selectedId?: string | null
+  /** Uncontrolled initial selected node id. */
+  defaultSelectedId?: string | null
+  /** Called whenever the expanded set changes. */
+  onExpandedChange?: (ids: string[]) => void
+  /** Called whenever the selection changes. */
+  onSelectionChange?: (id: string | null) => void
+  /** Accessible label for the tree (default `'File tree'`). */
+  'aria-label'?: string
+}
+
+/** Snapshot of the store. Returned by `getState()`; treat as immutable. */
+export interface FileTreeState {
+  nodes: FileTreeNode[]
+  expandedIds: string[]
+  selectedId: string | null
+  /** Node holding the roving-tabindex focus (null = the first visible item). */
+  focusedId: string | null
+}
+
+/** A row of the flattened, currently-visible tree (DFS order). */
+export interface VisibleTreeItem {
+  node: FileTreeNode
+  /** Id of the parent node, or null for root-level items. */
+  parentId: string | null
+  /** 1-based nesting depth (ARIA `aria-level`). */
+  depth: number
+  hasChildren: boolean
+  isExpanded: boolean
+  isSelected: boolean
+  isFocused: boolean
+}
+
+/** The framework-agnostic store. React/Astro adapters wrap this. */
+export interface FileTreeAPI {
+  /** Current immutable snapshot */
+  getState(): FileTreeState
+  /** Subscribe to changes; returns an unsubscribe fn (suits useSyncExternalStore) */
+  subscribe(listener: () => void): () => void
+
+  /** Flattened visible rows in DFS order (children of collapsed parents omitted) */
+  getVisibleItems(): VisibleTreeItem[]
+  isExpanded(id: string): boolean
+  /** Toggle a parent's expanded state (no-op for leaves/disabled nodes) */
+  toggle(id: string): void
+  expand(id: string): void
+  collapse(id: string): void
+  /** Select a node (`null` clears). No-op for unknown/disabled nodes. */
+  select(id: string | null): void
+  /** Move the roving focus to a node */
+  focus(id: string | null): void
+  /**
+   * WAI-ARIA treeview keyboard semantics, applied to the focused item:
+   * ArrowDown/Up move, ArrowRight expands or descends, ArrowLeft collapses or
+   * ascends, Home/End jump, Enter/Space selects.
+   */
+  handleKey(key: string): void
+
+  /** Replace the node model (adapters sync the prop) */
+  setNodes(nodes: FileTreeNode[]): void
+  /** Sync a controlled expanded set */
+  setExpandedIds(ids: string[]): void
+  /** Sync a controlled selection */
+  setSelectedId(id: string | null): void
+  /** Update callbacks/options after creation */
+  setOptions(options: {
+    onExpandedChange?: (ids: string[]) => void
+    onSelectionChange?: (id: string | null) => void
+    'aria-label'?: string
+  }): void
+
+  /** ARIA attributes for the tree container (`role="tree"`). */
+  getTreeAria(): Record<string, string | number | boolean>
+  /** ARIA attributes for one visible row (`role="treeitem"`). */
+  getItemAria(item: VisibleTreeItem): Record<string, string | number | boolean>
+}
+
+function arrayEquals(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i])
+}
+
+/**
+ * createFileTree — headless tree store with expand/collapse, single
+ * selection, roving focus, and treeview keyboard semantics. Supports
+ * controlled (`expandedIds` / `selectedId`) and uncontrolled
+ * (`defaultExpandedIds` / `defaultSelectedId`) usage.
+ */
+export function createFileTree(config: FileTreeConfig = {}): FileTreeAPI {
+  let nodes: FileTreeNode[] = config.nodes ?? []
+  let ariaLabel = config['aria-label'] ?? 'File tree'
+  let onExpandedChange = config.onExpandedChange
+  let onSelectionChange = config.onSelectionChange
+
+  let uncontrolledExpanded: string[] = config.defaultExpandedIds ?? []
+  let controlledExpanded: string[] | undefined = config.expandedIds
+  let uncontrolledSelected: string | null = config.defaultSelectedId ?? null
+  let controlledSelected: string | null | undefined = config.selectedId
+  let focusedId: string | null = null
+
+  // Indexes rebuilt whenever the node model changes.
+  let parentById = new Map<string, string | null>()
+  let nodeById = new Map<string, FileTreeNode>()
+
+  function reindex(): void {
+    parentById = new Map()
+    nodeById = new Map()
+    const walk = (list: FileTreeNode[], parentId: string | null) => {
+      for (const node of list) {
+        nodeById.set(node.id, node)
+        parentById.set(node.id, parentId)
+        if (node.children) walk(node.children, node.id)
+      }
+    }
+    walk(nodes, null)
+  }
+  reindex()
+
+  const listeners = new Set<() => void>()
+  let snapshot: FileTreeState = buildSnapshot()
+  let visibleItems: VisibleTreeItem[] = buildVisibleItems()
+
+  function expandedIds(): string[] {
+    return controlledExpanded !== undefined ? controlledExpanded : uncontrolledExpanded
+  }
+
+  function selectedId(): string | null {
+    return controlledSelected !== undefined ? controlledSelected : uncontrolledSelected
+  }
+
+  function buildSnapshot(): FileTreeState {
+    return {
+      nodes,
+      expandedIds: expandedIds(),
+      selectedId: selectedId(),
+      focusedId,
+    }
+  }
+
+  function buildVisibleItems(): VisibleTreeItem[] {
+    const expanded = new Set(expandedIds())
+    const selected = selectedId()
+    const items: VisibleTreeItem[] = []
+    const walk = (list: FileTreeNode[], parentId: string | null, depth: number) => {
+      for (const node of list) {
+        const hasChildren = Boolean(node.children && node.children.length > 0)
+        const isExpanded = hasChildren && expanded.has(node.id)
+        items.push({
+          node,
+          parentId,
+          depth,
+          hasChildren,
+          isExpanded,
+          isSelected: node.id === selected,
+          isFocused: node.id === focusedId,
+        })
+        if (hasChildren && isExpanded) walk(node.children!, node.id, depth + 1)
+      }
+    }
+    walk(nodes, null, 1)
+    return items
+  }
+
+  function emit(): void {
+    snapshot = buildSnapshot()
+    visibleItems = buildVisibleItems()
+    for (const l of listeners) l()
+  }
+
+  function setExpanded(ids: string[]): void {
+    if (controlledExpanded === undefined) {
+      if (arrayEquals(uncontrolledExpanded, ids)) return
+      uncontrolledExpanded = ids
+    }
+    onExpandedChange?.(ids)
+    emit()
+  }
+
+  function isExpandable(id: string): boolean {
+    const node = nodeById.get(id)
+    return Boolean(node && !node.disabled && node.children && node.children.length > 0)
+  }
+
+  const api: FileTreeAPI = {
+    getState() {
+      return snapshot
+    },
+
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+
+    getVisibleItems() {
+      return visibleItems
+    },
+
+    isExpanded(id) {
+      return expandedIds().includes(id)
+    },
+
+    toggle(id) {
+      if (!isExpandable(id)) return
+      const current = expandedIds()
+      setExpanded(current.includes(id) ? current.filter((v) => v !== id) : [...current, id])
+    },
+
+    expand(id) {
+      if (!isExpandable(id)) return
+      const current = expandedIds()
+      if (current.includes(id)) return
+      setExpanded([...current, id])
+    },
+
+    collapse(id) {
+      const current = expandedIds()
+      if (!current.includes(id)) return
+      setExpanded(current.filter((v) => v !== id))
+    },
+
+    select(id) {
+      if (id !== null) {
+        const node = nodeById.get(id)
+        if (!node || node.disabled) return
+      }
+      if (controlledSelected === undefined) {
+        if (uncontrolledSelected === id) return
+        uncontrolledSelected = id
+      }
+      onSelectionChange?.(id)
+      emit()
+    },
+
+    focus(id) {
+      // Focus is only meaningful on rows that are actually rendered.
+      if (id !== null && !visibleItems.some((i) => i.node.id === id)) return
+      if (focusedId === id) return
+      focusedId = id
+      emit()
+    },
+
+    handleKey(key) {
+      const items = visibleItems
+      if (items.length === 0) return
+      const currentIndex = focusedId ? items.findIndex((i) => i.node.id === focusedId) : -1
+
+      switch (key) {
+        case 'ArrowDown':
+          api.focus(items[Math.min(currentIndex + 1, items.length - 1)]!.node.id)
+          return
+        case 'ArrowUp':
+          api.focus(items[Math.max(currentIndex - 1, 0)]!.node.id)
+          return
+        case 'Home':
+          api.focus(items[0]!.node.id)
+          return
+        case 'End':
+          api.focus(items[items.length - 1]!.node.id)
+          return
+        case 'ArrowRight': {
+          const item = currentIndex === -1 ? undefined : items[currentIndex]
+          if (!item) {
+            api.focus(items[0]!.node.id)
+            return
+          }
+          if (!item.hasChildren) return
+          if (!item.isExpanded) api.expand(item.node.id)
+          // Expanded: descend to the first child (DFS order puts it next).
+          else api.focus(items[currentIndex + 1]?.node.id ?? item.node.id)
+          return
+        }
+        case 'ArrowLeft': {
+          const item = currentIndex === -1 ? undefined : items[currentIndex]
+          if (!item) return
+          if (item.hasChildren && item.isExpanded) api.collapse(item.node.id)
+          else if (item.parentId) api.focus(item.parentId)
+          return
+        }
+        case 'Enter':
+        case ' ': {
+          const item = currentIndex === -1 ? undefined : items[currentIndex]
+          if (item) api.select(item.node.id)
+          return
+        }
+        default:
+          return
+      }
+    },
+
+    setNodes(nextNodes) {
+      nodes = nextNodes
+      reindex()
+      emit()
+    },
+
+    setExpandedIds(ids) {
+      if (controlledExpanded !== undefined && arrayEquals(controlledExpanded, ids)) return
+      controlledExpanded = ids
+      emit()
+    },
+
+    setSelectedId(id) {
+      if (controlledSelected !== undefined && controlledSelected === id) return
+      controlledSelected = id
+      emit()
+    },
+
+    setOptions(options) {
+      if (options.onExpandedChange !== undefined) onExpandedChange = options.onExpandedChange
+      if (options.onSelectionChange !== undefined) onSelectionChange = options.onSelectionChange
+      if (options['aria-label'] !== undefined) ariaLabel = options['aria-label']
+    },
+
+    getTreeAria(): Record<string, string | number | boolean> {
+      return { role: 'tree', 'aria-label': ariaLabel }
+    },
+
+    getItemAria(item): Record<string, string | number | boolean> {
+      const aria: Record<string, string | number | boolean> = {
+        role: 'treeitem',
+        'aria-level': item.depth,
+        'aria-selected': item.isSelected,
+      }
+      if (item.hasChildren) aria['aria-expanded'] = item.isExpanded
+      if (item.node.disabled) aria['aria-disabled'] = true
+      return aria
+    },
+  }
+
+  return api
+}

--- a/packages/file-tree/src/index.ts
+++ b/packages/file-tree/src/index.ts
@@ -1,1 +1,15 @@
-export * from './file-tree';
+export { createFileTree } from './file-tree.js'
+
+export type {
+  FileTreeNode,
+  FileTreeConfig,
+  FileTreeState,
+  FileTreeAPI,
+  VisibleTreeItem,
+} from './file-tree.js'
+
+export {
+  fileTreeVariants,
+  fileTreeItemVariants,
+  fileTreeGlyphClass,
+} from './file-tree.styles.js'

--- a/packages/file-tree/vitest.config.ts
+++ b/packages/file-tree/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/icon-system/src/icon-system.ts
+++ b/packages/icon-system/src/icon-system.ts
@@ -1,1 +1,4 @@
+// Stub — not yet implemented. Scaffolded placeholder reserved for a future
+// named-icon registry; kept exported from the metas as-is because removing a
+// published export would be a breaking change.
 export const IconSystem = () => {};

--- a/packages/pagination/__tests__/pagination.test.ts
+++ b/packages/pagination/__tests__/pagination.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createPagination,
+  clampPage,
+  getPaginationItems,
+  type PaginationItem,
+} from '../src/index.js'
+
+const pages = (items: PaginationItem[]) =>
+  items.map((i) => (i.type === 'page' ? i.page : '…'))
+
+describe('clampPage', () => {
+  it('clamps into [1, total]', () => {
+    expect(clampPage(0, 10)).toBe(1)
+    expect(clampPage(-3, 10)).toBe(1)
+    expect(clampPage(11, 10)).toBe(10)
+    expect(clampPage(5, 10)).toBe(5)
+  })
+
+  it('treats a non-positive total as 1', () => {
+    expect(clampPage(7, 0)).toBe(1)
+    expect(clampPage(7, -2)).toBe(1)
+  })
+})
+
+describe('getPaginationItems', () => {
+  it('returns every page when the total fits without ellipses', () => {
+    expect(pages(getPaginationItems(3, 5))).toEqual([1, 2, 3, 4, 5])
+    expect(pages(getPaginationItems(4, 7))).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('returns nothing for a zero total', () => {
+    expect(getPaginationItems(1, 0)).toEqual([])
+  })
+
+  it('truncates the end when the current page is near the start', () => {
+    expect(pages(getPaginationItems(1, 10))).toEqual([1, 2, 3, 4, 5, '…', 10])
+    expect(pages(getPaginationItems(3, 10))).toEqual([1, 2, 3, 4, 5, '…', 10])
+  })
+
+  it('truncates the start when the current page is near the end', () => {
+    expect(pages(getPaginationItems(10, 10))).toEqual([1, '…', 6, 7, 8, 9, 10])
+    expect(pages(getPaginationItems(8, 10))).toEqual([1, '…', 6, 7, 8, 9, 10])
+  })
+
+  it('truncates both sides around a middle page', () => {
+    expect(pages(getPaginationItems(5, 10))).toEqual([1, '…', 4, 5, 6, '…', 10])
+  })
+
+  it('honors a wider siblingCount', () => {
+    expect(pages(getPaginationItems(6, 12, 2))).toEqual([1, '…', 4, 5, 6, 7, 8, '…', 12])
+  })
+
+  it('clamps an out-of-range current page', () => {
+    expect(pages(getPaginationItems(99, 10))).toEqual([1, '…', 6, 7, 8, 9, 10])
+    expect(pages(getPaginationItems(-4, 10))).toEqual([1, 2, 3, 4, 5, '…', 10])
+  })
+})
+
+describe('createPagination', () => {
+  it('exposes navigation role and data attributes', () => {
+    const api = createPagination({ page: 2, totalPages: 5 })
+    expect(api.ariaProps.role).toBe('navigation')
+    expect(api.ariaProps['aria-label']).toBe('Pagination')
+    expect(api.dataAttributes['data-page']).toBe('2')
+    expect(api.dataAttributes['data-total-pages']).toBe('5')
+  })
+
+  it('computes prev/next edges', () => {
+    const first = createPagination({ page: 1, totalPages: 5 })
+    expect(first.canGoPrevious).toBe(false)
+    expect(first.canGoNext).toBe(true)
+    expect(first.previousPage).toBe(1)
+    expect(first.nextPage).toBe(2)
+
+    const last = createPagination({ page: 5, totalPages: 5 })
+    expect(last.canGoPrevious).toBe(true)
+    expect(last.canGoNext).toBe(false)
+    expect(last.previousPage).toBe(4)
+    expect(last.nextPage).toBe(5)
+  })
+
+  it('marks only the current page with aria-current', () => {
+    const api = createPagination({ page: 3, totalPages: 5 })
+    expect(api.getPageAria(3)['aria-current']).toBe('page')
+    expect(api.getPageAria(2)['aria-current']).toBeUndefined()
+  })
+
+  it('labels the prev/next controls', () => {
+    const api = createPagination({ page: 1, totalPages: 1 })
+    expect(api.getPreviousAria()['aria-label']).toBe('Previous page')
+    expect(api.getNextAria()['aria-label']).toBe('Next page')
+    expect(api.canGoPrevious).toBe(false)
+    expect(api.canGoNext).toBe(false)
+  })
+})

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -1,1 +1,14 @@
-export {}
+export {
+  createPagination,
+  clampPage,
+  getPaginationItems,
+  type PaginationItem,
+  type PaginationConfig,
+  type PaginationAPI,
+} from './pagination.js'
+
+export {
+  paginationVariants,
+  paginationItemVariants,
+  paginationEllipsisClass,
+} from './pagination.styles.js'

--- a/packages/pagination/src/pagination.styles.ts
+++ b/packages/pagination/src/pagination.styles.ts
@@ -1,0 +1,33 @@
+import { cva } from '@refraction-ui/shared'
+
+/** Row of pagination controls. */
+export const paginationVariants = cva({
+  base: 'flex items-center gap-1',
+})
+
+/**
+ * A pagination button (prev / next / numbered page). The `state` variant
+ * carries the current-page treatment so adapters never inline these classes.
+ */
+export const paginationItemVariants = cva({
+  base: [
+    'inline-flex h-9 min-w-9 items-center justify-center rounded-md border px-3',
+    'text-sm font-medium transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+    'focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    'disabled:pointer-events-none disabled:opacity-50',
+  ].join(' '),
+  variants: {
+    state: {
+      current: 'border-primary bg-primary text-primary-foreground',
+      default: 'border-border bg-background text-foreground hover:bg-muted',
+    },
+  },
+  defaultVariants: {
+    state: 'default',
+  },
+})
+
+/** Ellipsis gap between page numbers (not interactive). */
+export const paginationEllipsisClass =
+  'inline-flex h-9 min-w-9 items-center justify-center text-sm text-muted-foreground'

--- a/packages/pagination/src/pagination.ts
+++ b/packages/pagination/src/pagination.ts
@@ -1,0 +1,160 @@
+/**
+ * @refraction-ui/pagination — headless pagination.
+ *
+ * Owns the *behavior* of page navigation: the windowed page range with
+ * ellipses, current-page clamping, and prev/next edge semantics. It has NO UI
+ * opinion — adapters render the controls and spread the ARIA objects.
+ */
+
+/** One entry of the computed page range: a page number or an ellipsis gap. */
+export type PaginationItem =
+  | { type: 'page'; page: number }
+  | { type: 'ellipsis'; id: 'start' | 'end' }
+
+/** Options for {@link createPagination}. */
+export interface PaginationConfig {
+  /** Current page (1-based). Clamped into `[1, totalPages]`. */
+  page?: number
+  /** Total number of pages. Values < 1 behave as 1. */
+  totalPages?: number
+  /** Pages shown on each side of the current page (default 1). */
+  siblingCount?: number
+  /** Accessible label for the nav landmark (default `'Pagination'`). */
+  ariaLabel?: string
+}
+
+/** The computed view of a pagination control. */
+export interface PaginationAPI {
+  /** ARIA attributes for the root element (`role="navigation"`). */
+  ariaProps: Record<string, string | number | boolean>
+  /** Data attributes for styling hooks. */
+  dataAttributes: Record<string, string>
+  /** Current page after clamping (1-based). */
+  page: number
+  /** Total number of pages (>= 1). */
+  totalPages: number
+  /** Windowed range of pages and ellipses to render. */
+  items: PaginationItem[]
+  /** Whether "previous" navigation is possible. */
+  canGoPrevious: boolean
+  /** Whether "next" navigation is possible. */
+  canGoNext: boolean
+  /** Target page for the previous control (clamped). */
+  previousPage: number
+  /** Target page for the next control (clamped). */
+  nextPage: number
+  /** ARIA attributes for a numbered page button (`aria-current` on the current page). */
+  getPageAria(page: number): Record<string, string | number | boolean>
+  /** ARIA attributes for the previous control. */
+  getPreviousAria(): Record<string, string | number | boolean>
+  /** ARIA attributes for the next control. */
+  getNextAria(): Record<string, string | number | boolean>
+}
+
+/** Clamp a 1-based page number into `[1, max(totalPages, 1)]`. */
+export function clampPage(page: number, totalPages: number): number {
+  const total = Math.max(1, Math.floor(totalPages))
+  if (Number.isNaN(page)) return 1
+  return Math.min(Math.max(1, Math.floor(page)), total)
+}
+
+function pageItem(page: number): PaginationItem {
+  return { type: 'page', page }
+}
+
+function pageRange(start: number, end: number): PaginationItem[] {
+  const items: PaginationItem[] = []
+  for (let p = start; p <= end; p++) items.push(pageItem(p))
+  return items
+}
+
+/**
+ * Compute the windowed page range with ellipses.
+ *
+ * Always shows the first and last page plus `siblingCount` pages on each side
+ * of the current page; gaps of more than one page collapse into an ellipsis.
+ * Small totals render every page (no ellipses).
+ */
+export function getPaginationItems(
+  current: number,
+  totalPages: number,
+  siblingCount = 1,
+): PaginationItem[] {
+  const total = Math.max(0, Math.floor(totalPages))
+  if (total === 0) return []
+
+  // first + last + current + 2 siblings + 2 ellipses
+  const maxVisibleWithoutEllipsis = siblingCount * 2 + 5
+  if (total <= maxVisibleWithoutEllipsis) return pageRange(1, total)
+
+  const currentPage = clampPage(current, total)
+  const leftSibling = Math.max(currentPage - siblingCount, 1)
+  const rightSibling = Math.min(currentPage + siblingCount, total)
+
+  const showLeftEllipsis = leftSibling > 2
+  const showRightEllipsis = rightSibling < total - 1
+
+  if (!showLeftEllipsis && showRightEllipsis) {
+    const leftCount = 3 + 2 * siblingCount
+    return [...pageRange(1, leftCount), { type: 'ellipsis', id: 'end' }, pageItem(total)]
+  }
+
+  if (showLeftEllipsis && !showRightEllipsis) {
+    const rightCount = 3 + 2 * siblingCount
+    return [
+      pageItem(1),
+      { type: 'ellipsis', id: 'start' },
+      ...pageRange(total - rightCount + 1, total),
+    ]
+  }
+
+  return [
+    pageItem(1),
+    { type: 'ellipsis', id: 'start' },
+    ...pageRange(leftSibling, rightSibling),
+    { type: 'ellipsis', id: 'end' },
+    pageItem(total),
+  ]
+}
+
+/**
+ * createPagination — the framework-agnostic view of a pagination control:
+ * ARIA objects for the nav landmark and controls, plus the clamped
+ * current/total and prev/next edge semantics. Adapters own the page state
+ * (controlled/uncontrolled) and call this per render.
+ */
+export function createPagination(config: PaginationConfig = {}): PaginationAPI {
+  const totalPages = Math.max(1, Math.floor(config.totalPages ?? 1))
+  const page = clampPage(config.page ?? 1, totalPages)
+  const siblingCount = Math.max(0, Math.floor(config.siblingCount ?? 1))
+
+  const canGoPrevious = page > 1
+  const canGoNext = page < totalPages
+
+  return {
+    ariaProps: {
+      role: 'navigation',
+      'aria-label': config.ariaLabel ?? 'Pagination',
+    },
+    dataAttributes: {
+      'data-page': String(page),
+      'data-total-pages': String(totalPages),
+    },
+    page,
+    totalPages,
+    items: getPaginationItems(page, totalPages, siblingCount),
+    canGoPrevious,
+    canGoNext,
+    previousPage: canGoPrevious ? page - 1 : page,
+    nextPage: canGoNext ? page + 1 : page,
+    getPageAria(p): Record<string, string | number | boolean> {
+      return p === page ? { 'aria-current': 'page' } : {}
+    },
+    getPreviousAria(): Record<string, string | number | boolean> {
+      return { 'aria-label': 'Previous page' }
+    },
+    getNextAria(): Record<string, string | number | boolean> {
+      return { 'aria-label': 'Next page' }
+    },
+  }
+}

--- a/packages/react-accordion/__tests__/accordion.test.tsx
+++ b/packages/react-accordion/__tests__/accordion.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '../src/accordion.js'
+
+function renderAccordion(props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      Accordion,
+      props,
+      React.createElement(
+        AccordionItem,
+        { value: 'a' },
+        React.createElement(AccordionTrigger, null, 'Section A'),
+        React.createElement(AccordionContent, null, 'Body A'),
+      ),
+      React.createElement(
+        AccordionItem,
+        { value: 'b' },
+        React.createElement(AccordionTrigger, null, 'Section B'),
+        React.createElement(AccordionContent, null, 'Body B'),
+      ),
+    ),
+  )
+}
+
+describe('Accordion (SSR)', () => {
+  it('renders items closed by default', () => {
+    const html = renderAccordion()
+    // Each item renders data-state on item + trigger + content.
+    expect((html.match(/data-state="closed"/g) ?? []).length).toBe(6)
+    expect((html.match(/aria-expanded="false"/g) ?? []).length).toBe(2)
+    expect((html.match(/hidden=""/g) ?? []).length).toBe(2)
+  })
+
+  it('opens the defaultValue item (single)', () => {
+    const html = renderAccordion({ defaultValue: 'a' })
+    expect(html).toContain('aria-expanded="true"')
+    // One content visible, one hidden.
+    expect((html.match(/hidden=""/g) ?? []).length).toBe(1)
+  })
+
+  it('opens the controlled value items (multiple)', () => {
+    const html = renderAccordion({ type: 'multiple', value: ['a', 'b'] })
+    expect((html.match(/aria-expanded="true"/g) ?? []).length).toBe(2)
+    expect(html).not.toContain('hidden=""')
+  })
+
+  it('forwards className onto the root', () => {
+    const html = renderAccordion({ className: 'my-accordion' })
+    expect(html).toContain('my-accordion')
+  })
+})

--- a/packages/react-accordion/src/accordion.tsx
+++ b/packages/react-accordion/src/accordion.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react'
 import { cn, devWarn } from '@refraction-ui/shared'
+import {
+  createAccordion,
+  isItemOpen,
+  type AccordionAPI,
+  type AccordionState,
+} from '@refraction-ui/accordion'
 
 const AccordionContext = React.createContext<{
-  type: 'single' | 'multiple'
-  value: string | string[]
-  onValueChange: (value: string) => void
+  state: AccordionState
+  toggleItem: AccordionAPI['toggleItem']
 } | null>(null)
 
 export interface AccordionProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
@@ -17,32 +22,25 @@ export interface AccordionProps extends Omit<React.HTMLAttributes<HTMLDivElement
 
 export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
   ({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) => {
-    const [uncontrolledValue, setUncontrolledValue] = React.useState<string | string[]>(
-      defaultValue ?? (type === 'multiple' ? [] : '')
-    )
+    // The headless core owns the open/closed state machine; it is created once
+    // and props are synced into it below.
+    const apiRef = React.useRef<AccordionAPI | null>(null)
+    if (apiRef.current === null) {
+      apiRef.current = createAccordion({ type, collapsible, defaultValue, value: controlledValue, onValueChange })
+    }
+    const api = apiRef.current
 
-    const value = controlledValue !== undefined ? controlledValue : uncontrolledValue
+    const state = React.useSyncExternalStore(api.subscribe, api.getState, api.getState)
 
-    const handleValueChange = React.useCallback(
-      (itemValue: string) => {
-        if (type === 'single') {
-          const newValue = value === itemValue && collapsible ? '' : itemValue
-          setUncontrolledValue(newValue)
-          onValueChange?.(newValue)
-        } else {
-          const arrValue = Array.isArray(value) ? value : []
-          const newValue = arrValue.includes(itemValue)
-            ? arrValue.filter((v) => v !== itemValue)
-            : [...arrValue, itemValue]
-          setUncontrolledValue(newValue)
-          onValueChange?.(newValue)
-        }
-      },
-      [type, collapsible, value, onValueChange]
-    )
+    React.useEffect(() => {
+      api.setOptions({ type, collapsible, onValueChange })
+    })
+    React.useEffect(() => {
+      if (controlledValue !== undefined) api.setValue(controlledValue)
+    }, [api, controlledValue])
 
     return (
-      <AccordionContext.Provider value={{ type, value, onValueChange: handleValueChange }}>
+      <AccordionContext.Provider value={{ state, toggleItem: api.toggleItem }}>
         <div ref={ref} className={cn("flex flex-col w-full", className)} {...props} />
       </AccordionContext.Provider>
     )
@@ -67,9 +65,7 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
       throw new Error('AccordionItem must be within Accordion')
     }
 
-    const isOpen = context.type === 'single'
-      ? context.value === value
-      : Array.isArray(context.value) && context.value.includes(value)
+    const isOpen = isItemOpen(context.state, value)
 
     return (
       <AccordionItemContext.Provider value={{ value, isOpen }}>
@@ -86,7 +82,7 @@ export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTri
   ({ className, children, ...props }, ref) => {
     const accordionContext = React.useContext(AccordionContext)
     const itemContext = React.useContext(AccordionItemContext)
-    
+
     if (!accordionContext || !itemContext) {
       devWarn(
         'react-accordion/trigger-missing-context',
@@ -106,7 +102,7 @@ export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTri
             className
           )}
           data-state={itemContext.isOpen ? 'open' : 'closed'}
-          onClick={() => accordionContext.onValueChange(itemContext.value)}
+          onClick={() => accordionContext.toggleItem(itemContext.value)}
           {...props}
         >
           {children}

--- a/packages/react-carousel/__tests__/carousel.test.tsx
+++ b/packages/react-carousel/__tests__/carousel.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  Carousel,
+  CarouselItem,
+  CarouselTrigger,
+  CarouselContent,
+} from '../src/carousel.js'
+
+function renderCarousel(props: Record<string, unknown> = {}) {
+  return renderToString(
+    React.createElement(
+      Carousel,
+      props,
+      React.createElement(
+        CarouselItem,
+        { value: 'a' },
+        React.createElement(CarouselTrigger, null, 'Panel A'),
+        React.createElement(CarouselContent, null, 'Body A'),
+      ),
+      React.createElement(
+        CarouselItem,
+        { value: 'b' },
+        React.createElement(CarouselTrigger, null, 'Panel B'),
+        React.createElement(CarouselContent, null, 'Body B'),
+      ),
+    ),
+  )
+}
+
+describe('Carousel (SSR)', () => {
+  it('renders panels closed by default', () => {
+    const html = renderCarousel()
+    // Each item renders data-state on item + trigger + content.
+    expect((html.match(/data-state="closed"/g) ?? []).length).toBe(6)
+    expect((html.match(/aria-expanded="false"/g) ?? []).length).toBe(2)
+    expect((html.match(/hidden=""/g) ?? []).length).toBe(2)
+  })
+
+  it('opens the defaultValue panel (single, collapsible)', () => {
+    const html = renderCarousel({ collapsible: true, defaultValue: 'a' })
+    expect(html).toContain('aria-expanded="true"')
+    expect((html.match(/hidden=""/g) ?? []).length).toBe(1)
+  })
+
+  it('opens the controlled panels (multiple)', () => {
+    const html = renderCarousel({ type: 'multiple', value: ['a', 'b'] })
+    expect((html.match(/aria-expanded="true"/g) ?? []).length).toBe(2)
+    expect(html).not.toContain('hidden=""')
+  })
+})

--- a/packages/react-carousel/src/carousel.tsx
+++ b/packages/react-carousel/src/carousel.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react'
 import { cn, devWarn } from '@refraction-ui/shared'
+import {
+  createCarousel,
+  isItemOpen,
+  type CarouselAPI,
+  type CarouselState,
+} from '@refraction-ui/carousel'
 
 const CarouselContext = React.createContext<{
-  type: 'single' | 'multiple'
-  value: string | string[]
-  onValueChange: (value: string) => void
+  state: CarouselState
+  toggleItem: CarouselAPI['toggleItem']
 } | null>(null)
 
 export interface CarouselProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
@@ -17,32 +22,25 @@ export interface CarouselProps extends Omit<React.HTMLAttributes<HTMLDivElement>
 
 export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
   ({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) => {
-    const [uncontrolledValue, setUncontrolledValue] = React.useState<string | string[]>(
-      defaultValue ?? (type === 'multiple' ? [] : '')
-    )
+    // The headless core owns the open/closed state machine; it is created once
+    // and props are synced into it below.
+    const apiRef = React.useRef<CarouselAPI | null>(null)
+    if (apiRef.current === null) {
+      apiRef.current = createCarousel({ type, collapsible, defaultValue, value: controlledValue, onValueChange })
+    }
+    const api = apiRef.current
 
-    const value = controlledValue !== undefined ? controlledValue : uncontrolledValue
+    const state = React.useSyncExternalStore(api.subscribe, api.getState, api.getState)
 
-    const handleValueChange = React.useCallback(
-      (itemValue: string) => {
-        if (type === 'single') {
-          const newValue = value === itemValue && collapsible ? '' : itemValue
-          setUncontrolledValue(newValue)
-          onValueChange?.(newValue)
-        } else {
-          const arrValue = Array.isArray(value) ? value : []
-          const newValue = arrValue.includes(itemValue)
-            ? arrValue.filter((v) => v !== itemValue)
-            : [...arrValue, itemValue]
-          setUncontrolledValue(newValue)
-          onValueChange?.(newValue)
-        }
-      },
-      [type, collapsible, value, onValueChange]
-    )
+    React.useEffect(() => {
+      api.setOptions({ type, collapsible, onValueChange })
+    })
+    React.useEffect(() => {
+      if (controlledValue !== undefined) api.setValue(controlledValue)
+    }, [api, controlledValue])
 
     return (
-      <CarouselContext.Provider value={{ type, value, onValueChange: handleValueChange }}>
+      <CarouselContext.Provider value={{ state, toggleItem: api.toggleItem }}>
         <div ref={ref} className={cn("flex flex-col w-full", className)} {...props} />
       </CarouselContext.Provider>
     )
@@ -67,9 +65,7 @@ export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
       throw new Error('CarouselItem must be within Carousel')
     }
 
-    const isOpen = context.type === 'single'
-      ? context.value === value
-      : Array.isArray(context.value) && context.value.includes(value)
+    const isOpen = isItemOpen(context.state, value)
 
     return (
       <CarouselItemContext.Provider value={{ value, isOpen }}>
@@ -86,7 +82,7 @@ export const CarouselTrigger = React.forwardRef<HTMLButtonElement, CarouselTrigg
   ({ className, children, ...props }, ref) => {
     const carouselContext = React.useContext(CarouselContext)
     const itemContext = React.useContext(CarouselItemContext)
-    
+
     if (!carouselContext || !itemContext) {
       devWarn(
         'react-carousel/carousel-trigger-outside-item',
@@ -106,7 +102,7 @@ export const CarouselTrigger = React.forwardRef<HTMLButtonElement, CarouselTrigg
             className
           )}
           data-state={itemContext.isOpen ? 'open' : 'closed'}
-          onClick={() => carouselContext.onValueChange(itemContext.value)}
+          onClick={() => carouselContext.toggleItem(itemContext.value)}
           {...props}
         >
           {children}

--- a/packages/react-file-tree/__tests__/file-tree.test.tsx
+++ b/packages/react-file-tree/__tests__/file-tree.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { FileTree, type FileTreeNode } from '../src/react-file-tree.js'
+
+const NODES: FileTreeNode[] = [
+  {
+    id: 'src',
+    label: 'src',
+    children: [
+      { id: 'src/index.ts', label: 'index.ts' },
+      {
+        id: 'src/components',
+        label: 'components',
+        children: [{ id: 'src/components/button.tsx', label: 'button.tsx' }],
+      },
+    ],
+  },
+  { id: 'package.json', label: 'package.json' },
+]
+
+const render = (props: Record<string, unknown>) =>
+  renderToString(React.createElement(FileTree, props))
+
+describe('FileTree (SSR)', () => {
+  it('renders a tree landmark with only root rows when collapsed', () => {
+    const html = render({ nodes: NODES })
+    expect(html).toContain('role="tree"')
+    expect(html).toContain('aria-label="File tree"')
+    expect((html.match(/role="treeitem"/g) ?? []).length).toBe(2)
+    expect(html).toContain('src')
+    expect(html).toContain('package.json')
+    expect(html).not.toContain('index.ts')
+  })
+
+  it('renders expanded groups with nested treeitems and aria-level', () => {
+    const html = render({ nodes: NODES, defaultExpandedIds: ['src', 'src/components'] })
+    expect((html.match(/role="treeitem"/g) ?? []).length).toBe(5)
+    expect((html.match(/role="group"/g) ?? []).length).toBe(2)
+    expect(html).toContain('button.tsx')
+    expect(html).toContain('aria-level="3"')
+    expect(html).toContain('aria-expanded="true"')
+  })
+
+  it('marks collapsed parents with aria-expanded="false" and leaves without it', () => {
+    const html = render({ nodes: NODES })
+    expect(html).toContain('aria-expanded="false"')
+    // The leaf (package.json) must not carry aria-expanded.
+    const leaf = html.slice(html.indexOf('package.json') - 300, html.indexOf('package.json'))
+    expect(leaf).not.toContain('aria-expanded')
+  })
+
+  it('marks the selected row and gives the first row the roving tab stop', () => {
+    const html = render({ nodes: NODES, defaultSelectedId: 'package.json' })
+    expect((html.match(/aria-selected="true"/g) ?? []).length).toBe(1)
+    expect((html.match(/tabindex="0"/g) ?? []).length).toBe(1)
+    expect((html.match(/tabindex="-1"/g) ?? []).length).toBe(1)
+  })
+
+  it('renders an empty tree for no nodes and forwards className', () => {
+    const html = render({ className: 'my-tree' })
+    expect(html).toContain('role="tree"')
+    expect(html).toContain('my-tree')
+    expect(html).not.toContain('role="treeitem"')
+  })
+})

--- a/packages/react-file-tree/package.json
+++ b/packages/react-file-tree/package.json
@@ -5,8 +5,18 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@refraction-ui/file-tree": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@types/react": "19.0.0",

--- a/packages/react-file-tree/src/react-file-tree.tsx
+++ b/packages/react-file-tree/src/react-file-tree.tsx
@@ -1,2 +1,193 @@
-import React from "react";
-export const FileTree = () => { return <div></div>; };
+import * as React from 'react'
+import { cn } from '@refraction-ui/shared'
+import {
+  createFileTree,
+  fileTreeVariants,
+  fileTreeItemVariants,
+  fileTreeGlyphClass,
+  type FileTreeAPI,
+  type FileTreeNode,
+  type FileTreeState,
+  type VisibleTreeItem,
+} from '@refraction-ui/file-tree'
+
+export type { FileTreeNode }
+
+export interface FileTreeProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  /** Root-level nodes of the tree. */
+  nodes?: FileTreeNode[]
+  /** Controlled expanded node ids. Pair with `onExpandedChange`. */
+  expandedIds?: string[]
+  /** Uncontrolled initial expanded node ids. */
+  defaultExpandedIds?: string[]
+  /** Controlled selected node id (`null` = none). Pair with `onSelectionChange`. */
+  selectedId?: string | null
+  /** Uncontrolled initial selected node id. */
+  defaultSelectedId?: string | null
+  /** Called whenever the expanded set changes. */
+  onExpandedChange?: (ids: string[]) => void
+  /** Called whenever the selection changes. */
+  onSelectionChange?: (id: string | null) => void
+}
+
+/** Keys the tree handles itself (WAI-ARIA treeview pattern). */
+const HANDLED_KEYS = new Set([
+  'ArrowDown',
+  'ArrowUp',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+  'Enter',
+  ' ',
+])
+
+interface TreeItemsProps {
+  nodes: FileTreeNode[]
+  depth: number
+  api: FileTreeAPI
+  state: FileTreeState
+  firstVisibleId: string | undefined
+}
+
+function TreeItems({ nodes, depth, api, state, firstVisibleId }: TreeItemsProps) {
+  return (
+    <>
+      {nodes.map((node) => {
+        const hasChildren = Boolean(node.children && node.children.length > 0)
+        const isExpanded = hasChildren && state.expandedIds.includes(node.id)
+        const isSelected = state.selectedId === node.id
+        const item: VisibleTreeItem = {
+          node,
+          parentId: null, // unused by getItemAria; the core tracks real parents
+          depth,
+          hasChildren,
+          isExpanded,
+          isSelected,
+          isFocused: state.focusedId === node.id,
+        }
+        const tabbable =
+          state.focusedId === node.id || (state.focusedId === null && node.id === firstVisibleId)
+
+        return (
+          <li key={node.id} role="none" className="list-none">
+            <div
+              {...api.getItemAria(item)}
+              tabIndex={tabbable ? 0 : -1}
+              data-disabled={node.disabled ? 'true' : undefined}
+              style={{ paddingLeft: `${(depth - 1) * 12}px` }}
+              className={fileTreeItemVariants({ selected: isSelected ? 'true' : 'false' })}
+              onClick={() => {
+                api.focus(node.id)
+                api.select(node.id)
+                if (hasChildren) api.toggle(node.id)
+              }}
+              onFocus={() => api.focus(node.id)}
+            >
+              <span aria-hidden="true" className={fileTreeGlyphClass}>
+                {hasChildren ? (isExpanded ? '▾' : '▸') : '·'}
+              </span>
+              <span className="truncate">{node.label}</span>
+            </div>
+            {hasChildren && isExpanded && (
+              <ul role="group" className="m-0 p-0">
+                <TreeItems
+                  nodes={node.children!}
+                  depth={depth + 1}
+                  api={api}
+                  state={state}
+                  firstVisibleId={firstVisibleId}
+                />
+              </ul>
+            )}
+          </li>
+        )
+      })}
+    </>
+  )
+}
+
+/**
+ * FileTree — a hierarchical file/folder tree view.
+ *
+ * Renders `role="tree"` with nested `role="group"`/`role="treeitem"` rows,
+ * expand/collapse, single selection, roving tabindex, and WAI-ARIA treeview
+ * keyboard navigation. All behavior comes from the headless
+ * `@refraction-ui/file-tree` core; supports controlled (`expandedIds` /
+ * `selectedId`) and uncontrolled usage.
+ */
+export const FileTree = React.forwardRef<HTMLDivElement, FileTreeProps>(
+  (
+    {
+      className,
+      nodes = [],
+      expandedIds: controlledExpandedIds,
+      defaultExpandedIds,
+      selectedId: controlledSelectedId,
+      defaultSelectedId,
+      onExpandedChange,
+      onSelectionChange,
+      'aria-label': ariaLabel,
+      ...props
+    },
+    ref,
+  ) => {
+    // The headless core owns expansion/selection/focus; it is created once and
+    // props are synced into it below.
+    const apiRef = React.useRef<FileTreeAPI | null>(null)
+    if (apiRef.current === null) {
+      apiRef.current = createFileTree({
+        nodes,
+        expandedIds: controlledExpandedIds,
+        defaultExpandedIds,
+        selectedId: controlledSelectedId,
+        defaultSelectedId,
+        onExpandedChange,
+        onSelectionChange,
+        'aria-label': ariaLabel,
+      })
+    }
+    const api = apiRef.current
+
+    const state = React.useSyncExternalStore(api.subscribe, api.getState, api.getState)
+
+    React.useEffect(() => {
+      api.setOptions({ onExpandedChange, onSelectionChange, 'aria-label': ariaLabel })
+    })
+    React.useEffect(() => {
+      api.setNodes(nodes)
+    }, [api, nodes])
+    React.useEffect(() => {
+      if (controlledExpandedIds !== undefined) api.setExpandedIds(controlledExpandedIds)
+    }, [api, controlledExpandedIds])
+    React.useEffect(() => {
+      if (controlledSelectedId !== undefined) api.setSelectedId(controlledSelectedId)
+    }, [api, controlledSelectedId])
+
+    const firstVisibleId = api.getVisibleItems()[0]?.node.id
+
+    return (
+      <div ref={ref} className={cn(fileTreeVariants(), className)} {...props}>
+        <ul
+          {...api.getTreeAria()}
+          className="m-0 p-0"
+          onKeyDown={(event) => {
+            if (!HANDLED_KEYS.has(event.key)) return
+            event.preventDefault()
+            api.handleKey(event.key)
+          }}
+        >
+          <TreeItems
+            nodes={state.nodes}
+            depth={1}
+            api={api}
+            state={state}
+            firstVisibleId={firstVisibleId}
+          />
+        </ul>
+      </div>
+    )
+  },
+)
+FileTree.displayName = 'FileTree'

--- a/packages/react-file-tree/vitest.config.ts
+++ b/packages/react-file-tree/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/react-pagination/__tests__/pagination.test.tsx
+++ b/packages/react-pagination/__tests__/pagination.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { Pagination } from '../src/pagination.js'
+
+const render = (props: Record<string, unknown>) =>
+  renderToString(React.createElement(Pagination, props))
+
+describe('Pagination (SSR)', () => {
+  it('renders a navigation landmark with prev/next and every page for small totals', () => {
+    const html = render({ totalPages: 5 })
+    expect(html).toContain('role="navigation"')
+    expect(html).toContain('aria-label="Pagination"')
+    expect(html).toContain('Previous')
+    expect(html).toContain('Next')
+    for (const n of [1, 2, 3, 4, 5]) expect(html).toContain(`>${n}</button>`)
+    expect(html).not.toContain('…')
+  })
+
+  it('marks the current page and disables previous on page 1', () => {
+    const html = render({ page: 1, totalPages: 5 })
+    expect((html.match(/aria-current="page"/g) ?? []).length).toBe(1)
+    expect(html).toContain('aria-label="Previous page" disabled=""')
+    expect(html).not.toContain('aria-label="Next page" disabled=""')
+  })
+
+  it('disables next on the last page', () => {
+    const html = render({ page: 5, totalPages: 5 })
+    expect(html).toContain('aria-label="Next page" disabled=""')
+  })
+
+  it('renders ellipses for large totals', () => {
+    const html = render({ page: 5, totalPages: 20 })
+    expect((html.match(/…/g) ?? []).length).toBe(2)
+    expect(html).toContain('>1</button>')
+    expect(html).toContain('>20</button>')
+    expect(html).not.toContain('>3</button>')
+  })
+
+  it('renders children instead of the generated controls when provided', () => {
+    const html = renderToString(
+      React.createElement(
+        Pagination,
+        { totalPages: 5 },
+        React.createElement('button', null, 'Custom'),
+      ),
+    )
+    expect(html).toContain('Custom')
+    expect(html).not.toContain('Previous')
+    expect(html).toContain('role="navigation"')
+  })
+})

--- a/packages/react-pagination/src/pagination.tsx
+++ b/packages/react-pagination/src/pagination.tsx
@@ -1,11 +1,124 @@
 import * as React from 'react'
 import { cn } from '@refraction-ui/shared'
+import {
+  createPagination,
+  paginationVariants,
+  paginationItemVariants,
+  paginationEllipsisClass,
+} from '@refraction-ui/pagination'
 
-export interface PaginationProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface PaginationProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /** Current page, 1-based (controlled). Pair with `onPageChange`. */
+  page?: number
+  /** Initial page for uncontrolled usage (default 1). */
+  defaultPage?: number
+  /** Total number of pages (default 1). */
+  totalPages?: number
+  /** Pages shown on each side of the current page (default 1). */
+  siblingCount?: number
+  /** Called with the target page when a control is activated. */
+  onPageChange?: (page: number) => void
+  /** Disables every control. */
+  disabled?: boolean
+}
 
+/**
+ * Pagination — page navigation with a windowed page range and ellipses.
+ *
+ * Renders `role="navigation"` with previous/next controls and numbered page
+ * buttons (`aria-current="page"` on the current page). Range computation,
+ * clamping, edge semantics, and ARIA come from the headless
+ * `@refraction-ui/pagination` core. Pass `children` to render fully custom
+ * controls instead of the generated ones.
+ */
 export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
-  ({ className, ...props }, ref) => {
-    return <div ref={ref} className={cn("", className)} {...props} />
-  }
+  (
+    {
+      className,
+      page: controlledPage,
+      defaultPage,
+      totalPages = 1,
+      siblingCount = 1,
+      onPageChange,
+      disabled = false,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const isControlled = controlledPage !== undefined
+    const [internalPage, setInternalPage] = React.useState(defaultPage ?? 1)
+
+    const api = createPagination({
+      page: isControlled ? controlledPage : internalPage,
+      totalPages,
+      siblingCount,
+    })
+
+    const goTo = (target: number) => {
+      if (disabled || target === api.page) return
+      if (!isControlled) setInternalPage(target)
+      onPageChange?.(target)
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(paginationVariants(), className)}
+        {...api.ariaProps}
+        {...api.dataAttributes}
+        {...props}
+      >
+        {children ?? (
+          <>
+            <button
+              type="button"
+              {...api.getPreviousAria()}
+              disabled={disabled || !api.canGoPrevious}
+              className={paginationItemVariants()}
+              onClick={() => goTo(api.previousPage)}
+            >
+              Previous
+            </button>
+            {api.items.map((item) =>
+              item.type === 'ellipsis' ? (
+                <span
+                  key={`ellipsis-${item.id}`}
+                  aria-hidden="true"
+                  className={paginationEllipsisClass}
+                >
+                  …
+                </span>
+              ) : (
+                <button
+                  key={item.page}
+                  type="button"
+                  {...api.getPageAria(item.page)}
+                  disabled={disabled}
+                  data-state={item.page === api.page ? 'current' : 'default'}
+                  className={paginationItemVariants({
+                    state: item.page === api.page ? 'current' : 'default',
+                  })}
+                  onClick={() => goTo(item.page)}
+                >
+                  {item.page}
+                </button>
+              ),
+            )}
+            <button
+              type="button"
+              {...api.getNextAria()}
+              disabled={disabled || !api.canGoNext}
+              className={paginationItemVariants()}
+              onClick={() => goTo(api.nextPage)}
+            >
+              Next
+            </button>
+          </>
+        )}
+      </div>
+    )
+  },
 )
 Pagination.displayName = 'Pagination'

--- a/packages/react-slider/__tests__/slider.test.tsx
+++ b/packages/react-slider/__tests__/slider.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { Slider } from '../src/slider.js'
+
+const render = (props: Record<string, unknown>) =>
+  renderToString(React.createElement(Slider, props))
+
+describe('Slider (SSR)', () => {
+  it('renders a range input with slider ARIA and normalized value', () => {
+    const html = render({ value: 40, min: 0, max: 100 })
+    expect(html).toContain('type="range"')
+    expect(html).toContain('role="slider"')
+    expect(html).toContain('aria-valuemin="0"')
+    expect(html).toContain('aria-valuemax="100"')
+    expect(html).toContain('aria-valuenow="40"')
+    expect(html).toContain('value="40"')
+  })
+
+  it('applies min/max/step attributes and clamps the value', () => {
+    const html = render({ value: 137, min: 0, max: 100, step: 5 })
+    expect(html).toContain('min="0"')
+    expect(html).toContain('max="100"')
+    expect(html).toContain('step="5"')
+    expect(html).toContain('value="100"')
+  })
+
+  it('rounds an uncontrolled defaultValue to the step', () => {
+    const html = render({ defaultValue: 37, step: 5 })
+    expect(html).toContain('value="35"')
+  })
+
+  it('marks a disabled slider', () => {
+    const html = render({ value: 10, disabled: true })
+    expect(html).toContain('disabled=""')
+    expect(html).toContain('aria-disabled="true"')
+  })
+
+  it('forwards className and aria-label', () => {
+    const html = render({ value: 10, className: 'my-slider', 'aria-label': 'Volume' })
+    expect(html).toContain('my-slider')
+    expect(html).toContain('aria-label="Volume"')
+  })
+})

--- a/packages/react-slider/src/slider.tsx
+++ b/packages/react-slider/src/slider.tsx
@@ -1,19 +1,90 @@
-import * as React from 'react';
+import * as React from 'react'
+import { cn } from '@refraction-ui/shared'
+import { createSlider, clampSliderValue, roundToStep } from '@refraction-ui/slider'
 
-export interface SliderProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  variant?: 'default';
+export interface SliderProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'value' | 'defaultValue' | 'onChange' | 'min' | 'max' | 'step'
+  > {
+  /** Current value (controlled). Pair with `onChange`/`onValueChange`. */
+  value?: number
+  /** Initial value for uncontrolled usage (defaults to `min`). */
+  defaultValue?: number
+  /** Minimum selectable value (default 0). */
+  min?: number
+  /** Maximum selectable value (default 100). */
+  max?: number
+  /** Granularity between selectable values (default 1). */
+  step?: number
+  /** Called with the new numeric value as the user moves the thumb. */
+  onChange?: (value: number) => void
+  /** Alias of `onChange`, matching the library-wide naming convention. */
+  onValueChange?: (value: number) => void
+  variant?: 'default'
 }
 
+/**
+ * Slider — a single-value range control over a native
+ * `<input type="range">`. Value clamping, step rounding, and ARIA come from
+ * the headless `@refraction-ui/slider` core; keyboard interaction is native
+ * to the input (the core's `getSliderValueFromKey` pins the same rules for
+ * non-native adapters).
+ */
 export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
-  ({ className, variant, ...props }, ref) => {
+  (
+    {
+      className,
+      variant: _variant,
+      value: controlledValue,
+      defaultValue,
+      min = 0,
+      max = 100,
+      step = 1,
+      disabled,
+      onChange,
+      onValueChange,
+      ...props
+    },
+    ref,
+  ) => {
+    const isControlled = controlledValue !== undefined
+    const [internalValue, setInternalValue] = React.useState(() =>
+      clampSliderValue(roundToStep(defaultValue ?? min, min, step), min, max),
+    )
+
+    const api = createSlider({
+      value: isControlled ? controlledValue : internalValue,
+      min,
+      max,
+      step,
+      disabled,
+      'aria-label': props['aria-label'],
+    })
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = clampSliderValue(roundToStep(Number(event.target.value), min, step), min, max)
+      if (!isControlled) setInternalValue(next)
+      onChange?.(next)
+      onValueChange?.(next)
+    }
+
     return (
-      <input 
+      <input
         type="range"
         ref={ref}
-        className={`w-full ${className || ''}`}
+        min={min}
+        max={max}
+        step={step}
+        value={api.value}
+        disabled={disabled}
+        className={cn('w-full', className)}
+        {...api.ariaProps}
+        {...api.dataAttributes}
+        onChange={handleChange}
         {...props}
       />
-    );
-  }
-);
-Slider.displayName = 'Slider';
+    )
+  },
+)
+Slider.displayName = 'Slider'

--- a/packages/slider/__tests__/slider.test.ts
+++ b/packages/slider/__tests__/slider.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createSlider,
+  clampSliderValue,
+  roundToStep,
+  getSliderValueFromKey,
+} from '../src/index.js'
+
+describe('clampSliderValue', () => {
+  it('clamps into [min, max]', () => {
+    expect(clampSliderValue(-5, 0, 100)).toBe(0)
+    expect(clampSliderValue(105, 0, 100)).toBe(100)
+    expect(clampSliderValue(42, 0, 100)).toBe(42)
+    expect(clampSliderValue(5, 10, 20)).toBe(10)
+  })
+
+  it('returns min for NaN', () => {
+    expect(clampSliderValue(Number('nope'), 3, 9)).toBe(3)
+  })
+})
+
+describe('roundToStep', () => {
+  it('rounds to the nearest step offset from min', () => {
+    expect(roundToStep(37, 0, 5)).toBe(35)
+    expect(roundToStep(38, 0, 5)).toBe(40)
+    expect(roundToStep(4, 2, 5)).toBe(2)
+    expect(roundToStep(5, 2, 5)).toBe(7)
+  })
+
+  it('avoids float noise on decimal steps', () => {
+    expect(roundToStep(0.3, 0, 0.1)).toBe(0.3)
+    expect(roundToStep(0.55, 0, 0.25)).toBe(0.5)
+  })
+
+  it('leaves the value unchanged for a non-positive step', () => {
+    expect(roundToStep(3.7, 0, 0)).toBe(3.7)
+  })
+})
+
+describe('getSliderValueFromKey', () => {
+  const opts = { min: 0, max: 100, step: 5 }
+
+  it('increments/decrements by step on arrows', () => {
+    expect(getSliderValueFromKey(40, 'ArrowRight', opts)).toBe(45)
+    expect(getSliderValueFromKey(40, 'ArrowUp', opts)).toBe(45)
+    expect(getSliderValueFromKey(40, 'ArrowLeft', opts)).toBe(35)
+    expect(getSliderValueFromKey(40, 'ArrowDown', opts)).toBe(35)
+  })
+
+  it('moves by 10×step on PageUp/PageDown', () => {
+    expect(getSliderValueFromKey(20, 'PageUp', opts)).toBe(70)
+    expect(getSliderValueFromKey(80, 'PageDown', opts)).toBe(30)
+  })
+
+  it('jumps to the extremes on Home/End', () => {
+    expect(getSliderValueFromKey(40, 'Home', opts)).toBe(0)
+    expect(getSliderValueFromKey(40, 'End', opts)).toBe(100)
+  })
+
+  it('clamps at the edges', () => {
+    expect(getSliderValueFromKey(98, 'ArrowRight', opts)).toBe(100)
+    expect(getSliderValueFromKey(2, 'ArrowLeft', opts)).toBe(0)
+  })
+
+  it('returns current for unhandled keys', () => {
+    expect(getSliderValueFromKey(40, 'Enter', opts)).toBe(40)
+  })
+})
+
+describe('createSlider', () => {
+  it('exposes slider role and value ARIA', () => {
+    const api = createSlider({ value: 40, min: 0, max: 100 })
+    expect(api.ariaProps.role).toBe('slider')
+    expect(api.ariaProps['aria-valuemin']).toBe(0)
+    expect(api.ariaProps['aria-valuemax']).toBe(100)
+    expect(api.ariaProps['aria-valuenow']).toBe(40)
+    expect(api.ariaProps['aria-orientation']).toBe('horizontal')
+  })
+
+  it('normalizes the value (clamp + step round)', () => {
+    expect(createSlider({ value: 137, max: 100 }).value).toBe(100)
+    expect(createSlider({ value: -2 }).value).toBe(0)
+    expect(createSlider({ value: 37, step: 5 }).value).toBe(35)
+    expect(createSlider({ value: 6, min: 10, max: 20 }).value).toBe(10)
+  })
+
+  it('computes the percentage position', () => {
+    expect(createSlider({ value: 25, max: 100 }).percentage).toBe(25)
+    expect(createSlider({ value: 15, min: 10, max: 20 }).percentage).toBe(50)
+    expect(createSlider({ value: 5, min: 5, max: 5 }).percentage).toBe(0)
+  })
+
+  it('emits aria-disabled and aria-label only when set', () => {
+    const plain = createSlider({ value: 1 })
+    expect(plain.ariaProps['aria-disabled']).toBeUndefined()
+    expect(plain.ariaProps['aria-label']).toBeUndefined()
+
+    const labeled = createSlider({ value: 1, disabled: true, 'aria-label': 'Volume' })
+    expect(labeled.ariaProps['aria-disabled']).toBe(true)
+    expect(labeled.ariaProps['aria-label']).toBe('Volume')
+  })
+})

--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -1,2 +1,134 @@
-// Core slider logic
-export interface SliderProps {}
+/**
+ * @refraction-ui/slider — headless slider.
+ *
+ * Owns the *behavior* of a single-value range slider: min/max clamping,
+ * step rounding, and keyboard increment/decrement semantics. It has NO UI
+ * opinion — adapters render the control (a native `<input type="range">` in
+ * React, which already applies these same keyboard rules natively) and spread
+ * the ARIA object.
+ */
+
+/** Options for {@link createSlider}. */
+export interface SliderProps {
+  /** Current value. Clamped into `[min, max]` and rounded to `step`. */
+  value?: number
+  /** Minimum selectable value (default 0). */
+  min?: number
+  /** Maximum selectable value (default 100). */
+  max?: number
+  /** Granularity between selectable values (default 1). */
+  step?: number
+  /** Disables the control. */
+  disabled?: boolean
+  /** Accessible label attached to the slider, when provided. */
+  'aria-label'?: string
+}
+
+/** The computed view of a slider control. */
+export interface SliderAPI {
+  /** Normalized value (clamped + step-rounded). */
+  value: number
+  min: number
+  max: number
+  step: number
+  /** Value position within the range, 0–100. */
+  percentage: number
+  /** ARIA attributes for the slider element (`role="slider"` + value attrs). */
+  ariaProps: Record<string, string | number | boolean>
+  /** Data attributes for styling hooks. */
+  dataAttributes: Record<string, string>
+}
+
+/** Clamp a value into `[min, max]`. */
+export function clampSliderValue(value: number, min = 0, max = 100): number {
+  if (Number.isNaN(value)) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Round a value to the nearest multiple of `step`, offset from `min`.
+ * Non-positive steps leave the value unchanged. The result is re-rounded to
+ * the step's decimal precision to avoid float noise (e.g. 0.30000000000000004).
+ */
+export function roundToStep(value: number, min = 0, step = 1): number {
+  if (!step || step <= 0 || Number.isNaN(value)) return value
+  const snapped = min + Math.round((value - min) / step) * step
+  const decimals = (String(step).split('.')[1] ?? '').length
+  return Number(snapped.toFixed(decimals))
+}
+
+/**
+ * Pure keyboard rule for a slider (WAI-ARIA slider pattern), shared by every
+ * adapter that does NOT render a native range input (native inputs already
+ * implement these keys):
+ *
+ * - ArrowRight / ArrowUp   → +step
+ * - ArrowLeft  / ArrowDown → -step
+ * - PageUp   / PageDown    → ±10×step
+ * - Home / End             → min / max
+ *
+ * The result is clamped; unhandled keys return `current` unchanged.
+ */
+export function getSliderValueFromKey(
+  current: number,
+  key: string,
+  options: { min?: number; max?: number; step?: number } = {},
+): number {
+  const { min = 0, max = 100, step = 1 } = options
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowUp':
+      return clampSliderValue(current + step, min, max)
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      return clampSliderValue(current - step, min, max)
+    case 'PageUp':
+      return clampSliderValue(current + step * 10, min, max)
+    case 'PageDown':
+      return clampSliderValue(current - step * 10, min, max)
+    case 'Home':
+      return min
+    case 'End':
+      return max
+    default:
+      return current
+  }
+}
+
+/**
+ * createSlider — the framework-agnostic view of a slider: normalized value,
+ * percentage position, and the ARIA object (`role="slider"`,
+ * `aria-valuemin/max/now`). Adapters own the value state
+ * (controlled/uncontrolled) and call this per render.
+ */
+export function createSlider(props: SliderProps = {}): SliderAPI {
+  const min = props.min ?? 0
+  const max = props.max ?? 100
+  const step = props.step ?? 1
+  const value = clampSliderValue(roundToStep(props.value ?? min, min, step), min, max)
+  const percentage = max === min ? 0 : ((value - min) / (max - min)) * 100
+
+  const ariaProps: Record<string, string | number | boolean> = {
+    role: 'slider',
+    'aria-valuemin': min,
+    'aria-valuemax': max,
+    'aria-valuenow': value,
+    'aria-orientation': 'horizontal',
+  }
+  if (props.disabled) ariaProps['aria-disabled'] = true
+  if (props['aria-label']) ariaProps['aria-label'] = props['aria-label']
+
+  return {
+    value,
+    min,
+    max,
+    step,
+    percentage,
+    ariaProps,
+    dataAttributes: {
+      'data-value': String(value),
+      'data-min': String(min),
+      'data-max': String(max),
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2579,6 +2579,9 @@ importers:
 
   packages/carousel:
     dependencies:
+      '@refraction-ui/accordion':
+        specifier: workspace:*
+        version: link:../accordion
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2748,7 +2751,11 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
-  packages/file-tree: {}
+  packages/file-tree:
+    dependencies:
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/file-upload:
     dependencies:
@@ -4266,6 +4273,13 @@ importers:
         version: 19.0.0(react@19.0.0)
 
   packages/react-file-tree:
+    dependencies:
+      '@refraction-ui/file-tree':
+        specifier: workspace:*
+        version: link:../file-tree
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@types/react':
         specifier: 19.0.0


### PR DESCRIPTION
## Summary
Fixes the inverted architecture found in the review — hollow core stubs with logic trapped in React adapters, and two shipped components rendering empty divs. 101 tests pass across the 10 touched packages; full meta build green; no export collisions.

- **accordion**: disclosure state machine (single/multiple, collapsible, controlled+uncontrolled) moved into the core as a framework-agnostic store; adapter consumes it via useSyncExternalStore. Public API + DOM identical
- **carousel**: docs/story demo expand/collapse panels — it's an accordion in disguise. Core now honestly shares the accordion state machine under carousel-named types (dedup, zero behavior change); header comment documents that a slide-navigation carousel would be a different core
- **pagination**: real core (windowed ranges + ellipsis, clamping, ARIA nav) + adapter renders a real pagination nav (children still override generated controls, so existing composed examples work)
- **slider**: real core (clamping, float-safe step rounding, WAI-ARIA keys, slider ARIA); adapter normalizes through it
- **file-tree**: real headless tree (expand/collapse, selection, roving focus, treeview keyboard semantics, tree/treeitem ARIA) + adapter renders a real nested tree; docs page/examples/story updated to match (they previously hand-rolled a demo around the empty stub)
- **icon-system**: investigated (scaffold-generated stub, zero references, classified 'Stub/re-export only' in docs/instrumentation) — stays a stub with an honest comment; NOT unwired (removing a published export is breaking)

NOTE FOR REVIEWER: pagination/slider/file-tree docs pages now render real UI where empty divs shipped before — visual baselines will legitimately diff; a baseline regen on this branch is part of the merge plan.

## Checklist
- [x] Tests added or updated (core unit + adapter SSR per package)
- [x] Axe/Accessibility checks pass (ARIA assertions in SSR tests)
- [x] Docs updated (file-tree docs/story synced to the real implementation)
- [x] Changeset added if package API changed (minor @refraction-ui/react)

## Breaking changes?
accordion/carousel: none. pagination/slider/file-tree: additive (all new props optional; bare usages compile). One type-level change: SliderProps.onChange is now (value: number) => void — matches what the docs props table already promised.