### PR TITLE
test(astro): container-api render harness + smoke/deep coverage for all adapters

### DIFF
--- a/packages/astro-meta/__tests__/compositions/command.astro
+++ b/packages/astro-meta/__tests__/compositions/command.astro
@@ -1,0 +1,16 @@
+---
+import Command from '../../dist/astro-command/Command.astro'
+import CommandInput from '../../dist/astro-command/CommandInput.astro'
+import CommandList from '../../dist/astro-command/CommandList.astro'
+import CommandItem from '../../dist/astro-command/CommandItem.astro'
+import CommandEmpty from '../../dist/astro-command/CommandEmpty.astro'
+---
+
+<Command open>
+  <CommandInput placeholder="Type a command" />
+  <CommandList>
+    <CommandEmpty>No results.</CommandEmpty>
+    <CommandItem value="open">Open file</CommandItem>
+    <CommandItem value="delete" disabled>Delete file</CommandItem>
+  </CommandList>
+</Command>

--- a/packages/astro-meta/__tests__/compositions/dialog.astro
+++ b/packages/astro-meta/__tests__/compositions/dialog.astro
@@ -1,0 +1,15 @@
+---
+import Dialog from '../../dist/astro-dialog/Dialog.astro'
+import DialogTrigger from '../../dist/astro-dialog/DialogTrigger.astro'
+import DialogContent from '../../dist/astro-dialog/DialogContent.astro'
+import DialogTitle from '../../dist/astro-dialog/DialogTitle.astro'
+import DialogDescription from '../../dist/astro-dialog/DialogDescription.astro'
+---
+
+<Dialog defaultOpen modal>
+  <DialogTrigger>Open settings</DialogTrigger>
+  <DialogContent modal>
+    <DialogTitle>Settings</DialogTitle>
+    <DialogDescription>Adjust your preferences.</DialogDescription>
+  </DialogContent>
+</Dialog>

--- a/packages/astro-meta/__tests__/compositions/dropdown-menu.astro
+++ b/packages/astro-meta/__tests__/compositions/dropdown-menu.astro
@@ -1,0 +1,14 @@
+---
+import DropdownMenu from '../../dist/astro-dropdown-menu/DropdownMenu.astro'
+import DropdownMenuTrigger from '../../dist/astro-dropdown-menu/DropdownMenuTrigger.astro'
+import DropdownMenuContent from '../../dist/astro-dropdown-menu/DropdownMenuContent.astro'
+import DropdownMenuItem from '../../dist/astro-dropdown-menu/DropdownMenuItem.astro'
+---
+
+<DropdownMenu>
+  <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem>Rename</DropdownMenuItem>
+    <DropdownMenuItem disabled>Archive</DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>

--- a/packages/astro-meta/__tests__/compositions/radio.astro
+++ b/packages/astro-meta/__tests__/compositions/radio.astro
@@ -1,0 +1,9 @@
+---
+import RadioGroup from '../../dist/astro-radio/RadioGroup.astro'
+import RadioItem from '../../dist/astro-radio/RadioItem.astro'
+---
+
+<RadioGroup value="a" name="choice" orientation="vertical">
+  <RadioItem value="a" checked>Option A</RadioItem>
+  <RadioItem value="b">Option B</RadioItem>
+</RadioGroup>

--- a/packages/astro-meta/__tests__/compositions/select.astro
+++ b/packages/astro-meta/__tests__/compositions/select.astro
@@ -1,0 +1,14 @@
+---
+import Select from '../../dist/astro-select/Select.astro'
+import SelectTrigger from '../../dist/astro-select/SelectTrigger.astro'
+import SelectContent from '../../dist/astro-select/SelectContent.astro'
+import SelectItem from '../../dist/astro-select/SelectItem.astro'
+---
+
+<Select value="apple" name="fruit">
+  <SelectTrigger>Apple</SelectTrigger>
+  <SelectContent>
+    <SelectItem value="apple" selected>Apple</SelectItem>
+    <SelectItem value="banana" disabled>Banana</SelectItem>
+  </SelectContent>
+</Select>

--- a/packages/astro-meta/__tests__/compositions/tabs.astro
+++ b/packages/astro-meta/__tests__/compositions/tabs.astro
@@ -1,0 +1,15 @@
+---
+import Tabs from '../../dist/astro-tabs/Tabs.astro'
+import TabsList from '../../dist/astro-tabs/TabsList.astro'
+import TabsTrigger from '../../dist/astro-tabs/TabsTrigger.astro'
+import TabsContent from '../../dist/astro-tabs/TabsContent.astro'
+---
+
+<Tabs defaultValue="account" orientation="horizontal">
+  <TabsList>
+    <TabsTrigger value="account" isActive>Account</TabsTrigger>
+    <TabsTrigger value="profile">Profile</TabsTrigger>
+  </TabsList>
+  <TabsContent value="account" isActive>Account panel content</TabsContent>
+  <TabsContent value="profile">Profile panel content</TabsContent>
+</Tabs>

--- a/packages/astro-meta/__tests__/compositions/toaster.astro
+++ b/packages/astro-meta/__tests__/compositions/toaster.astro
@@ -1,0 +1,8 @@
+---
+import Toaster from '../../dist/astro-toast/Toaster.astro'
+import Toast from '../../dist/astro-toast/Toast.astro'
+---
+
+<Toaster>
+  <Toast variant="success" duration={5000} message="Saved successfully" />
+</Toaster>

--- a/packages/astro-meta/__tests__/deep.test.ts
+++ b/packages/astro-meta/__tests__/deep.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import TabsComposition from './compositions/tabs.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import SelectComposition from './compositions/select.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import DialogComposition from './compositions/dialog.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import CommandComposition from './compositions/command.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import RadioComposition from './compositions/radio.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import DropdownMenuComposition from './compositions/dropdown-menu.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import ToasterComposition from './compositions/toaster.astro'
+// @ts-expect-error -- .astro modules are compiled by the Astro vite plugin
+import Switch from '../dist/astro-switch/Switch.astro'
+
+/**
+ * Deep render tests for the stateful / ARIA-heavy adapters. Multi-part
+ * components are rendered as real compositions (`__tests__/compositions/`)
+ * through the Container API; assertions cover roles, aria-* wiring, the
+ * data-attribute contract the client scripts drive, and slot content.
+ *
+ * Note on matching: Astro pads SSR slot output with whitespace, so text
+ * assertions use `\s*` around the expected content.
+ */
+
+async function render(
+  component: unknown,
+  options?: { props?: Record<string, unknown>; slots?: Record<string, string> }
+): Promise<string> {
+  const container = await AstroContainer.create()
+  return container.renderToString(
+    component as Parameters<AstroContainer['renderToString']>[0],
+    options
+  )
+}
+
+/** Count occurrences of an attribute marker like `role="tab"`. */
+function count(html: string, marker: string): number {
+  return html.split(marker).length - 1
+}
+
+describe('astro-tabs (composed)', () => {
+  it('renders tablist/tab/tabpanel roles with selection ARIA', async () => {
+    const html = await render(TabsComposition)
+
+    // Root wiring the client script drives.
+    expect(html).toContain('data-rfr-tabs')
+    expect(html).toContain('data-rfr-tabs-value="account"')
+    expect(html).toContain('data-orientation="horizontal"')
+    expect(html).toContain('data-rfr-tabs-id-prefix')
+
+    // Structure + roles.
+    expect(html).toContain('role="tablist"')
+    expect(count(html, 'role="tab"')).toBe(2)
+    expect(count(html, 'role="tabpanel"')).toBe(2)
+
+    // Selected vs unselected trigger.
+    expect(html).toMatch(
+      /<button[^>]*aria-selected="true"[^>]*tabindex="0"[^>]*data-rfr-tab-value="account"[^>]*>\s*Account\s*<\/button>/
+    )
+    expect(html).toMatch(
+      /<button[^>]*aria-selected="false"[^>]*tabindex="-1"[^>]*data-rfr-tab-value="profile"[^>]*>\s*Profile\s*<\/button>/
+    )
+
+    // Active panel visible, inactive panel hidden; slot content rendered.
+    expect(html).toMatch(/<div[^>]*data-rfr-tab-panel="account"[^>]*>\s*Account panel content\s*<\/div>/)
+    expect(html).not.toMatch(/<div[^>]*data-rfr-tab-panel="account"[^>]*hidden/)
+    expect(html).toMatch(/<div[^>]*data-rfr-tab-panel="profile"[^>]*hidden[^>]*>\s*Profile panel content\s*<\/div>/)
+  })
+})
+
+describe('astro-select (composed)', () => {
+  it('renders combobox/listbox/option with value and disabled state', async () => {
+    const html = await render(SelectComposition)
+
+    // Root value + form wiring (hidden input carries the value for forms).
+    expect(html).toContain('data-rfr-select')
+    expect(html).toContain('data-rfr-select-value="apple"')
+    expect(html).toMatch(/<input[^>]*type="hidden"[^>]*name="fruit"[^>]*value="apple"/)
+
+    // Trigger: collapsed combobox showing the selected value.
+    expect(html).toContain('role="combobox"')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toMatch(/data-rfr-select-value-text>\s*Apple\s*<\/span>/)
+
+    // Listbox starts hidden.
+    expect(html).toMatch(/<div[^>]*role="listbox"[^>]*hidden/)
+
+    // Options: selected and disabled states.
+    expect(count(html, 'role="option"')).toBe(2)
+    expect(html).toMatch(/<div[^>]*role="option"[^>]*aria-selected="true"[^>]*data-rfr-select-item-value="apple"/)
+    expect(html).toMatch(/<div[^>]*role="option"[^>]*aria-disabled="true"[^>]*data-rfr-select-item-value="banana"/)
+  })
+})
+
+describe('astro-dialog (composed)', () => {
+  it('renders dialog role, modal ARIA and defaultOpen state', async () => {
+    const html = await render(DialogComposition)
+
+    // Root reflects defaultOpen in its state machine attributes.
+    expect(html).toContain('data-rfr-dialog')
+    expect(html).toContain('data-rfr-dialog-modal="true"')
+    expect(html).toContain('data-state="open"')
+
+    // Trigger advertises the popup.
+    expect(html).toContain('aria-haspopup="dialog"')
+    expect(html).toContain('Open settings')
+
+    // Content carries the dialog role + modality (client script unhides it).
+    expect(html).toMatch(/<div[^>]*role="dialog"[^>]*aria-modal="true"/)
+    expect(html).toContain('data-rfr-dialog-content')
+
+    // Title/description slots.
+    expect(html).toMatch(/<h2[^>]*data-rfr-dialog-title[^>]*>\s*Settings\s*<\/h2>/)
+    expect(html).toContain('Adjust your preferences.')
+  })
+})
+
+describe('astro-command (composed)', () => {
+  it('renders combobox + searchbox + listbox + options', async () => {
+    const html = await render(CommandComposition)
+
+    expect(html).toContain('data-rfr-command')
+    expect(html).toContain('role="combobox"')
+    expect(html).toContain('aria-expanded="true"')
+    expect(html).toContain('aria-haspopup="listbox"')
+
+    expect(html).toMatch(/<input[^>]*role="searchbox"[^>]*aria-autocomplete="list"/)
+    expect(html).toContain('role="listbox"')
+
+    expect(count(html, 'role="option"')).toBe(2)
+    expect(html).toMatch(/<div[^>]*data-value="open"[^>]*role="option"[^>]*>\s*Open file\s*<\/div>/)
+    expect(html).toMatch(/<div[^>]*data-value="delete"[^>]*role="option"[^>]*aria-disabled="true"[^>]*>\s*Delete file\s*<\/div>/)
+
+    // Empty state starts hidden.
+    expect(html).toMatch(/<div[^>]*data-rfr-command-empty[^>]*hidden[^>]*>\s*No results\.\s*<\/div>/)
+  })
+})
+
+describe('astro-radio (composed)', () => {
+  it('renders radiogroup/radio roles with checked state and form input', async () => {
+    const html = await render(RadioComposition)
+
+    expect(html).toContain('role="radiogroup"')
+    expect(html).toContain('aria-orientation="vertical"')
+    expect(html).toMatch(/<input[^>]*type="hidden"[^>]*name="choice"[^>]*value="a"/)
+
+    expect(count(html, 'role="radio"')).toBe(2)
+    expect(html).toMatch(/<button[^>]*role="radio"[^>]*aria-checked="true"[^>]*tabindex="0"/)
+    expect(html).toMatch(/<button[^>]*role="radio"[^>]*aria-checked="false"[^>]*tabindex="-1"/)
+    expect(html).toContain('Option A')
+    expect(html).toContain('Option B')
+  })
+})
+
+describe('astro-dropdown-menu (composed)', () => {
+  it('renders menu/menuitem roles with trigger ARIA', async () => {
+    const html = await render(DropdownMenuComposition)
+
+    expect(html).toContain('data-rfr-dropdown-menu')
+    expect(html).toMatch(/<button[^>]*data-rfr-dropdown-trigger[^>]*aria-haspopup="menu"[^>]*aria-expanded="false"[^>]*>\s*Actions\s*<\/button>/)
+
+    // Menu starts hidden.
+    expect(html).toMatch(/<div[^>]*role="menu"[^>]*hidden/)
+
+    expect(count(html, 'role="menuitem"')).toBe(2)
+    expect(html).toMatch(/<div[^>]*role="menuitem"[^>]*>\s*Rename\s*<\/div>/)
+    expect(html).toMatch(/<div[^>]*role="menuitem"[^>]*tabindex="-1"[^>]*aria-disabled="true"[^>]*>\s*Archive\s*<\/div>/)
+  })
+})
+
+describe('astro-toast (Toaster + Toast composed)', () => {
+  it('renders alert ARIA, variant data and dismiss affordance', async () => {
+    const html = await render(ToasterComposition)
+
+    expect(html).toContain('data-rfr-toaster')
+
+    expect(html).toMatch(
+      /<div[^>]*data-rfr-toast[^>]*role="alert"[^>]*aria-live="assertive"[^>]*aria-atomic="true"/
+    )
+    expect(html).toContain('data-rfr-toast-variant="success"')
+    expect(html).toContain('data-rfr-toast-duration="5000"')
+    expect(html).toContain('Saved successfully')
+    expect(html).toMatch(/<button[^>]*aria-label="Dismiss"/)
+  })
+})
+
+describe('astro-switch', () => {
+  it('renders switch role with checked ARIA and form input', async () => {
+    const html = await render(Switch, {
+      props: { checked: true, name: 'notifications' },
+    })
+
+    expect(html).toMatch(/<button[^>]*role="switch"[^>]*aria-checked="true"[^>]*data-state="checked"/)
+    expect(html).toMatch(/<input[^>]*type="hidden"[^>]*name="notifications"[^>]*value="true"/)
+  })
+
+  it('renders unchecked state by default', async () => {
+    const html = await render(Switch)
+
+    expect(html).toMatch(/<button[^>]*role="switch"[^>]*aria-checked="false"[^>]*data-state="unchecked"/)
+  })
+})

--- a/packages/astro-meta/__tests__/fixtures.ts
+++ b/packages/astro-meta/__tests__/fixtures.ts
@@ -1,0 +1,160 @@
+/**
+ * Fixture table for the adapter smoke suite (`smoke.test.ts`).
+ *
+ * Every `astro-*` adapter's primary component is rendered with minimal
+ * sensible props via the Astro Container API. Most components render fine with
+ * zero props (headless cores supply defaults); this table covers everything
+ * that deviates from that default:
+ *
+ * - `props` — components whose required props have no defaults.
+ * - `expectSlotContent` — components whose contract includes rendering the
+ *   default slot (verified against real render output).
+ * - `placeholders` — intentional placeholder components (a bare wrapper div
+ *   or less); they can only be asserted to render without throwing.
+ * - `componentOverrides` — pin a different primary `.astro` file than the
+ *   namesake/first rule in `harness.discoverPrimaries`.
+ */
+
+/** Components with required props (no core defaults) + their minimal values. */
+export const PROPS: Record<string, Record<string, unknown>> = {
+  'astro-animated-text': { words: ['Alpha', 'Beta'] },
+  'astro-audio-room': { participants: [{ id: 'p1', name: 'Alice' }] },
+  'astro-avatar-group': {
+    users: [{ name: 'Alice', src: 'https://example.com/alice.jpg' }],
+  },
+  'astro-browser-chrome-mock': { url: 'https://example.com/docs/guide' },
+  'astro-checklist': { items: [{ id: '1', label: 'Task one' }] },
+  'astro-data-table': {
+    columns: [
+      { id: 'id', header: 'ID', accessor: (row: Record<string, unknown>) => row.id },
+      { id: 'name', header: 'Name', accessor: (row: Record<string, unknown>) => row.name },
+    ],
+    data: [{ id: 1, name: 'Alice' }],
+  },
+  'astro-device-frame': { device: 'iphone' },
+  'astro-diff-viewer': {
+    files: [
+      { path: 'src/a.js', status: 'modified', additions: 1, deletions: 1 },
+    ],
+  },
+  'astro-editor-tabs': {
+    tabs: [{ id: '1', label: 'index.ts' }],
+    activeId: '1',
+  },
+  'astro-flow-editor': {
+    nodes: [{ id: 'n1', x: 0, y: 0, label: 'Start' }],
+    edges: [],
+  },
+  'astro-graph-view': {
+    nodes: [{ id: 'n1', x: 0, y: 0, label: 'A' }],
+    edges: [],
+  },
+  'astro-kanban-board': {
+    columns: [{ id: 'todo', title: 'Todo' }],
+    cards: [{ columnId: 'todo', title: 'Task' }],
+  },
+  'astro-language-selector': {
+    options: [{ label: 'English', value: 'en' }],
+  },
+  'astro-live-captions': { cues: [{ id: '1', text: 'Hello world' }] },
+  'astro-live-cursors': { cursors: [{ id: '1', name: 'Alice', x: 10, y: 10 }] },
+  'astro-live-transcript': {
+    entries: [{ id: '1', speaker: 'Alice', text: 'Hi' }],
+  },
+  'astro-markdown-renderer': { content: '# Hello' },
+  'astro-marquee-strip': { items: ['One', 'Two'] },
+  'astro-mini-map': { items: [{ id: '1', x: 0, y: 0 }] },
+  'astro-numbered-steps': { items: [{ title: 'Step one', body: 'Do it' }] },
+  'astro-pricing-card': {
+    name: 'Pro',
+    price: '$29',
+    features: ['Everything'],
+    cta: 'Buy now',
+  },
+  'astro-slide-viewer': {
+    slides: [{ id: 's1', type: 'lesson', content: 'First slide' }],
+  },
+  'astro-slot-picker': {
+    days: [{ id: 'd1', weekday: 'Fri', dayNum: 14 }],
+    slotsByDay: { d1: ['10:00'] },
+  },
+  'astro-sortable-list': { items: [{ id: '1', label: 'One' }] },
+  'astro-stat-grid': { items: [{ value: '10k+', label: 'Users' }] },
+  'astro-terminal': { lines: [{ kind: 'command', text: 'ls -la' }] },
+  'astro-test-results': {
+    results: [{ id: '1', name: 'smoke test', status: 'pass' }],
+  },
+  'astro-timeline': { items: [{ id: '1', title: 'Event one' }] },
+  'astro-version-selector': {
+    versions: [{ value: '1.0.0', label: 'v1.0.0', isLatest: true }],
+  },
+  'astro-video-grid': { participants: [{ id: 'p1', name: 'Alice' }] },
+  'astro-video-tile': { name: 'Alice' },
+  'astro-wizard': { steps: [{ id: 's1', label: 'Step one' }] },
+}
+
+/**
+ * Components whose SSR contract includes rendering the default slot. Verified
+ * against real render output — a component lands here only if it actually
+ * rendered slot content. (Prop-driven components — inputs, charts, scripts —
+ * have no slot and are not flagged; that is correct behavior, not a gap.)
+ */
+export const EXPECT_SLOT_CONTENT = new Set([
+  'astro-accordion',
+  'astro-app-shell',
+  'astro-audience-feature-card',
+  'astro-auth',
+  'astro-avatar',
+  'astro-badge',
+  'astro-button',
+  'astro-call-controls',
+  'astro-callout',
+  'astro-card',
+  'astro-card-grid',
+  'astro-carousel',
+  'astro-code-block',
+  'astro-collapsible',
+  'astro-command',
+  'astro-command-input',
+  'astro-composer',
+  'astro-content-protection',
+  'astro-dialog',
+  'astro-dropdown-menu',
+  'astro-file-upload',
+  'astro-infinite-canvas',
+  'astro-input-group',
+  'astro-link-card',
+  'astro-mobile-nav',
+  'astro-popover',
+  'astro-radio',
+  'astro-resizable-layout',
+  'astro-search-bar',
+  'astro-section-head',
+  'astro-segmented-control',
+  'astro-select',
+  'astro-separator',
+  'astro-sticky-note',
+  'astro-tabs',
+  'astro-toast',
+  'astro-tooltip',
+])
+
+/**
+ * Intentional placeholder components — a bare `<div></div>` (or wrapper with a
+ * class hook) is their entire current implementation. Asserted to render
+ * without throwing; a marker assertion would be meaningless.
+ */
+export const PLACEHOLDERS = new Set([
+  'astro-file-tree',
+  'astro-icon-system',
+  'astro-pagination',
+  'astro-skip-to-content',
+  'astro-steps',
+])
+
+/** Pin a different primary component than the namesake/first-file rule. */
+export const COMPONENT_OVERRIDES: Record<string, string> = {
+  // First file alphabetically is `Bars.astro`, but `Chart.astro` is the
+  // actual chart wrapper consumers start from.
+  'astro-charts': 'Chart.astro',
+}

--- a/packages/astro-meta/__tests__/global-setup.ts
+++ b/packages/astro-meta/__tests__/global-setup.ts
@@ -1,0 +1,9 @@
+import { ensureDistBuilt } from './harness'
+
+// Vitest global setup — runs once per run, before any test file loads.
+// The render tests import the meta's copied dist sources; make sure they
+// exist. (Turbo normally runs the meta's `build` task first; this keeps bare
+// `vitest` invocations from this package green too.)
+export default function setup(): void {
+  ensureDistBuilt()
+}

--- a/packages/astro-meta/__tests__/harness.ts
+++ b/packages/astro-meta/__tests__/harness.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Shared harness for the Astro adapter render tests.
+ *
+ * The meta build (`build.mjs`) copies every adapter's `src/` — including the
+ * `.astro` single-file components — into `packages/astro-meta/dist/<pkg>/`.
+ * These tests compile those copied components through the Astro vite plugin
+ * (see `vitest.config.ts`) and render them SSR-side with the Container API
+ * (`astro/container`). Rendering the meta's dist — rather than the per-package
+ * sources — means the suite exercises exactly what consumers install.
+ */
+
+export const packageDir = join(dirname(fileURLToPath(import.meta.url)), '..')
+export const distDir = join(packageDir, 'dist')
+
+/** Slot content sentinel asserted by fixtures with `expectSlotContent`. */
+export const SLOT_SENTINEL = 'rfr-smoke-slot-content'
+
+/**
+ * Marker every non-placeholder component is expected to carry unless a fixture
+ * says otherwise: a `data-rfr-*` / `rfr-` / `refraction-` hook, an ARIA role,
+ * a `data-slot`, a non-empty class attribute, or a semantic root element.
+ */
+export const DEFAULT_MARKER_RE =
+  /data-rfr-|refraction-|\brfr-|\brole=|data-slot|class="[^"]|<(script|svg|button|input|nav|footer|header|aside|textarea|select|table|form|ul|ol|a|img|video|audio|label|main|section|dialog)[\s>]/
+
+export interface PrimaryComponent {
+  /** Adapter package folder, e.g. `astro-tabs`. */
+  pkg: string
+  /** Primary `.astro` file inside `dist/<pkg>/`, e.g. `Tabs.astro`. */
+  file: string
+}
+
+/** `astro-tabs` -> `Tabs` (mirrors `scripts/generate-astro-stories.mjs`). */
+function pascal(folder: string): string {
+  return folder
+    .replace(/^astro-/, '')
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('')
+}
+
+/**
+ * One primary component per adapter package: the `.astro` file matching the
+ * package name, else the first one alphabetically (same rule the story
+ * generator uses). `overrides` may pin a different file per package.
+ */
+export function discoverPrimaries(
+  overrides: Record<string, string> = {}
+): PrimaryComponent[] {
+  const primaries: PrimaryComponent[] = []
+  for (const entry of readdirSync(distDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('astro-')) continue
+    const dir = join(distDir, entry.name)
+    const astroFiles = readdirSync(dir)
+      .filter((f) => f.endsWith('.astro'))
+      .sort()
+    if (astroFiles.length === 0) continue
+    const override = overrides[entry.name]
+    if (override && !astroFiles.includes(override)) {
+      throw new Error(
+        `Fixture override ${entry.name}/${override} not found in dist (${astroFiles.join(', ')})`
+      )
+    }
+    const file =
+      override ??
+      astroFiles.find((f) => f === `${pascal(entry.name)}.astro`) ??
+      astroFiles[0]
+    primaries.push({ pkg: entry.name, file })
+  }
+  return primaries
+}
+
+/** Build the meta dist once per vitest run when it is missing (turbo normally
+ * runs `build` first via the task graph; this keeps bare `vitest` runs green). */
+export function ensureDistBuilt(): void {
+  if (!existsSync(distDir)) {
+    execFileSync('node', ['build.mjs'], { cwd: packageDir, stdio: 'inherit' })
+  }
+}

--- a/packages/astro-meta/__tests__/smoke.test.ts
+++ b/packages/astro-meta/__tests__/smoke.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import {
+  DEFAULT_MARKER_RE,
+  SLOT_SENTINEL,
+  discoverPrimaries,
+} from './harness'
+import {
+  COMPONENT_OVERRIDES,
+  EXPECT_SLOT_CONTENT,
+  PLACEHOLDERS,
+  PROPS,
+} from './fixtures'
+
+/**
+ * Smoke coverage for every Astro adapter, rendered exactly as consumers get
+ * it: the meta's copied `dist/<pkg>/*.astro` sources compiled by the Astro
+ * vite plugin and rendered SSR-side via the Container API.
+ *
+ * Per primary component the suite asserts:
+ *   1. it renders without throwing (catches core-API drift, bad rewrites),
+ *   2. the HTML is non-trivial and carries an expected hook (data-rfr-* /
+ *      role / class / semantic root — see DEFAULT_MARKER_RE),
+ *   3. components whose contract includes a default slot actually render the
+ *      slot content (fixture table `EXPECT_SLOT_CONTENT`).
+ *
+ * Intentional placeholders (`PLACEHOLDERS`) can only be asserted to render.
+ */
+
+const primaries = discoverPrimaries(COMPONENT_OVERRIDES)
+
+describe('astro adapter smoke (meta dist, container API)', () => {
+  it('discovers a primary component for (almost) every adapter package', () => {
+    // 125 astro-* packages; astro-slider ships no .astro component.
+    expect(primaries.length).toBeGreaterThanOrEqual(120)
+  })
+
+  for (const { pkg, file } of primaries) {
+    it(`${pkg}: renders ${file} with minimal props`, async () => {
+      const mod = await import(`../dist/${pkg}/${file}`)
+      const container = await AstroContainer.create()
+      const html = await container.renderToString(mod.default, {
+        props: PROPS[pkg],
+        slots: { default: SLOT_SENTINEL },
+      })
+
+      expect(typeof html).toBe('string')
+
+      if (PLACEHOLDERS.has(pkg)) {
+        // Placeholder component — rendering without throwing is the contract.
+        return
+      }
+
+      expect(html.trim().length).toBeGreaterThan(0)
+      expect(html).toContain('<')
+      expect(html).toMatch(DEFAULT_MARKER_RE)
+
+      if (EXPECT_SLOT_CONTENT.has(pkg)) {
+        expect(html).toContain(SLOT_SENTINEL)
+      }
+    })
+  }
+})

--- a/packages/astro-meta/package.json
+++ b/packages/astro-meta/package.json
@@ -13,9 +13,10 @@
     "build": "node build.mjs",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --passWithNoTests"
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint __tests__ vitest.config.ts --ext .ts"
   },
-  "dependencies": {},
   "peerDependencies": {
     "astro": ">=4.0.0"
   },
@@ -88,8 +89,8 @@
     "@refraction-ui/astro-logger": "workspace:*",
     "@refraction-ui/astro-markdown-renderer": "workspace:*",
     "@refraction-ui/astro-marquee-strip": "workspace:*",
-    "@refraction-ui/astro-mastery-bar": "workspace:*",
     "@refraction-ui/astro-mascot": "workspace:*",
+    "@refraction-ui/astro-mastery-bar": "workspace:*",
     "@refraction-ui/astro-mini-map": "workspace:*",
     "@refraction-ui/astro-mobile-nav": "workspace:*",
     "@refraction-ui/astro-navbar": "workspace:*",
@@ -144,7 +145,8 @@
     "@refraction-ui/astro-voice-pill": "workspace:*",
     "@refraction-ui/astro-waveform": "workspace:*",
     "@refraction-ui/astro-wizard": "workspace:*",
-    "@refraction-ui/shared": "workspace:*"
+    "@refraction-ui/shared": "workspace:*",
+    "@types/node": "22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/astro-meta/tsconfig.json
+++ b/packages/astro-meta/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["__tests__", "vitest.config.ts"]
+}

--- a/packages/astro-meta/vitest.config.ts
+++ b/packages/astro-meta/vitest.config.ts
@@ -1,8 +1,68 @@
-import { defineConfig } from 'vitest/config'
+import { getViteConfig } from 'astro/config'
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    passWithNoTests: true,
+// `getViteConfig` wires the Astro vite plugin into Vitest so that `.astro`
+// single-file components (the meta's copied dist sources) compile on import.
+// The suite runs in node and renders via the Container API (`astro/container`).
+//
+// The esnext overrides mirror `.storybook-astro/main.ts`: the repo's pinned
+// esbuild can't lower the modern syntax in Astro's own runtime to Vite's
+// default legacy browser targets.
+
+type ViteUserConfig = Parameters<typeof getViteConfig>[0]
+type VitePlugin = NonNullable<ViteUserConfig['plugins']>[number]
+type ViteUserConfigFn = ReturnType<typeof getViteConfig>
+
+// Astro's `astro:vite-plugin-environment` unconditionally assigns
+// `optimizeDeps.include = ['astro/runtime/client/dev-toolbar/entrypoint.js',
+// 'astro > html-escaper']` for the CLIENT environment. That entrypoint (and
+// the toolbar apps it pulls in) uses modern syntax the repo's pinned esbuild
+// cannot lower to Vite's default legacy browser targets, so the client
+// dep-optimizer crashes Vitest at startup — and the plugin's wholesale
+// assignment means neither top-level `exclude` nor `esbuildOptions.target`
+// reach it. User plugins run after Astro's, so this `configEnvironment` hook
+// wins. The tests are SSR-only (node environment); the client optimizer has
+// nothing to do.
+const disableClientDepsOptimizer: VitePlugin = {
+  name: 'refraction:disable-client-deps-optimizer',
+  configEnvironment(name, options) {
+    if (name === 'client') {
+      options.optimizeDeps = {
+        ...options.optimizeDeps,
+        include: [],
+        noDiscovery: true,
+      }
+    }
   },
-})
+}
+
+const config: ViteUserConfigFn = getViteConfig(
+  {
+    build: { target: 'esnext' },
+    esbuild: { target: 'esnext' },
+    css: {
+      // The repo root's postcss.config.cjs wires Tailwind for Storybook with
+      // a config path relative to the repo root; run from this package it
+      // loads a broken Tailwind context and crashes on any `<style>` block.
+      // Tests don't assert visuals — skip PostCSS entirely.
+      postcss: { plugins: [] },
+    },
+    optimizeDeps: {
+      esbuildOptions: { target: 'esnext' },
+    },
+    plugins: [disableClientDepsOptimizer],
+    // `test` is Vitest's extension of the Vite config; `getViteConfig` types
+    // the object as a plain Vite UserConfig.
+    test: {
+      environment: 'node',
+      passWithNoTests: true,
+      globalSetup: './__tests__/global-setup.ts',
+    },
+  } as ViteUserConfig,
+  {
+    // Belt and braces: also ask Astro to keep the dev toolbar out of
+    // compiled `.astro` output.
+    devToolbar: { enabled: false },
+  }
+)
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1819,6 +1819,9 @@ importers:
       '@refraction-ui/shared':
         specifier: workspace:*
         version: link:../shared
+      '@types/node':
+        specifier: 22.0.0
+        version: 22.0.0
 
   packages/astro-mini-map:
     dependencies:


### PR DESCRIPTION
## Summary
121 of 125 astro adapters shipped with zero tests — this gives them a safety net. 138 tests pass (124 smoke + 9 deep + 5 pre-existing meta guardrails); `turbo test/lint/typecheck --filter=@refraction-ui/astro` green (130/130, 388/388).

- **Central harness in astro-meta** (no 121 new vitest configs): renders the meta's copied dist .astro files SSR-side via Astro's experimental_AstroContainer, driven by a fixture table (33 components with required props, 37 slot-content contracts)
- **Smoke suite**: all 123 primary components render without throwing, with expected root hooks (data-rfr-*/role/data-slot/semantic tag)
- **Deep suite**: tabs, select, dialog, command, radio, dropdown-menu, toast, switch — roles, aria-*, slot content via real compositions
- Three environment landmines documented + worked around in the vitest config (client dep-optimizer clobbering, PostCSS storybook-path, dist build ordering)

Findings for follow-up (not fixed here): 4 stale hand-written astro stories would crash the storybook canvas (astro-data-table, astro-diff-viewer, astro-slide-viewer, astro-version-selector — fixtures don't match core types); astro-meta src/index.ts has pre-existing TS2308 export collisions (excluded from the new typecheck, flagged in commit message); 5 intentional placeholder components render near-empty.

## Checklist
- [x] Tests added or updated (133 new)
- [x] Axe/Accessibility checks pass (ARIA assertions in deep tests)
- [x] Docs updated (n/a)
- [ ] Changeset added (test-only)

## Breaking changes?
None.