### PR TITLE
test: SSR suites for 7 adapters + core tests for diff-viewer/http/location-selector/table-of-contents

### DIFF
--- a/packages/callout/__tests__/callout.test.ts
+++ b/packages/callout/__tests__/callout.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { createCallout } from '../src/index.js'
+
+describe('callout core — data-slot/ARIA contract', () => {
+  it('exposes the callout data-slot with a default region role', () => {
+    expect(createCallout()).toEqual({
+      ariaProps: { role: 'region' },
+      dataAttributes: { 'data-slot': 'callout' },
+    })
+  })
+})

--- a/packages/callout/vitest.config.ts
+++ b/packages/callout/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/card-grid/__tests__/card-grid.test.ts
+++ b/packages/card-grid/__tests__/card-grid.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { createCardGrid } from '../src/index.js'
+
+describe('card-grid core — data-slot contract', () => {
+  it('exposes the card-grid data-slot', () => {
+    expect(createCardGrid()).toEqual({
+      dataAttributes: { 'data-slot': 'card-grid' },
+    })
+  })
+})

--- a/packages/card-grid/vitest.config.ts
+++ b/packages/card-grid/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/code-block/__tests__/code-block.test.ts
+++ b/packages/code-block/__tests__/code-block.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createCodeBlock,
+  createCodeBlockHeader,
+  createCodeBlockContent,
+} from '../src/index.js'
+
+describe('code-block core — data-slot contract', () => {
+  it('exposes the code-block slot family', () => {
+    expect({
+      root: createCodeBlock().dataAttributes['data-slot'],
+      header: createCodeBlockHeader().dataAttributes['data-slot'],
+      content: createCodeBlockContent().dataAttributes['data-slot'],
+    }).toEqual({
+      root: 'code-block',
+      header: 'code-block-header',
+      content: 'code-block-content',
+    })
+  })
+})

--- a/packages/code-block/vitest.config.ts
+++ b/packages/code-block/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/diff-viewer/__tests__/diff-viewer.test.ts
+++ b/packages/diff-viewer/__tests__/diff-viewer.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createDiffViewer, type DiffFile } from '../src/index.js'
+
+function makeFiles(): DiffFile[] {
+  return [
+    { path: 'src/app.ts', status: 'modified', additions: 10, deletions: 2 },
+    { path: 'README.md', status: 'added', additions: 20, deletions: 0 },
+    { path: 'old/util.py', status: 'deleted', additions: 0, deletions: 15 },
+  ]
+}
+
+describe('createDiffViewer — initial state', () => {
+  it('applies defaults: side-by-side, dark theme, sidebar open, first file active', () => {
+    const api = createDiffViewer({ files: makeFiles() })
+    expect(api.state.viewMode).toBe('side-by-side')
+    expect(api.state.theme).toBe('dark')
+    expect(api.state.sidebarOpen).toBe(true)
+    expect(api.state.activeFileIndex).toBe(0)
+  })
+
+  it('derives the language from the active file when none is given', () => {
+    const api = createDiffViewer({ files: makeFiles() })
+    expect(api.state.language).toBe('typescript')
+  })
+
+  it('falls back to plaintext with no files', () => {
+    const api = createDiffViewer()
+    expect(api.state.language).toBe('plaintext')
+    expect(api.state.files).toEqual([])
+  })
+
+  it('clamps an out-of-range initial activeFileIndex to the last file', () => {
+    const api = createDiffViewer({ files: makeFiles(), activeFileIndex: 99 })
+    expect(api.state.activeFileIndex).toBe(2)
+    expect(api.state.language).toBe('python')
+  })
+
+  it('honors an explicit language override', () => {
+    const api = createDiffViewer({ files: makeFiles(), language: 'go' })
+    expect(api.state.language).toBe('go')
+  })
+
+  it('exposes region ARIA props and initial data attributes', () => {
+    const api = createDiffViewer({ files: makeFiles(), theme: 'light' })
+    expect(api.ariaProps.role).toBe('region')
+    expect(api.ariaProps['aria-label']).toBe('Diff viewer')
+    expect(api.dataAttributes['data-view-mode']).toBe('side-by-side')
+    expect(api.dataAttributes['data-theme']).toBe('light')
+    expect(api.dataAttributes['data-file-count']).toBe('3')
+    expect(api.dataAttributes).not.toHaveProperty('data-sidebar-collapsed')
+  })
+
+  it('marks data-sidebar-collapsed when created with the sidebar closed', () => {
+    const api = createDiffViewer({ files: makeFiles(), sidebarOpen: false })
+    expect(api.state.sidebarOpen).toBe(false)
+    expect(api.dataAttributes).toHaveProperty('data-sidebar-collapsed')
+  })
+})
+
+describe('createDiffViewer — file selection', () => {
+  it('selectFile updates the active index, language, and fires onFileSelect', () => {
+    const onFileSelect = vi.fn()
+    const api = createDiffViewer({ files: makeFiles(), onFileSelect })
+    api.selectFile(1)
+    expect(api.state.activeFileIndex).toBe(1)
+    expect(api.state.language).toBe('markdown')
+    expect(onFileSelect).toHaveBeenCalledWith(1)
+  })
+
+  it('ignores out-of-range selection (negative and past the end)', () => {
+    const onFileSelect = vi.fn()
+    const api = createDiffViewer({ files: makeFiles(), onFileSelect })
+    api.selectFile(-1)
+    api.selectFile(3)
+    expect(api.state.activeFileIndex).toBe(0)
+    expect(onFileSelect).not.toHaveBeenCalled()
+  })
+
+  it('nextFile/prevFile move within bounds', () => {
+    const api = createDiffViewer({ files: makeFiles() })
+    api.nextFile()
+    expect(api.state.activeFileIndex).toBe(1)
+    api.nextFile()
+    expect(api.state.activeFileIndex).toBe(2)
+    api.nextFile() // no-op at the end
+    expect(api.state.activeFileIndex).toBe(2)
+    api.prevFile()
+    expect(api.state.activeFileIndex).toBe(1)
+    api.prevFile()
+    api.prevFile() // no-op at the start
+    expect(api.state.activeFileIndex).toBe(0)
+  })
+
+  it('keeps the explicit language override when changing files', () => {
+    const api = createDiffViewer({ files: makeFiles(), language: 'go' })
+    api.selectFile(1)
+    expect(api.state.language).toBe('go')
+  })
+})
+
+describe('createDiffViewer — view mode and sidebar toggles', () => {
+  it('toggleViewMode flips between side-by-side and inline and notifies', () => {
+    const onViewModeChange = vi.fn()
+    const api = createDiffViewer({ files: makeFiles(), onViewModeChange })
+    api.toggleViewMode()
+    expect(api.state.viewMode).toBe('inline')
+    expect(api.dataAttributes['data-view-mode']).toBe('inline')
+    expect(onViewModeChange).toHaveBeenCalledWith('inline')
+    api.toggleViewMode()
+    expect(api.state.viewMode).toBe('side-by-side')
+    expect(onViewModeChange).toHaveBeenCalledWith('side-by-side')
+  })
+
+  it('toggleSidebar flips state and the collapsed data attribute and notifies', () => {
+    const onSidebarToggle = vi.fn()
+    const api = createDiffViewer({ files: makeFiles(), onSidebarToggle })
+    api.toggleSidebar()
+    expect(api.state.sidebarOpen).toBe(false)
+    expect(api.dataAttributes).toHaveProperty('data-sidebar-collapsed')
+    expect(onSidebarToggle).toHaveBeenCalledTimes(1)
+    api.toggleSidebar()
+    expect(api.state.sidebarOpen).toBe(true)
+    expect(api.dataAttributes).not.toHaveProperty('data-sidebar-collapsed')
+    expect(onSidebarToggle).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('createDiffViewer — helpers', () => {
+  it('maps file extensions to languages', () => {
+    const api = createDiffViewer()
+    expect(api.getLanguageForFile('a/b/component.tsx')).toBe('typescript')
+    expect(api.getLanguageForFile('script.py')).toBe('python')
+    expect(api.getLanguageForFile('STYLE.CSS')).toBe('css')
+    expect(api.getLanguageForFile('config.yml')).toBe('yaml')
+    expect(api.getLanguageForFile('mystery.xyz')).toBe('plaintext')
+  })
+
+  it('detects Dockerfile by basename regardless of extension', () => {
+    const api = createDiffViewer()
+    expect(api.getLanguageForFile('deploy/Dockerfile')).toBe('dockerfile')
+  })
+
+  it('returns a status icon per file status', () => {
+    const api = createDiffViewer()
+    expect(api.getFileStatusIcon('added')).toBe('\u{1F7E2}')
+    expect(api.getFileStatusIcon('modified')).toBe('\u{1F7E1}')
+    expect(api.getFileStatusIcon('deleted')).toBe('\u{1F534}')
+    expect(api.getFileStatusIcon('renamed')).toBe('\u{1F535}')
+  })
+
+  it('sums additions and deletions across all files', () => {
+    const api = createDiffViewer({ files: makeFiles() })
+    expect(api.totalAdditions()).toBe(30)
+    expect(api.totalDeletions()).toBe(17)
+  })
+
+  it('sums to zero with no files', () => {
+    const api = createDiffViewer()
+    expect(api.totalAdditions()).toBe(0)
+    expect(api.totalDeletions()).toBe(0)
+  })
+})

--- a/packages/http/__tests__/http.test.ts
+++ b/packages/http/__tests__/http.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { HttpClient, HttpError, createHttpClient } from '../src/index.js'
+
+type FetchArgs = [string, RequestInit & { timeout?: number }]
+
+function jsonResponse(data: unknown, init: { status?: number; statusText?: string } = {}) {
+  return new Response(JSON.stringify(data), {
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mockFetch(impl: (...args: FetchArgs) => Promise<Response>) {
+  const fn = vi.fn(impl)
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('HttpClient — request building', () => {
+  it('joins baseUrl and endpoint', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({ ok: true })))
+    const client = new HttpClient({ baseUrl: 'https://api.example.com/v1' })
+    await client.get('/users')
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/users')
+  })
+
+  it('uses the endpoint as-is without a baseUrl', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.get('https://other.example.com/x')
+    expect(fetchMock.mock.calls[0][0]).toBe('https://other.example.com/x')
+  })
+
+  it('defaults Content-Type to application/json and JSON-stringifies object bodies', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.post('/items', { name: 'widget' })
+    const [, options] = fetchMock.mock.calls[0]
+    expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect(options.body).toBe(JSON.stringify({ name: 'widget' }))
+    expect(options.method).toBe('POST')
+  })
+
+  it('passes string bodies through untouched', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.post('/items', 'raw-body')
+    expect(fetchMock.mock.calls[0][1].body).toBe('raw-body')
+  })
+
+  it('respects a caller-provided Content-Type', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.post('/items', 'a=1', { headers: { 'Content-Type': 'text/plain' } })
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers['Content-Type']).toBe('text/plain')
+  })
+
+  it('omits Content-Type for FormData bodies so the runtime sets the boundary', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    const form = new FormData()
+    form.append('file', 'data')
+    await client.post('/upload', form)
+    const [, options] = fetchMock.mock.calls[0]
+    expect((options.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+    expect(options.body).toBe(form)
+  })
+
+  it('omits Content-Type for URLSearchParams bodies', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    const params = new URLSearchParams({ a: '1' })
+    await client.post('/form', params)
+    const [, options] = fetchMock.mock.calls[0]
+    expect((options.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+    expect(options.body).toBe(params)
+  })
+
+  it('merges config headers and lets per-request headers win', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient({ headers: { 'X-App': 'demo', 'X-Shared': 'config' } })
+    await client.get('/x', { headers: { 'X-Shared': 'request' } })
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers['X-App']).toBe('demo')
+    expect(headers['X-Shared']).toBe('request')
+  })
+
+  it('maps helper methods to HTTP verbs', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.get('/x')
+    await client.post('/x', {})
+    await client.put('/x', {})
+    await client.patch('/x', {})
+    await client.delete('/x')
+    const methods = fetchMock.mock.calls.map((c) => (c[1] as RequestInit).method)
+    expect(methods).toEqual(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+  })
+})
+
+describe('HttpClient — auth header', () => {
+  it('adds a Bearer token from a sync getToken', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient({ getToken: () => 'tok123' })
+    await client.get('/me')
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer tok123')
+  })
+
+  it('adds a Bearer token from an async getToken', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient({ getToken: async () => 'async-tok' })
+    await client.get('/me')
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer async-tok')
+  })
+
+  it('sends no Authorization header when getToken returns null', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient({ getToken: () => null })
+    await client.get('/me')
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('sends no Authorization header when no getToken is configured', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient()
+    await client.get('/me')
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+})
+
+describe('HttpClient — response handling', () => {
+  it('parses JSON responses by content-type', async () => {
+    mockFetch(() => Promise.resolve(jsonResponse({ id: 7 })))
+    const client = new HttpClient()
+    const res = await client.get<{ id: number }>('/item')
+    expect(res.data).toEqual({ id: 7 })
+    expect(res.status).toBe(200)
+    expect(res.statusText).toBe('OK')
+  })
+
+  it('returns text for non-JSON responses', async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response('plain text', { status: 200, headers: { 'content-type': 'text/plain' } }),
+      ),
+    )
+    const client = new HttpClient()
+    const res = await client.get<string>('/doc')
+    expect(res.data).toBe('plain text')
+  })
+
+  it('returns null data for 204 No Content', async () => {
+    mockFetch(() => Promise.resolve(new Response(null, { status: 204 })))
+    const client = new HttpClient()
+    const res = await client.delete('/item/1')
+    expect(res.status).toBe(204)
+    expect(res.data).toBeNull()
+  })
+
+  it('throws HttpError with status and parsed body on HTTP errors', async () => {
+    mockFetch(() =>
+      Promise.resolve(jsonResponse({ message: 'nope' }, { status: 422, statusText: 'Unprocessable Entity' })),
+    )
+    const client = new HttpClient()
+    const err = await client.post('/items', {}).catch((e) => e)
+    expect(err).toBeInstanceOf(HttpError)
+    expect(err.status).toBe(422)
+    expect(err.statusText).toBe('Unprocessable Entity')
+    expect(err.data).toEqual({ message: 'nope' })
+    expect(err.message).toContain('422')
+  })
+
+  it('throws HttpError for error responses with unparseable bodies', async () => {
+    mockFetch(() => Promise.resolve(new Response('oops', { status: 500, statusText: 'Server Error' })))
+    const client = new HttpClient()
+    const err = await client.get('/boom').catch((e) => e)
+    expect(err).toBeInstanceOf(HttpError)
+    expect(err.status).toBe(500)
+    expect(err.data).toBe('oops')
+  })
+})
+
+describe('HttpClient — timeout', () => {
+  it('aborts the request and rejects with a timeout error', async () => {
+    // A fetch that only settles when the client's AbortController fires.
+    mockFetch(
+      (_url, options) =>
+        new Promise<Response>((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        }),
+    )
+    const client = new HttpClient({ timeout: 10 })
+    await expect(client.get('/slow')).rejects.toThrow('Request timed out after 10ms')
+  })
+
+  it('passes an AbortSignal to fetch', async () => {
+    const fetchMock = mockFetch(() => Promise.resolve(jsonResponse({})))
+    const client = new HttpClient({ timeout: 1000 })
+    await client.get('/x')
+    expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('per-request timeout overrides the client default', async () => {
+    mockFetch(
+      (_url, options) =>
+        new Promise<Response>((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        }),
+    )
+    const client = new HttpClient({ timeout: 60000 })
+    await expect(client.get('/slow', { timeout: 5 })).rejects.toThrow(
+      'Request timed out after 5ms',
+    )
+  })
+
+  it('does not abort requests that settle within the timeout', async () => {
+    mockFetch(() => Promise.resolve(jsonResponse({ fast: true })))
+    const client = new HttpClient({ timeout: 1000 })
+    const res = await client.get<{ fast: boolean }>('/fast')
+    expect(res.data).toEqual({ fast: true })
+  })
+})
+
+describe('createHttpClient', () => {
+  it('returns an HttpClient instance', () => {
+    expect(createHttpClient()).toBeInstanceOf(HttpClient)
+  })
+})

--- a/packages/http/vitest.config.ts
+++ b/packages/http/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/link-card/__tests__/link-card.test.ts
+++ b/packages/link-card/__tests__/link-card.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { createLinkCard } from '../src/index.js'
+
+describe('link-card core — data-slot contract', () => {
+  it('exposes the link-card data-slot', () => {
+    expect(createLinkCard()).toEqual({
+      dataAttributes: { 'data-slot': 'link-card' },
+    })
+  })
+})

--- a/packages/link-card/vitest.config.ts
+++ b/packages/link-card/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/location-selector/__tests__/location-selector.test.ts
+++ b/packages/location-selector/__tests__/location-selector.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createLocationSelector } from '../src/index.js'
+
+describe('createLocationSelector — initial state', () => {
+  it('defaults to US / en', () => {
+    const api = createLocationSelector()
+    expect(api.state.country).toBe('US')
+    expect(api.state.language).toBe('en')
+  })
+
+  it('honors custom defaults', () => {
+    const api = createLocationSelector({ defaultCountry: 'GB', defaultLanguage: 'hi' })
+    expect(api.state.country).toBe('GB')
+    expect(api.state.language).toBe('hi')
+  })
+
+  it('exposes named select props with unique, prefixed ids', () => {
+    const api = createLocationSelector()
+    expect(api.countryProps.name).toBe('country')
+    expect(api.languageProps.name).toBe('language')
+    expect(api.countryProps.id).toMatch(/^location-sel-country-\d+$/)
+    expect(api.languageProps.id).toMatch(/^location-sel-language-\d+$/)
+    expect(api.countryProps.id).not.toBe(api.languageProps.id)
+  })
+})
+
+describe('createLocationSelector — state updates', () => {
+  it('setCountry updates state and fires onCountryChange', () => {
+    const onCountryChange = vi.fn()
+    const api = createLocationSelector({ onCountryChange })
+    api.setCountry('IN')
+    expect(api.state.country).toBe('IN')
+    expect(onCountryChange).toHaveBeenCalledWith('IN')
+  })
+
+  it('setLanguage updates state and fires onLanguageChange', () => {
+    const onLanguageChange = vi.fn()
+    const api = createLocationSelector({ onLanguageChange })
+    api.setLanguage('ta')
+    expect(api.state.language).toBe('ta')
+    expect(onLanguageChange).toHaveBeenCalledWith('ta')
+  })
+
+  it('works without callbacks', () => {
+    const api = createLocationSelector()
+    expect(() => {
+      api.setCountry('FR')
+      api.setLanguage('fr')
+    }).not.toThrow()
+    expect(api.state.country).toBe('FR')
+    expect(api.state.language).toBe('fr')
+  })
+})
+
+describe('createLocationSelector — option data', () => {
+  it('exposes the i18n country list as code/name objects', () => {
+    const api = createLocationSelector()
+    expect(Array.isArray(api.countries)).toBe(true)
+    expect(api.countries.length).toBeGreaterThan(0)
+    const us = api.countries.find((c: any) => c.code === 'US')
+    expect(us).toMatchObject({ code: 'US', name: 'United States' })
+  })
+
+  it('exposes the i18n language list as code/name objects', () => {
+    const api = createLocationSelector()
+    expect(Array.isArray(api.languages)).toBe(true)
+    expect(api.languages.length).toBeGreaterThan(0)
+    const en = api.languages.find((l: any) => l.code === 'en')
+    const hi = api.languages.find((l: any) => l.code === 'hi')
+    expect(en).toMatchObject({ code: 'en', name: 'English' })
+    expect(hi).toMatchObject({ code: 'hi', name: 'Hindi' })
+  })
+})

--- a/packages/location-selector/package.json
+++ b/packages/location-selector/package.json
@@ -19,6 +19,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/location-selector/vitest.config.ts
+++ b/packages/location-selector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/payment/__tests__/payment.test.ts
+++ b/packages/payment/__tests__/payment.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { createPayment } from '../src/index.js'
+
+describe('payment core — data-slot contract', () => {
+  it('exposes the payment data-slot on the returned props', () => {
+    expect(createPayment()).toEqual({
+      props: { 'data-slot': 'payment' },
+    })
+  })
+})

--- a/packages/payment/package.json
+++ b/packages/payment/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/payment/vitest.config.ts
+++ b/packages/payment/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/react-keyboard-shortcut/__tests__/keyboard-shortcut.test.tsx
+++ b/packages/react-keyboard-shortcut/__tests__/keyboard-shortcut.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  KeyboardShortcut,
+  ShortcutBadge,
+  ShortcutContext,
+  ShortcutHint,
+} from '../src/keyboard-shortcut.js'
+
+// SSR note: modern Node exposes a global `navigator` (platform 'MacIntel' on
+// macOS), so the core's `isMac()` is host-dependent. Tests that assert
+// individual key spans pass `platform: false` for a deterministic,
+// cross-platform render; the platform-default path is only asserted on its
+// platform-independent structure (kbd + presentation ARIA).
+describe('ShortcutBadge (React SSR)', () => {
+  it('renders a kbd element with presentation ARIA', () => {
+    const html = renderToString(React.createElement(ShortcutBadge, { keys: ['Ctrl', 'K'] }))
+    expect(html).toContain('<kbd')
+    expect(html).toContain('aria-hidden="true"')
+    expect(html).toContain('role="presentation"')
+  })
+
+  it('renders each key as a styled span joined by a + separator', () => {
+    const html = renderToString(
+      React.createElement(ShortcutBadge, { keys: ['Ctrl', 'K'], platform: false }),
+    )
+    expect(html).toContain('Ctrl')
+    expect(html).toContain('>+</span>')
+    expect(html).toContain('>K</span>')
+  })
+
+  it('uppercases single-character keys for display', () => {
+    const html = renderToString(
+      React.createElement(ShortcutBadge, { keys: ['Meta', 's'], platform: false }),
+    )
+    expect(html).toContain('>Meta</span>')
+    expect(html).toContain('>S</span>')
+  })
+
+  it('renders known keys with their display aliases', () => {
+    const html = renderToString(
+      React.createElement(ShortcutBadge, { keys: ['Escape'], platform: false }),
+    )
+    expect(html).toContain('>Esc</span>')
+  })
+
+  it('appends a custom className to the kbd', () => {
+    const html = renderToString(
+      React.createElement(ShortcutBadge, { keys: ['Ctrl'], className: 'my-badge' }),
+    )
+    expect(html).toContain('my-badge')
+    // Default styles are preserved alongside the custom class.
+    expect(html).toContain('font-mono')
+  })
+})
+
+describe('ShortcutHint (React SSR)', () => {
+  it('renders nothing when hints are hidden (default context)', () => {
+    const html = renderToString(React.createElement(ShortcutHint, { shortcut: 'Ctrl+K' }))
+    expect(html).toBe('')
+  })
+
+  it('renders the badge inside a positioned wrapper when hints are shown', () => {
+    const html = renderToString(
+      React.createElement(
+        ShortcutContext.Provider,
+        { value: true },
+        React.createElement(ShortcutHint, { shortcut: 'Ctrl+K', platform: false }),
+      ),
+    )
+    expect(html).toContain('pointer-events-none')
+    expect(html).toContain('<kbd')
+    expect(html).toContain('>Ctrl</span>')
+    expect(html).toContain('>K</span>')
+  })
+
+  it('resolves keys from a SANE_DEFAULTS action name', () => {
+    const html = renderToString(
+      React.createElement(
+        ShortcutContext.Provider,
+        { value: true },
+        React.createElement(ShortcutHint, { action: 'save', platform: false }),
+      ),
+    )
+    // SANE_DEFAULTS.save is ['Meta', 's'].
+    expect(html).toContain('>Meta</span>')
+    expect(html).toContain('>S</span>')
+  })
+
+  it('renders nothing for an unknown action with no explicit shortcut', () => {
+    const html = renderToString(
+      React.createElement(
+        ShortcutContext.Provider,
+        { value: true },
+        React.createElement(ShortcutHint, { action: 'not-a-real-action' }),
+      ),
+    )
+    expect(html).toBe('')
+  })
+
+  it('prefers an explicit shortcut over an action', () => {
+    const html = renderToString(
+      React.createElement(
+        ShortcutContext.Provider,
+        { value: true },
+        React.createElement(ShortcutHint, { shortcut: 'Ctrl+P', action: 'save', platform: false }),
+      ),
+    )
+    expect(html).toContain('>Ctrl</span>')
+    expect(html).toContain('>P</span>')
+    expect(html).not.toContain('>Meta</span>')
+  })
+})
+
+describe('KeyboardShortcut (React SSR)', () => {
+  it('renders nothing — it is an invisible global listener by design', () => {
+    // KeyboardShortcut attaches its keydown listener in useEffect and returns
+    // null from render. SSR never runs effects, so the honest contract here
+    // is "no markup, and no crash without a document".
+    const html = renderToString(
+      React.createElement(KeyboardShortcut, { keys: ['Meta', 'k'], onTrigger: () => {} }),
+    )
+    expect(html).toBe('')
+  })
+
+  it('renders nothing even when disabled', () => {
+    const html = renderToString(
+      React.createElement(KeyboardShortcut, {
+        keys: ['Meta', 'k'],
+        onTrigger: () => {},
+        enabled: false,
+      }),
+    )
+    expect(html).toBe('')
+  })
+})

--- a/packages/react-link-card/__tests__/link-card.test.tsx
+++ b/packages/react-link-card/__tests__/link-card.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { LinkCard } from '../src/link-card.js'
+
+describe('LinkCard (React SSR)', () => {
+  it('renders an anchor element with the link-card data-slot', () => {
+    const html = renderToString(React.createElement(LinkCard, { href: 'https://example.com' }))
+    expect(html).toContain('<a')
+    expect(html).toContain('data-slot="link-card"')
+  })
+
+  it('passes href through to the anchor', () => {
+    const html = renderToString(React.createElement(LinkCard, { href: 'https://example.com/docs' }))
+    expect(html).toContain('href="https://example.com/docs"')
+  })
+
+  it('renders children inside the anchor', () => {
+    const html = renderToString(
+      React.createElement(LinkCard, { href: 'https://example.com' }, 'Read the docs'),
+    )
+    expect(html).toContain('Read the docs')
+  })
+
+  it('passes through standard anchor attributes', () => {
+    const html = renderToString(
+      React.createElement(LinkCard, {
+        href: 'https://example.com',
+        target: '_blank',
+        rel: 'noreferrer',
+        'aria-label': 'External docs',
+      }),
+    )
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noreferrer"')
+    expect(html).toContain('aria-label="External docs"')
+  })
+
+  it('applies a custom className', () => {
+    const html = renderToString(
+      React.createElement(LinkCard, { href: 'https://example.com', className: 'my-card' }),
+    )
+    expect(html).toContain('class="my-card"')
+  })
+})

--- a/packages/react-link-card/vitest.config.ts
+++ b/packages/react-link-card/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/react-location-selector/__tests__/location-selector.test.tsx
+++ b/packages/react-location-selector/__tests__/location-selector.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { LocationSelector } from '../src/location-selector.js'
+
+describe('LocationSelector (React SSR)', () => {
+  it('renders country and language selects with visible labels', () => {
+    const html = renderToString(React.createElement(LocationSelector, {}))
+    expect(html).toContain('name="country"')
+    expect(html).toContain('name="language"')
+    expect(html).toContain('>Country</label>')
+    expect(html).toContain('>Language</label>')
+  })
+
+  it('associates each label with its select via matching for/id', () => {
+    const html = renderToString(React.createElement(LocationSelector, {}))
+    const countryFor = html.match(/for="(location-sel-country-[^"]+)"/)
+    const languageFor = html.match(/for="(location-sel-language-[^"]+)"/)
+    expect(countryFor).not.toBeNull()
+    expect(languageFor).not.toBeNull()
+    expect(html).toContain(`id="${countryFor![1]}"`)
+    expect(html).toContain(`id="${languageFor![1]}"`)
+  })
+
+  it('renders i18n country options', () => {
+    const html = renderToString(React.createElement(LocationSelector, {}))
+    // Non-default options render plain; the default (US) carries selected.
+    expect(html).toContain('<option value="GB">United Kingdom</option>')
+    expect(html).toContain('<option value="IN">India</option>')
+    expect(html).toContain('<option value="US" selected="">United States</option>')
+  })
+
+  it('renders i18n language options', () => {
+    const html = renderToString(React.createElement(LocationSelector, {}))
+    expect(html).toContain('<option value="hi">Hindi</option>')
+    expect(html).toContain('<option value="fr">French</option>')
+  })
+
+  it('marks the default country and language options as selected', () => {
+    // React SSR injects `selected` after `value` on the option matching the
+    // controlled select's value.
+    const html = renderToString(
+      React.createElement(LocationSelector, { defaultCountry: 'GB', defaultLanguage: 'hi' }),
+    )
+    expect(html).toContain('<option value="GB" selected="">')
+    expect(html).toContain('<option value="hi" selected="">')
+  })
+
+  it('lays out the two selects in a responsive flex wrapper', () => {
+    const html = renderToString(React.createElement(LocationSelector, {}))
+    expect(html).toContain('flex flex-col gap-4 sm:flex-row')
+  })
+
+  it('appends a custom className to the wrapper', () => {
+    const html = renderToString(React.createElement(LocationSelector, { className: 'my-selector' }))
+    expect(html).toContain('my-selector')
+    expect(html).toContain('flex flex-col gap-4 sm:flex-row')
+  })
+})

--- a/packages/react-location-selector/package.json
+++ b/packages/react-location-selector/package.json
@@ -19,6 +19,9 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/react-location-selector/vitest.config.ts
+++ b/packages/react-location-selector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/react-skip-to-content/__tests__/skip-to-content.test.tsx
+++ b/packages/react-skip-to-content/__tests__/skip-to-content.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { SkipToContent } from '../src/skip-to-content.js'
+
+describe('SkipToContent (React SSR)', () => {
+  it('renders an anchor pointing at #main-content by default', () => {
+    const html = renderToString(React.createElement(SkipToContent, {}))
+    expect(html).toContain('<a')
+    expect(html).toContain('href="#main-content"')
+  })
+
+  it('renders the default "Skip to content" label', () => {
+    const html = renderToString(React.createElement(SkipToContent, {}))
+    expect(html).toContain('Skip to content')
+  })
+
+  it('honors a custom targetId', () => {
+    const html = renderToString(React.createElement(SkipToContent, { targetId: 'content' }))
+    expect(html).toContain('href="#content"')
+  })
+
+  it('renders custom children instead of the default label', () => {
+    const html = renderToString(
+      React.createElement(SkipToContent, {}, 'Skip to main'),
+    )
+    expect(html).toContain('Skip to main')
+    expect(html).not.toContain('Skip to content')
+  })
+
+  it('carries the skip-to-content data-slot', () => {
+    const html = renderToString(React.createElement(SkipToContent, {}))
+    expect(html).toContain('data-slot="skip-to-content"')
+  })
+
+  it('is visually hidden until focused (off-screen translate, restored on focus)', () => {
+    const html = renderToString(React.createElement(SkipToContent, {}))
+    expect(html).toContain('-translate-y-16')
+    expect(html).toContain('focus:translate-y-0')
+  })
+
+  it('appends a custom className without dropping the variant classes', () => {
+    const html = renderToString(React.createElement(SkipToContent, { className: 'my-skip' }))
+    expect(html).toContain('my-skip')
+    expect(html).toContain('-translate-y-16')
+  })
+})

--- a/packages/react-skip-to-content/vitest.config.ts
+++ b/packages/react-skip-to-content/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/react-steps/__tests__/steps.test.tsx
+++ b/packages/react-steps/__tests__/steps.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import {
+  Steps,
+  Step,
+  StepIndicator,
+  StepContent,
+  StepTitle,
+  StepDescription,
+} from '../src/steps.js'
+
+describe('Steps (React SSR)', () => {
+  it('renders a div with the steps data-slot', () => {
+    const html = renderToString(React.createElement(Steps, {}))
+    expect(html).toContain('<div')
+    expect(html).toContain('data-slot="steps"')
+  })
+
+  it('defaults to vertical orientation', () => {
+    const html = renderToString(React.createElement(Steps, {}))
+    expect(html).toContain('flex-col')
+  })
+
+  it('applies horizontal orientation classes', () => {
+    const html = renderToString(React.createElement(Steps, { orientation: 'horizontal' }))
+    expect(html).toContain('flex-row')
+  })
+
+  it('renders children and passes through HTML attributes', () => {
+    const html = renderToString(
+      React.createElement(Steps, { 'aria-label': 'Onboarding steps' }, 'step list'),
+    )
+    expect(html).toContain('aria-label="Onboarding steps"')
+    expect(html).toContain('step list')
+  })
+
+  it('appends a custom className without dropping variant classes', () => {
+    const html = renderToString(React.createElement(Steps, { className: 'my-steps' }))
+    expect(html).toContain('my-steps')
+    expect(html).toContain('flex-col')
+  })
+})
+
+describe('Step (React SSR)', () => {
+  it('renders a div with the step data-slot', () => {
+    const html = renderToString(React.createElement(Step, {}))
+    expect(html).toContain('data-slot="step"')
+  })
+
+  it('defaults to the upcoming (muted) status', () => {
+    const html = renderToString(React.createElement(Step, {}))
+    expect(html).toContain('text-muted-foreground')
+  })
+
+  it('applies the active status classes', () => {
+    const html = renderToString(React.createElement(Step, { status: 'active' }))
+    expect(html).toContain('text-foreground')
+  })
+
+  it('applies the completed status classes', () => {
+    const html = renderToString(React.createElement(Step, { status: 'completed' }))
+    expect(html).toContain('text-foreground')
+  })
+})
+
+describe('StepIndicator (React SSR)', () => {
+  it('renders a div with the step-indicator data-slot', () => {
+    const html = renderToString(React.createElement(StepIndicator, {}))
+    expect(html).toContain('data-slot="step-indicator"')
+    expect(html).toContain('rounded-full')
+  })
+
+  it('defaults to the upcoming status ring', () => {
+    const html = renderToString(React.createElement(StepIndicator, {}))
+    expect(html).toContain('border-muted')
+  })
+
+  it('renders the completed status as a filled primary disc', () => {
+    const html = renderToString(React.createElement(StepIndicator, { status: 'completed' }))
+    expect(html).toContain('border-primary')
+    expect(html).toContain('bg-primary')
+  })
+
+  it('renders the active status as a primary outline', () => {
+    const html = renderToString(React.createElement(StepIndicator, { status: 'active' }))
+    expect(html).toContain('border-primary')
+    expect(html).toContain('bg-background')
+    expect(html).toContain('text-primary')
+  })
+})
+
+describe('StepContent / StepTitle / StepDescription (React SSR)', () => {
+  it('StepContent renders a div with the step-content data-slot', () => {
+    const html = renderToString(React.createElement(StepContent, {}, 'content'))
+    expect(html).toContain('data-slot="step-content"')
+    expect(html).toContain('content')
+  })
+
+  it('StepTitle renders an h4 heading with the step-title data-slot', () => {
+    const html = renderToString(React.createElement(StepTitle, {}, 'Account'))
+    expect(html).toContain('<h4')
+    expect(html).toContain('data-slot="step-title"')
+    expect(html).toContain('Account')
+  })
+
+  it('StepDescription renders a paragraph with the step-description data-slot', () => {
+    const html = renderToString(React.createElement(StepDescription, {}, 'Tell us about you'))
+    expect(html).toContain('<p')
+    expect(html).toContain('data-slot="step-description"')
+    expect(html).toContain('Tell us about you')
+  })
+
+  it('composes a full step without crashing', () => {
+    const html = renderToString(
+      React.createElement(
+        Steps,
+        {},
+        React.createElement(
+          Step,
+          { status: 'active' },
+          React.createElement(StepIndicator, { status: 'active' }, '1'),
+          React.createElement(
+            StepContent,
+            {},
+            React.createElement(StepTitle, {}, 'Account'),
+            React.createElement(StepDescription, {}, 'Create your account'),
+          ),
+        ),
+      ),
+    )
+    expect(html).toContain('data-slot="steps"')
+    expect(html).toContain('data-slot="step"')
+    expect(html).toContain('data-slot="step-indicator"')
+    expect(html).toContain('data-slot="step-content"')
+    expect(html).toContain('data-slot="step-title"')
+    expect(html).toContain('data-slot="step-description"')
+  })
+})

--- a/packages/react-steps/vitest.config.ts
+++ b/packages/react-steps/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})

--- a/packages/react-table-of-contents/__tests__/table-of-contents.test.tsx
+++ b/packages/react-table-of-contents/__tests__/table-of-contents.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { TableOfContents } from '../src/table-of-contents.js'
+
+// SSR contract: TableOfContents starts with an empty heading list and parses
+// the container inside useEffect, which never runs during SSR. The honest
+// server-rendered output is therefore "nothing" — the nav only appears after
+// hydration. Parsing itself is covered by the core package's unit tests.
+describe('TableOfContents (React SSR)', () => {
+  it('renders nothing on the server — headings are parsed in an effect after mount', () => {
+    const html = renderToString(React.createElement(TableOfContents, {}))
+    expect(html).toBe('')
+  })
+
+  it('renders nothing even when a containerRef is provided (no document access during SSR)', () => {
+    const containerRef = React.createRef<HTMLElement>()
+    const html = renderToString(React.createElement(TableOfContents, { containerRef }))
+    expect(html).toBe('')
+  })
+
+  it('accepts custom selectors and callbacks without crashing the server render', () => {
+    const html = renderToString(
+      React.createElement(TableOfContents, {
+        selectors: 'h1, h2',
+        onActiveIdChange: () => {},
+        className: 'my-toc',
+      }),
+    )
+    expect(html).toBe('')
+  })
+})

--- a/packages/react-thread-view/__tests__/thread-view.test.tsx
+++ b/packages/react-thread-view/__tests__/thread-view.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { ThreadView } from '../src/thread-view.js'
+import type { MessageData } from '@refraction-ui/thread-view'
+
+function makeMessage(overrides: Partial<MessageData> = {}): MessageData {
+  return {
+    id: 'm1',
+    author: { id: 'u1', name: 'Ada' },
+    content: 'Hello thread',
+    // 3:05 PM local time — formatTimestamp uses local getters.
+    timestamp: new Date(2026, 0, 15, 15, 5),
+    ...overrides,
+  }
+}
+
+describe('ThreadView (React SSR)', () => {
+  it('renders a log-role container with polite live region', () => {
+    const html = renderToString(React.createElement(ThreadView, { messages: [] }))
+    expect(html).toContain('role="log"')
+    expect(html).toContain('aria-label="Message thread"')
+    expect(html).toContain('aria-live="polite"')
+  })
+
+  it('renders each message as an article with an accessible label', () => {
+    const html = renderToString(React.createElement(ThreadView, { messages: [makeMessage()] }))
+    expect(html).toContain('role="article"')
+    expect(html).toContain('aria-label="Message from Ada at 3:05 PM"')
+  })
+
+  it('marks messages from the current user with "(you)"', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, { messages: [makeMessage()], currentUserId: 'u1' }),
+    )
+    expect(html).toContain('Message from Ada (you) at 3:05 PM')
+  })
+
+  it('renders the author name, timestamp, and message body', () => {
+    const html = renderToString(React.createElement(ThreadView, { messages: [makeMessage()] }))
+    expect(html).toContain('>Ada</span>')
+    expect(html).toContain('3:05 PM')
+    expect(html).toContain('Hello thread')
+  })
+
+  it('renders the author initial when no avatarUrl is set', () => {
+    const html = renderToString(React.createElement(ThreadView, { messages: [makeMessage()] }))
+    expect(html).toContain('>A</div>')
+    expect(html).not.toContain('<img')
+  })
+
+  it('renders an avatar image with the author name as alt text', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [makeMessage({ author: { id: 'u1', name: 'Ada', avatarUrl: 'https://example.com/a.png' } })],
+      }),
+    )
+    expect(html).toContain('<img')
+    expect(html).toContain('src="https://example.com/a.png"')
+    expect(html).toContain('alt="Ada"')
+  })
+
+  it('renders reactions as buttons with emoji and count', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [
+          makeMessage({ reactions: [{ emoji: '👍', count: 3, userReacted: false }] }),
+        ],
+      }),
+    )
+    expect(html).toContain('<button')
+    expect(html).toContain('👍 3')
+  })
+
+  it('highlights reactions the current user already made', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [
+          makeMessage({ reactions: [{ emoji: '🎉', count: 1, userReacted: true }] }),
+        ],
+      }),
+    )
+    expect(html).toContain('border-primary')
+    expect(html).toContain('bg-primary/10')
+  })
+
+  it('renders a singular reply indicator for one reply', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [makeMessage({ replies: [makeMessage({ id: 'm2' })] })],
+      }),
+    )
+    expect(html).toContain('1 reply')
+  })
+
+  it('renders a plural reply indicator for multiple replies', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [
+          makeMessage({ replies: [makeMessage({ id: 'm2' }), makeMessage({ id: 'm3' })] }),
+        ],
+      }),
+    )
+    expect(html).toContain('2 replies')
+  })
+
+  it('renders the (edited) marker for edited messages', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, { messages: [makeMessage({ edited: true })] }),
+    )
+    expect(html).toContain('(edited)')
+  })
+
+  it('renders attachments with their names', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, {
+        messages: [
+          makeMessage({
+            attachments: [{ id: 'a1', name: 'spec.pdf', url: '#', type: 'file' }],
+          }),
+        ],
+      }),
+    )
+    expect(html).toContain('spec.pdf')
+  })
+
+  it('renders a Reply action button per message with an accessible label', () => {
+    const html = renderToString(React.createElement(ThreadView, { messages: [makeMessage()] }))
+    expect(html).toContain('aria-label="Reply to message"')
+    expect(html).toContain('>Reply</button>')
+  })
+
+  it('appends a custom className to the container', () => {
+    const html = renderToString(
+      React.createElement(ThreadView, { messages: [], className: 'my-thread' }),
+    )
+    expect(html).toContain('my-thread')
+  })
+})

--- a/packages/skip-to-content/__tests__/skip-to-content.test.ts
+++ b/packages/skip-to-content/__tests__/skip-to-content.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { createSkipToContent } from '../src/index.js'
+
+describe('skip-to-content core — data-slot contract', () => {
+  it('exposes the skip-to-content data-slot', () => {
+    expect(createSkipToContent()).toEqual({
+      dataAttributes: { 'data-slot': 'skip-to-content' },
+    })
+  })
+})

--- a/packages/skip-to-content/vitest.config.ts
+++ b/packages/skip-to-content/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/steps/__tests__/steps.test.ts
+++ b/packages/steps/__tests__/steps.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createSteps,
+  createStep,
+  createStepIndicator,
+  createStepContent,
+  createStepTitle,
+  createStepDescription,
+} from '../src/index.js'
+
+describe('steps core — data-slot contract', () => {
+  it('exposes the full steps slot family', () => {
+    expect({
+      steps: createSteps().dataAttributes['data-slot'],
+      step: createStep().dataAttributes['data-slot'],
+      indicator: createStepIndicator().dataAttributes['data-slot'],
+      content: createStepContent().dataAttributes['data-slot'],
+      title: createStepTitle().dataAttributes['data-slot'],
+      description: createStepDescription().dataAttributes['data-slot'],
+    }).toEqual({
+      steps: 'steps',
+      step: 'step',
+      indicator: 'step-indicator',
+      content: 'step-content',
+      title: 'step-title',
+      description: 'step-description',
+    })
+  })
+})

--- a/packages/steps/vitest.config.ts
+++ b/packages/steps/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/packages/table-of-contents/__tests__/table-of-contents.test.ts
+++ b/packages/table-of-contents/__tests__/table-of-contents.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { parseHeadings, observeHeadings } from '../src/index.js'
+
+// The core's parsing logic is DOM-shaped but not DOM-dependent: parseHeadings
+// only needs `querySelectorAll` plus `tagName`/`id`/`textContent` per item, so
+// minimal fakes cover it without jsdom. observeHeadings needs the real
+// IntersectionObserver + document globals — those are stubbed below.
+// The DOM seam: jsdom/happy-dom would let these run against real elements.
+
+function fakeHeading(tagName: string, id: string, text: string | null) {
+  return { tagName, id, textContent: text } as unknown as HTMLElement
+}
+
+function fakeContainer(headings: HTMLElement[]) {
+  const querySelectorAll = vi.fn((_selectors: string) => headings)
+  return {
+    container: { querySelectorAll } as unknown as HTMLElement,
+    querySelectorAll,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseHeadings', () => {
+  it('parses heading level from the tag name', () => {
+    const { container } = fakeContainer([
+      fakeHeading('H2', 'a', 'Alpha'),
+      fakeHeading('H3', 'b', 'Beta'),
+      fakeHeading('H4', 'c', 'Gamma'),
+    ])
+    const items = parseHeadings(container)
+    expect(items.map((i) => i.level)).toEqual([2, 3, 4])
+  })
+
+  it('keeps explicit ids and text content', () => {
+    const { container } = fakeContainer([fakeHeading('H2', 'intro', 'Introduction')])
+    expect(parseHeadings(container)).toEqual([{ id: 'intro', text: 'Introduction', level: 2 }])
+  })
+
+  it('derives a slug id from the text when the heading has no id', () => {
+    const { container } = fakeContainer([fakeHeading('H2', '', 'Getting Started Guide')])
+    const items = parseHeadings(container)
+    expect(items).toEqual([{ id: 'getting-started-guide', text: 'Getting Started Guide', level: 2 }])
+  })
+
+  it('drops headings that would get an empty id', () => {
+    const { container } = fakeContainer([
+      fakeHeading('H2', '', ''),
+      fakeHeading('H3', '', null),
+      fakeHeading('H2', 'kept', 'Kept'),
+    ])
+    const items = parseHeadings(container)
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('kept')
+  })
+
+  it('returns an empty list when the container has no matching headings', () => {
+    const { container } = fakeContainer([])
+    expect(parseHeadings(container)).toEqual([])
+  })
+
+  it('passes the selectors through to the container', () => {
+    const { container, querySelectorAll } = fakeContainer([])
+    parseHeadings(container, 'h1, h2')
+    expect(querySelectorAll).toHaveBeenCalledWith('h1, h2')
+  })
+
+  it('defaults to h2, h3, h4 selectors', () => {
+    const { container, querySelectorAll } = fakeContainer([])
+    parseHeadings(container)
+    expect(querySelectorAll).toHaveBeenCalledWith('h2, h3, h4')
+  })
+})
+
+describe('observeHeadings', () => {
+  interface FakeObserver {
+    callback: IntersectionObserverCallback
+    options?: IntersectionObserverInit
+    observed: unknown[]
+    disconnected: boolean
+  }
+
+  function stubDom(elements: Record<string, object | null>) {
+    const observers: FakeObserver[] = []
+
+    class FakeIntersectionObserver {
+      observed: unknown[] = []
+      disconnected = false
+      constructor(
+        public callback: IntersectionObserverCallback,
+        public options?: IntersectionObserverInit,
+      ) {
+        observers.push(this as unknown as FakeObserver)
+      }
+      observe(el: unknown) {
+        this.observed.push(el)
+      }
+      unobserve() {}
+      disconnect() {
+        this.disconnected = true
+      }
+      takeRecords() {
+        return []
+      }
+      root = null
+      rootMargin = ''
+      thresholds = []
+    }
+
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+    vi.stubGlobal('document', {
+      getElementById: (id: string) => elements[id] ?? null,
+    })
+    return observers
+  }
+
+  it('observes every heading id that resolves to an element', () => {
+    const elA = { id: 'a' }
+    const elB = { id: 'b' }
+    const observers = stubDom({ a: elA, b: elB })
+    observeHeadings(['a', 'b'], () => {})
+    expect(observers).toHaveLength(1)
+    expect(observers[0].observed).toEqual([elA, elB])
+  })
+
+  it('skips ids with no matching element', () => {
+    const elA = { id: 'a' }
+    const observers = stubDom({ a: elA })
+    observeHeadings(['a', 'missing'], () => {})
+    expect(observers[0].observed).toEqual([elA])
+  })
+
+  it('applies the default rootMargin and allows overrides', () => {
+    const observers = stubDom({ a: { id: 'a' } })
+    observeHeadings(['a'], () => {})
+    expect(observers[0].options).toMatchObject({ rootMargin: '0px 0px -80% 0px' })
+    observeHeadings(['a'], () => {}, { rootMargin: '0px' })
+    expect(observers[1].options).toMatchObject({ rootMargin: '0px' })
+  })
+
+  it('calls the callback with the first intersecting entry id', () => {
+    const observers = stubDom({ a: { id: 'a' }, b: { id: 'b' } })
+    const onActive = vi.fn()
+    observeHeadings(['a', 'b'], onActive)
+    const entries = [
+      { isIntersecting: false, target: { id: 'a' } },
+      { isIntersecting: true, target: { id: 'b' } },
+    ] as unknown as IntersectionObserverEntry[]
+    observers[0].callback(entries, {} as IntersectionObserver)
+    expect(onActive).toHaveBeenCalledWith('b')
+  })
+
+  it('does not call the callback when nothing intersects', () => {
+    const observers = stubDom({ a: { id: 'a' } })
+    const onActive = vi.fn()
+    observeHeadings(['a'], onActive)
+    const entries = [
+      { isIntersecting: false, target: { id: 'a' } },
+    ] as unknown as IntersectionObserverEntry[]
+    observers[0].callback(entries, {} as IntersectionObserver)
+    expect(onActive).not.toHaveBeenCalled()
+  })
+
+  it('returns a cleanup function that disconnects the observer', () => {
+    const observers = stubDom({ a: { id: 'a' } })
+    const disconnect = observeHeadings(['a'], () => {})
+    expect(observers[0].disconnected).toBe(false)
+    disconnect()
+    expect(observers[0].disconnected).toBe(true)
+  })
+})

--- a/packages/table-of-contents/vitest.config.ts
+++ b/packages/table-of-contents/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    passWithNoTests: true,
+  },
+})


### PR DESCRIPTION
## Summary
134 tests across 18 packages, all passing; no src files modified.

- **SSR adapter suites**: keyboard-shortcut (12), link-card (5), location-selector (7), skip-to-content (7), steps (17), table-of-contents (3 — honest 'renders nothing on SSR'), thread-view (14)
- **Core unit tests**: diff-viewer (18 — reducer/state), http (23 — mocked fetch: timeout abort, auth token variants, content-type branching), location-selector (8), table-of-contents (13 — pure parsing with fakes; DOM seam noted)
- **data-slot contract one-assertion tests**: steps, code-block, callout, card-grid, link-card, payment, skip-to-content (+ missing vitest configs)

Follow-ups found (reported, not fixed): location-selector core has pre-existing lint errors invisible to CI (package defines no lint script — same for http, react-location-selector); HttpClient drops Headers-instance/tuple headers and its content-type dedup is case-sensitive.

## Checklist
- [x] Tests added or updated (134 new)
- [x] Axe/Accessibility checks pass
- [x] Docs updated (n/a)
- [ ] Changeset added (test-only)

## Breaking changes?
None.