### PR TITLE
fix: tree-shaking (494 kB → 8 kB), success/warning utilities, sm-radius

### DIFF
--- a/.changeset/badge-callout-tokens.md
+++ b/.changeset/badge-callout-tokens.md
@@ -1,0 +1,6 @@
+---
+'@refraction-ui/react': patch
+'@refraction-ui/astro': patch
+---
+
+Badge and Callout `success`/`warning` variants now use the theme token utilities (`bg-success`, `text-success-foreground`, `bg-success/10`, …) instead of hardcoded `green-500`/`yellow-500` palette classes, so they follow the active theme's `--success`/`--warning` variables. Rendered hues shift slightly from the old fixed palette values.

--- a/.changeset/tailwind-success-warning-radius.md
+++ b/.changeset/tailwind-success-warning-radius.md
@@ -1,0 +1,5 @@
+---
+'@refraction-ui/tailwind-config': minor
+---
+
+Add `success`/`success-foreground` and `warning`/`warning-foreground` color utilities to the preset (mapped to the existing `--success`/`--warning` CSS variables), and make `borderRadius.sm` a fixed `2px` absolute instead of `calc(var(--radius) - 4px)` so small elements (e.g. checkboxes) no longer collapse toward a circle at large `--radius` values. The default theme (`--radius: 0.375rem`) renders pixel-identical `sm` radius as before.

--- a/.changeset/treeshake-displayname.md
+++ b/.changeset/treeshake-displayname.md
@@ -1,0 +1,12 @@
+---
+'@refraction-ui/react': patch
+---
+
+Fix tree-shaking of the published meta package. Previously `import { Button } from '@refraction-ui/react'` bundled the entire library (494 kB minified) because tsup collapsed all ~128 adapters into a single `dist/index.js`, anchoring every component behind impure module-scope statements.
+
+Two changes fix it:
+
+1. All 249 top-level `X.displayName = '…'` assignment side effects in the react adapters are gone. `forwardRef` arrow bodies are now named function expressions (`React.forwardRef(function Foo(props, ref) { … })`) and components whose binding name already matched simply dropped the line, so React DevTools keeps showing the same component names without the impure assignments.
+2. The meta's ESM build is now emitted as one module per adapter (plus shared chunks) with `dist/index.js` reduced to pure re-export statements, so consumer bundlers can drop unused component modules at module granularity (`sideEffects: false`). The CJS build and the published export surface are unchanged.
+
+Importing a single component now bundles ~8 kB instead of 494 kB.

--- a/packages/badge/__tests__/badge.test.ts
+++ b/packages/badge/__tests__/badge.test.ts
@@ -68,12 +68,12 @@ describe('badgeVariants', () => {
 
   it('returns success variant classes', () => {
     const classes = badgeVariants({ variant: 'success' })
-    expect(classes).toContain('bg-green-500')
+    expect(classes).toContain('bg-success')
   })
 
   it('returns warning variant classes', () => {
     const classes = badgeVariants({ variant: 'warning' })
-    expect(classes).toContain('bg-yellow-500')
+    expect(classes).toContain('bg-warning')
   })
 
   it('returns sm size classes', () => {

--- a/packages/badge/src/badge.styles.ts
+++ b/packages/badge/src/badge.styles.ts
@@ -9,8 +9,8 @@ export const badgeVariants = cva({
       secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
       destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80 font-semibold',
       outline: 'text-foreground',
-      success: 'border-transparent bg-green-500 text-white shadow hover:bg-green-500/80 font-semibold',
-      warning: 'border-transparent bg-yellow-500 text-white shadow hover:bg-yellow-500/80 font-semibold',
+      success: 'border-transparent bg-success text-success-foreground shadow hover:bg-success/80 font-semibold',
+      warning: 'border-transparent bg-warning text-warning-foreground shadow hover:bg-warning/80 font-semibold',
     },
     size: {
       sm: 'px-2 py-0 text-[10px]',

--- a/packages/callout/src/callout.styles.ts
+++ b/packages/callout/src/callout.styles.ts
@@ -6,8 +6,8 @@ export const calloutVariants = cva({
     variant: {
       default: 'bg-muted/50 border-border text-foreground',
       destructive: 'bg-destructive/10 border-destructive/20 text-destructive',
-      success: 'bg-green-500/10 border-green-500/20 text-green-700 dark:text-green-400',
-      warning: 'bg-yellow-500/10 border-yellow-500/20 text-yellow-700 dark:text-yellow-400',
+      success: 'bg-success/10 border-success/20 text-success',
+      warning: 'bg-warning/10 border-warning/20 text-warning',
       info: 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400',
     },
   },

--- a/packages/react-accordion/src/accordion.tsx
+++ b/packages/react-accordion/src/accordion.tsx
@@ -21,7 +21,7 @@ export interface AccordionProps extends Omit<React.HTMLAttributes<HTMLDivElement
 }
 
 export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
-  ({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) => {
+  function Accordion({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) {
     // The headless core owns the open/closed state machine; it is created once
     // and props are synced into it below.
     const apiRef = React.useRef<AccordionAPI | null>(null)
@@ -46,7 +46,6 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
     )
   }
 )
-Accordion.displayName = 'Accordion'
 
 const AccordionItemContext = React.createContext<{ value: string; isOpen: boolean } | null>(null)
 
@@ -55,7 +54,7 @@ export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement>
 }
 
 export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
-  ({ className, value, ...props }, ref) => {
+  function AccordionItem({ className, value, ...props }, ref) {
     const context = React.useContext(AccordionContext)
     if (!context) {
       devWarn(
@@ -74,12 +73,11 @@ export const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps
     )
   }
 )
-AccordionItem.displayName = 'AccordionItem'
 
 export interface AccordionTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTriggerProps>(
-  ({ className, children, ...props }, ref) => {
+  function AccordionTrigger({ className, children, ...props }, ref) {
     const accordionContext = React.useContext(AccordionContext)
     const itemContext = React.useContext(AccordionItemContext)
 
@@ -125,12 +123,11 @@ export const AccordionTrigger = React.forwardRef<HTMLButtonElement, AccordionTri
     )
   }
 )
-AccordionTrigger.displayName = 'AccordionTrigger'
 
 export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const AccordionContent = React.forwardRef<HTMLDivElement, AccordionContentProps>(
-  ({ className, children, ...props }, ref) => {
+  function AccordionContent({ className, children, ...props }, ref) {
     const itemContext = React.useContext(AccordionItemContext)
     if (!itemContext) {
       devWarn(
@@ -156,4 +153,3 @@ export const AccordionContent = React.forwardRef<HTMLDivElement, AccordionConten
     )
   }
 )
-AccordionContent.displayName = 'AccordionContent'

--- a/packages/react-animated-text/src/animated-text.tsx
+++ b/packages/react-animated-text/src/animated-text.tsx
@@ -18,7 +18,7 @@ export interface AnimatedTextProps
     CoreAnimatedTextProps {}
 
 export const AnimatedText = React.forwardRef<HTMLSpanElement, AnimatedTextProps>(
-  ({ words, interval = 2500, transitionDuration = 1000, className, ...props }, ref) => {
+  function AnimatedText({ words, interval = 2500, transitionDuration = 1000, className, ...props }, ref) {
     const apiRef = React.useRef(
       createAnimatedText({ words, interval, transitionDuration }),
     )
@@ -76,8 +76,6 @@ export const AnimatedText = React.forwardRef<HTMLSpanElement, AnimatedTextProps>
   },
 )
 
-AnimatedText.displayName = 'AnimatedText'
-
 /* ------------------------------------------------------------------ */
 /*  TypewriterText — char-by-char reveal                               */
 /* ------------------------------------------------------------------ */
@@ -87,7 +85,7 @@ export interface TypewriterTextProps
     CoreTypewriterProps {}
 
 export const TypewriterText = React.forwardRef<HTMLSpanElement, TypewriterTextProps>(
-  ({ text, speed = 50, startDelay = 0, className, ...props }, ref) => {
+  function TypewriterText({ text, speed = 50, startDelay = 0, className, ...props }, ref) {
     const apiRef = React.useRef(createTypewriter({ text, speed, startDelay }))
     const api = apiRef.current
 
@@ -136,5 +134,3 @@ export const TypewriterText = React.forwardRef<HTMLSpanElement, TypewriterTextPr
     )
   },
 )
-
-TypewriterText.displayName = 'TypewriterText'

--- a/packages/react-app-shell/src/app-shell.tsx
+++ b/packages/react-app-shell/src/app-shell.tsx
@@ -42,7 +42,7 @@ export interface AppShellProps {
 }
 
 const AppShellRoot = React.forwardRef<HTMLDivElement, AppShellProps>(
-  ({ config, children, className }, ref) => {
+  function AppShell({ config, children, className }, ref) {
   // Create the headless API once
   const apiRef = React.useRef<AppShellAPI | null>(null)
   if (apiRef.current === null) {
@@ -112,8 +112,6 @@ const AppShellRoot = React.forwardRef<HTMLDivElement, AppShellProps>(
   },
 )
 
-AppShellRoot.displayName = 'AppShell'
-
 // ---------------------------------------------------------------------------
 // AppShell.Sidebar
 // ---------------------------------------------------------------------------
@@ -124,7 +122,7 @@ export interface AppShellSidebarProps {
 }
 
 const Sidebar = React.forwardRef<HTMLElement, AppShellSidebarProps>(
-  ({ children, className }, ref) => {
+  function Sidebar({ children, className }, ref) {
   const { api, state } = useAppShell()
   const isRight = api.config.sidebarPosition === 'right'
 
@@ -168,8 +166,6 @@ const Sidebar = React.forwardRef<HTMLElement, AppShellSidebarProps>(
   },
 )
 
-Sidebar.displayName = 'AppShell.Sidebar'
-
 // ---------------------------------------------------------------------------
 // AppShell.Main
 // ---------------------------------------------------------------------------
@@ -180,7 +176,7 @@ export interface AppShellMainProps {
 }
 
 const Main = React.forwardRef<HTMLDivElement, AppShellMainProps>(
-  ({ children, className }, ref) => {
+  function Main({ children, className }, ref) {
   return React.createElement(
     'div',
     {
@@ -192,8 +188,6 @@ const Main = React.forwardRef<HTMLDivElement, AppShellMainProps>(
   },
 )
 
-Main.displayName = 'AppShell.Main'
-
 // ---------------------------------------------------------------------------
 // AppShell.Header
 // ---------------------------------------------------------------------------
@@ -204,7 +198,7 @@ export interface AppShellHeaderProps {
 }
 
 const Header = React.forwardRef<HTMLElement, AppShellHeaderProps>(
-  ({ children, className }, ref) => {
+  function Header({ children, className }, ref) {
   const { api, state } = useAppShell()
 
   const hamburger = state.isMobile
@@ -257,8 +251,6 @@ const Header = React.forwardRef<HTMLElement, AppShellHeaderProps>(
   },
 )
 
-Header.displayName = 'AppShell.Header'
-
 // ---------------------------------------------------------------------------
 // AppShell.Content
 // ---------------------------------------------------------------------------
@@ -271,7 +263,7 @@ export interface AppShellContentProps {
 }
 
 const Content = React.forwardRef<HTMLElement, AppShellContentProps>(
-  ({ children, className, maxWidth }, ref) => {
+  function Content({ children, className, maxWidth }, ref) {
   const { api } = useAppShell()
   const mwClass = maxWidth ? `max-w-${maxWidth}` : ''
 
@@ -292,8 +284,6 @@ const Content = React.forwardRef<HTMLElement, AppShellContentProps>(
   },
 )
 
-Content.displayName = 'AppShell.Content'
-
 // ---------------------------------------------------------------------------
 // AppShell.MobileNav
 // ---------------------------------------------------------------------------
@@ -304,7 +294,7 @@ export interface AppShellMobileNavProps {
 }
 
 const MobileNav = React.forwardRef<HTMLElement, AppShellMobileNavProps>(
-  ({ children, className }, ref) => {
+  function MobileNav({ children, className }, ref) {
   const { api, state } = useAppShell()
 
   if (!state.isMobile) return null
@@ -328,8 +318,6 @@ const MobileNav = React.forwardRef<HTMLElement, AppShellMobileNavProps>(
   },
 )
 
-MobileNav.displayName = 'AppShell.MobileNav'
-
 // ---------------------------------------------------------------------------
 // AppShell.Overlay
 // ---------------------------------------------------------------------------
@@ -339,7 +327,7 @@ export interface AppShellOverlayProps {
 }
 
 const Overlay = React.forwardRef<HTMLDivElement, AppShellOverlayProps>(
-  ({ className }, ref) => {
+  function Overlay({ className }, ref) {
   const { api, state } = useAppShell()
 
   if (!state.isMobile || !state.sidebarOpen) return null
@@ -356,8 +344,6 @@ const Overlay = React.forwardRef<HTMLDivElement, AppShellOverlayProps>(
   })
   },
 )
-
-Overlay.displayName = 'AppShell.Overlay'
 
 // ---------------------------------------------------------------------------
 // Compound export

--- a/packages/react-app-shell/src/auth-shell.tsx
+++ b/packages/react-app-shell/src/auth-shell.tsx
@@ -38,7 +38,7 @@ export interface AuthShellProps {
   className?: string
 }
 
-function AuthShellRoot({ config, children, className }: AuthShellProps) {
+const AuthShellRoot = function AuthShell({ config, children, className }: AuthShellProps) {
   const apiRef = React.useRef<AuthShellAPI | null>(null)
   if (apiRef.current === null) {
     apiRef.current = createAuthShell(config)
@@ -65,8 +65,6 @@ function AuthShellRoot({ config, children, className }: AuthShellProps) {
   )
 }
 
-AuthShellRoot.displayName = 'AuthShell'
-
 // ---------------------------------------------------------------------------
 // AuthShell.Card
 // ---------------------------------------------------------------------------
@@ -88,8 +86,6 @@ function AuthShellCard({ children, className }: AuthShellCardProps) {
     children,
   )
 }
-
-AuthShellCard.displayName = 'AuthShell.Card'
 
 // ---------------------------------------------------------------------------
 // Compound export

--- a/packages/react-app-shell/src/page-shell.tsx
+++ b/packages/react-app-shell/src/page-shell.tsx
@@ -39,7 +39,7 @@ export interface PageShellProps {
   className?: string
 }
 
-function PageShellRoot({ config, children, className }: PageShellProps) {
+const PageShellRoot = function PageShell({ config, children, className }: PageShellProps) {
   const apiRef = React.useRef<PageShellAPI | null>(null)
   if (apiRef.current === null) {
     apiRef.current = createPageShell(config)
@@ -67,8 +67,6 @@ function PageShellRoot({ config, children, className }: PageShellProps) {
     ),
   )
 }
-
-PageShellRoot.displayName = 'PageShell'
 
 // ---------------------------------------------------------------------------
 // PageShell.Nav
@@ -100,8 +98,6 @@ function Nav({ children, className }: PageShellNavProps) {
   )
 }
 
-Nav.displayName = 'PageShell.Nav'
-
 // ---------------------------------------------------------------------------
 // PageShell.Section
 // ---------------------------------------------------------------------------
@@ -131,8 +127,6 @@ function Section({
     children,
   )
 }
-
-Section.displayName = 'PageShell.Section'
 
 // ---------------------------------------------------------------------------
 // PageShell.Footer
@@ -169,8 +163,6 @@ function Footer({ children, className, columns }: PageShellFooterProps) {
     ),
   )
 }
-
-Footer.displayName = 'PageShell.Footer'
 
 // ---------------------------------------------------------------------------
 // Compound export

--- a/packages/react-audience-feature-card/src/audience-feature-card.tsx
+++ b/packages/react-audience-feature-card/src/audience-feature-card.tsx
@@ -31,7 +31,7 @@ export interface AudienceFeatureCardProps
 export const AudienceFeatureCard = React.forwardRef<
   HTMLDivElement,
   AudienceFeatureCardProps
->(({ kicker, title, body, footer, className, ...props }, ref) => {
+>(function AudienceFeatureCard({ kicker, title, body, footer, className, ...props }, ref) {
   const { ariaProps, dataAttributes } = createAudienceFeatureCard()
 
   return (
@@ -53,5 +53,3 @@ export const AudienceFeatureCard = React.forwardRef<
     </div>
   )
 })
-
-AudienceFeatureCard.displayName = 'AudienceFeatureCard'

--- a/packages/react-audio-room/src/audio-room.tsx
+++ b/packages/react-audio-room/src/audio-room.tsx
@@ -40,7 +40,7 @@ export interface SpeakingOrbProps
  * `aria-label` set to the participant's name.
  */
 export const SpeakingOrb = React.forwardRef<HTMLDivElement, SpeakingOrbProps>(
-  (
+  function SpeakingOrb(
     {
       name,
       avatarUrl,
@@ -51,7 +51,7 @@ export const SpeakingOrb = React.forwardRef<HTMLDivElement, SpeakingOrbProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const initials = getInitials(name)
 
     return (
@@ -97,8 +97,6 @@ export const SpeakingOrb = React.forwardRef<HTMLDivElement, SpeakingOrbProps>(
   },
 )
 
-SpeakingOrb.displayName = 'SpeakingOrb'
-
 // ── AudioRoom ─────────────────────────────────────────────────────────────────
 
 export interface AudioRoomProps
@@ -115,7 +113,7 @@ export interface AudioRoomProps
  * `gridTemplateColumns` because the column count is dynamic.
  */
 export const AudioRoom = React.forwardRef<HTMLDivElement, AudioRoomProps>(
-  ({ participants, className, ...props }, ref) => {
+  function AudioRoom({ participants, className, ...props }, ref) {
     const cols = orbColumns(participants.length)
     const { ariaProps, dataAttributes } = createAudioRoom()
 
@@ -144,5 +142,3 @@ export const AudioRoom = React.forwardRef<HTMLDivElement, AudioRoomProps>(
     )
   },
 )
-
-AudioRoom.displayName = 'AudioRoom'

--- a/packages/react-avatar-group/src/avatar-group.tsx
+++ b/packages/react-avatar-group/src/avatar-group.tsx
@@ -19,7 +19,7 @@ export interface AvatarGroupProps {
 }
 
 export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
-  ({ users, max, size = 'md', className }, ref) => {
+  function AvatarGroup({ users, max, size = 'md', className }, ref) {
   const api = createAvatarGroup({ users, max, size })
 
   return React.createElement(
@@ -58,5 +58,3 @@ export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
   )
   },
 )
-
-AvatarGroup.displayName = 'AvatarGroup'

--- a/packages/react-avatar/src/avatar.tsx
+++ b/packages/react-avatar/src/avatar.tsx
@@ -35,7 +35,7 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLSpanElement> {
  * Compound component: use Avatar > AvatarImage + AvatarFallback.
  */
 export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
-  ({ size = 'md', className, children, ...props }, ref) => {
+  function Avatar({ size = 'md', className, children, ...props }, ref) {
     const [imageLoaded, setImageLoaded] = React.useState(false)
     const [imageError, setImageError] = React.useState(false)
 
@@ -56,13 +56,12 @@ export const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
     )
   },
 )
-Avatar.displayName = 'Avatar'
 
 /* ─── AvatarImage ──────────────────────────────────────────────── */
 export interface AvatarImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
 
 export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
-  ({ className, src, alt = '', onLoad, onError, ...props }, ref) => {
+  function AvatarImage({ className, src, alt = '', onLoad, onError, ...props }, ref) {
     const { imageError, setImageLoaded, setImageError } = React.useContext(AvatarContext)
 
     React.useEffect(() => {
@@ -95,13 +94,12 @@ export const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
     )
   },
 )
-AvatarImage.displayName = 'AvatarImage'
 
 /* ─── AvatarFallback ───────────────────────────────────────────── */
 export interface AvatarFallbackProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 export const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackProps>(
-  ({ className, children, ...props }, ref) => {
+  function AvatarFallback({ className, children, ...props }, ref) {
     const { size, imageLoaded, imageError } = React.useContext(AvatarContext)
 
     if (imageLoaded && !imageError) return null
@@ -117,4 +115,3 @@ export const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackPr
     )
   },
 )
-AvatarFallback.displayName = 'AvatarFallback'

--- a/packages/react-badge/__tests__/badge.test.tsx
+++ b/packages/react-badge/__tests__/badge.test.tsx
@@ -26,7 +26,7 @@ describe('Badge (React)', () => {
     const html = renderToString(
       React.createElement(Badge, { variant: 'success' }, 'Active'),
     )
-    expect(html).toContain('bg-green-500')
+    expect(html).toContain('bg-success')
     expect(html).toContain('role="status"')
   })
 
@@ -34,7 +34,7 @@ describe('Badge (React)', () => {
     const html = renderToString(
       React.createElement(Badge, { variant: 'warning' }, 'Warning'),
     )
-    expect(html).toContain('bg-yellow-500')
+    expect(html).toContain('bg-warning')
     expect(html).toContain('role="status"')
   })
 
@@ -117,7 +117,7 @@ describe('Badge – custom className appended', () => {
       React.createElement(Badge, { variant: 'success', className: 'extra-class' }, 'Test'),
     )
     expect(html).toContain('extra-class')
-    expect(html).toContain('bg-green-500')
+    expect(html).toContain('bg-success')
   })
 })
 

--- a/packages/react-badge/src/badge.tsx
+++ b/packages/react-badge/src/badge.tsx
@@ -19,7 +19,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
-  ({ variant, size, className, children, ...props }, ref) => {
+  function Badge({ variant, size, className, children, ...props }, ref) {
     const api = createBadge({ variant, size })
     const classes = cn(badgeVariants({ variant, size }), className)
 
@@ -36,5 +36,3 @@ export const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
     )
   },
 )
-
-Badge.displayName = 'Badge'

--- a/packages/react-bottom-nav/src/bottom-nav.tsx
+++ b/packages/react-bottom-nav/src/bottom-nav.tsx
@@ -21,7 +21,7 @@ export interface BottomNavProps extends React.HTMLAttributes<HTMLElement> {
  * Visible on mobile only (md:hidden via styles).
  */
 export const BottomNav = React.forwardRef<HTMLElement, BottomNavProps>(
-  ({ tabs = [], currentPath, className, ...props }, ref) => {
+  function BottomNav({ tabs = [], currentPath, className, ...props }, ref) {
     const api = createBottomNav({ tabs, currentPath })
     const classes = cn(bottomNavVariants(), className)
 
@@ -47,5 +47,3 @@ export const BottomNav = React.forwardRef<HTMLElement, BottomNavProps>(
     )
   },
 )
-
-BottomNav.displayName = 'BottomNav'

--- a/packages/react-brand-network-cell/src/brand-network-cell.tsx
+++ b/packages/react-brand-network-cell/src/brand-network-cell.tsx
@@ -41,7 +41,7 @@ export const BrandNetworkCell = React.forwardRef<
   HTMLDivElement,
   BrandNetworkCellProps
 >(
-  (
+  function BrandNetworkCell(
     {
       glyph,
       glyphBg,
@@ -55,7 +55,7 @@ export const BrandNetworkCell = React.forwardRef<
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createBrandNetworkCell({ current })
 
     return (
@@ -101,5 +101,3 @@ export const BrandNetworkCell = React.forwardRef<
     )
   },
 )
-
-BrandNetworkCell.displayName = 'BrandNetworkCell'

--- a/packages/react-breadcrumbs/src/breadcrumbs.tsx
+++ b/packages/react-breadcrumbs/src/breadcrumbs.tsx
@@ -27,7 +27,7 @@ export interface BreadcrumbsProps extends React.HTMLAttributes<HTMLElement> {
  * Uses the headless @refraction-ui/breadcrumbs core for state and ARIA attributes.
  */
 export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
-  (
+  function Breadcrumbs(
     {
       pathname,
       items,
@@ -38,7 +38,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createBreadcrumbs({ pathname, items, labels, separator, maxItems })
     const classes = cn(breadcrumbsVariants(), className)
 
@@ -79,5 +79,3 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
     )
   },
 )
-
-Breadcrumbs.displayName = 'Breadcrumbs'

--- a/packages/react-browser-chrome-mock/src/browser-chrome-mock.tsx
+++ b/packages/react-browser-chrome-mock/src/browser-chrome-mock.tsx
@@ -37,7 +37,7 @@ const TRAFFIC_DOTS = ['bg-red-400', 'bg-yellow-400', 'bg-green-400'] as const
 export const BrowserChromeMock = React.forwardRef<
   HTMLDivElement,
   BrowserChromeMockProps
->(({ url, status, className, children, ...props }, ref) => {
+>(function BrowserChromeMock({ url, status, className, children, ...props }, ref) {
   const { ariaProps, dataAttributes } = createBrowserChromeMock({ status })
   const { domain, path } = splitUrl(url)
 
@@ -80,5 +80,3 @@ export const BrowserChromeMock = React.forwardRef<
     </div>
   )
 })
-
-BrowserChromeMock.displayName = 'BrowserChromeMock'

--- a/packages/react-button/src/button.tsx
+++ b/packages/react-button/src/button.tsx
@@ -26,7 +26,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant, size, loading, asChild, className, disabled, children, shortcut, action, ...props }, ref) => {
+  function Button({ variant, size, loading, asChild, className, disabled, children, shortcut, action, ...props }, ref) {
     // `primary` is an ecosystem-muscle-memory alias for `default` — resolve it
     // here so styling, aria, and data attributes all see the canonical variant.
     // See issue #201.
@@ -111,5 +111,3 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     )
   },
 )
-
-Button.displayName = 'Button'

--- a/packages/react-calendar/src/calendar.tsx
+++ b/packages/react-calendar/src/calendar.tsx
@@ -25,7 +25,7 @@ const MONTH_NAMES = [
 const DAY_HEADERS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
 export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
-  ({ className, value, defaultValue, onSelect, month, onMonthChange, minDate, maxDate, disabledDates }: CalendarProps, ref) => {
+  function Calendar({ className, value, defaultValue, onSelect, month, onMonthChange, minDate, maxDate, disabledDates }: CalendarProps, ref) {
   const [uncontrolledValue, setUncontrolledValue] = React.useState<Date | undefined>(defaultValue)
   const [uncontrolledMonth, setUncontrolledMonth] = React.useState<Date>(
     () => month ?? value ?? defaultValue ?? new Date(),
@@ -139,8 +139,6 @@ export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
   },
 )
 
-Calendar.displayName = 'Calendar'
-
 // ---------------------------------------------------------------------------
 // CalendarHeader
 // ---------------------------------------------------------------------------
@@ -154,7 +152,7 @@ export interface CalendarHeaderProps {
 }
 
 export const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderProps>(
-  ({ label, labelId, onPrevMonth, onNextMonth, className }, ref) => {
+  function CalendarHeader({ label, labelId, onPrevMonth, onNextMonth, className }, ref) {
   return React.createElement(
     'div',
     {
@@ -193,5 +191,3 @@ export const CalendarHeader = React.forwardRef<HTMLDivElement, CalendarHeaderPro
   )
   },
 )
-
-CalendarHeader.displayName = 'CalendarHeader'

--- a/packages/react-call-controls/src/call-controls.tsx
+++ b/packages/react-call-controls/src/call-controls.tsx
@@ -39,7 +39,7 @@ export const CallControlButton = React.forwardRef<
   HTMLButtonElement,
   CallControlButtonProps
 >(
-  (
+  function CallControlButton(
     {
       label,
       icon,
@@ -50,7 +50,7 @@ export const CallControlButton = React.forwardRef<
       ...props
     },
     ref,
-  ) => {
+  ) {
     const ariaPressedProps =
       pressed !== undefined ? { 'aria-pressed': pressed } : {}
 
@@ -69,8 +69,6 @@ export const CallControlButton = React.forwardRef<
     )
   },
 )
-
-CallControlButton.displayName = 'CallControlButton'
 
 // ─── CallControls ─────────────────────────────────────────────────────────────
 
@@ -93,7 +91,7 @@ export interface CallControlsProps
  * ```
  */
 export const CallControls = React.forwardRef<HTMLDivElement, CallControlsProps>(
-  ({ size = 'md', className, children, ...props }, ref) => {
+  function CallControls({ size = 'md', className, children, ...props }, ref) {
     const api = createCallControls()
 
     return (
@@ -109,5 +107,3 @@ export const CallControls = React.forwardRef<HTMLDivElement, CallControlsProps>(
     )
   },
 )
-
-CallControls.displayName = 'CallControls'

--- a/packages/react-callout/__tests__/callout.test.tsx
+++ b/packages/react-callout/__tests__/callout.test.tsx
@@ -39,8 +39,8 @@ describe('Callout (React)', () => {
   })
 
   it('applies variant-specific classes', () => {
-    expect(renderToString(React.createElement(Callout, { variant: 'success' }, 'x'))).toContain('bg-green-500/10')
-    expect(renderToString(React.createElement(Callout, { variant: 'warning' }, 'x'))).toContain('bg-yellow-500/10')
+    expect(renderToString(React.createElement(Callout, { variant: 'success' }, 'x'))).toContain('bg-success/10')
+    expect(renderToString(React.createElement(Callout, { variant: 'warning' }, 'x'))).toContain('bg-warning/10')
     expect(renderToString(React.createElement(Callout, { variant: 'info' }, 'x'))).toContain('bg-blue-500/10')
   })
 

--- a/packages/react-callout/src/callout.tsx
+++ b/packages/react-callout/src/callout.tsx
@@ -16,7 +16,7 @@ export interface CalloutProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
-  ({ className, variant, ...props }, ref) => {
+  function Callout({ className, variant, ...props }, ref) {
     const api = createCallout({ role: variant === 'destructive' ? 'alert' : 'region' })
     return (
       <div
@@ -29,10 +29,9 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     )
   },
 )
-Callout.displayName = 'Callout'
 
 export const CalloutIcon = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CalloutIcon({ className, ...props }, ref) {
     const api = createCalloutIcon()
     return (
       <div
@@ -44,10 +43,9 @@ export const CalloutIcon = React.forwardRef<HTMLDivElement, React.HTMLAttributes
     )
   },
 )
-CalloutIcon.displayName = 'CalloutIcon'
 
 export const CalloutContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CalloutContent({ className, ...props }, ref) {
     const api = createCalloutContent()
     return (
       <div
@@ -59,10 +57,9 @@ export const CalloutContent = React.forwardRef<HTMLDivElement, React.HTMLAttribu
     )
   },
 )
-CalloutContent.displayName = 'CalloutContent'
 
 export const CalloutTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => {
+  function CalloutTitle({ className, ...props }, ref) {
     const api = createCalloutTitle()
     return (
       <h5
@@ -74,10 +71,9 @@ export const CalloutTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttri
     )
   },
 )
-CalloutTitle.displayName = 'CalloutTitle'
 
 export const CalloutDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CalloutDescription({ className, ...props }, ref) {
     const api = createCalloutDescription()
     return (
       <div
@@ -89,4 +85,3 @@ export const CalloutDescription = React.forwardRef<HTMLDivElement, React.HTMLAtt
     )
   },
 )
-CalloutDescription.displayName = 'CalloutDescription'

--- a/packages/react-card-grid/src/card-grid.tsx
+++ b/packages/react-card-grid/src/card-grid.tsx
@@ -5,7 +5,7 @@ import { cn } from '@refraction-ui/shared'
 export interface ReactCardGridProps extends React.HTMLAttributes<HTMLDivElement>, CardGridProps {}
 
 export const CardGrid = React.forwardRef<HTMLDivElement, ReactCardGridProps>(
-  ({ className, columns = 3, ...props }, ref) => {
+  function CardGrid({ className, columns = 3, ...props }, ref) {
     const api = createCardGrid({ columns })
     return (
       <div
@@ -17,4 +17,3 @@ export const CardGrid = React.forwardRef<HTMLDivElement, ReactCardGridProps>(
     )
   }
 )
-CardGrid.displayName = 'CardGrid'

--- a/packages/react-card/src/card.tsx
+++ b/packages/react-card/src/card.tsx
@@ -19,7 +19,7 @@ import { cn } from '@refraction-ui/shared'
  * Card -- a container with rounded corners, border, and shadow.
  */
 export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function Card({ className, ...props }, ref) {
     const api = createCard()
     return (
       <div
@@ -32,13 +32,12 @@ export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
     )
   },
 )
-Card.displayName = 'Card'
 
 /**
  * CardHeader -- top section of a card, typically contains title and description.
  */
 export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CardHeader({ className, ...props }, ref) {
     const api = createCardHeader()
     return (
       <div
@@ -50,13 +49,12 @@ export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
     )
   },
 )
-CardHeader.displayName = 'CardHeader'
 
 /**
  * CardTitle -- heading within a card header.
  */
 export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => {
+  function CardTitle({ className, ...props }, ref) {
     const api = createCardTitle()
     return (
       <h3
@@ -68,13 +66,12 @@ export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttribut
     )
   },
 )
-CardTitle.displayName = 'CardTitle'
 
 /**
  * CardDescription -- subtext within a card header.
  */
 export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => {
+  function CardDescription({ className, ...props }, ref) {
     const api = createCardDescription()
     return (
       <p
@@ -86,13 +83,12 @@ export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTML
     )
   },
 )
-CardDescription.displayName = 'CardDescription'
 
 /**
  * CardContent -- main body content area of a card.
  */
 export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CardContent({ className, ...props }, ref) {
     const api = createCardContent()
     return (
       <div
@@ -104,13 +100,12 @@ export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes
     )
   },
 )
-CardContent.displayName = 'CardContent'
 
 /**
  * CardFooter -- bottom section of a card, typically contains actions.
  */
 export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CardFooter({ className, ...props }, ref) {
     const api = createCardFooter()
     return (
       <div
@@ -122,4 +117,3 @@ export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
     )
   },
 )
-CardFooter.displayName = 'CardFooter'

--- a/packages/react-carousel/src/carousel.tsx
+++ b/packages/react-carousel/src/carousel.tsx
@@ -21,7 +21,7 @@ export interface CarouselProps extends Omit<React.HTMLAttributes<HTMLDivElement>
 }
 
 export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
-  ({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) => {
+  function Carousel({ className, type = 'single', collapsible, value: controlledValue, defaultValue, onValueChange, ...props }, ref) {
     // The headless core owns the open/closed state machine; it is created once
     // and props are synced into it below.
     const apiRef = React.useRef<CarouselAPI | null>(null)
@@ -46,7 +46,6 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
     )
   }
 )
-Carousel.displayName = 'Carousel'
 
 const CarouselItemContext = React.createContext<{ value: string; isOpen: boolean } | null>(null)
 
@@ -55,7 +54,7 @@ export interface CarouselItemProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
-  ({ className, value, ...props }, ref) => {
+  function CarouselItem({ className, value, ...props }, ref) {
     const context = React.useContext(CarouselContext)
     if (!context) {
       devWarn(
@@ -74,12 +73,11 @@ export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
     )
   }
 )
-CarouselItem.displayName = 'CarouselItem'
 
 export interface CarouselTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const CarouselTrigger = React.forwardRef<HTMLButtonElement, CarouselTriggerProps>(
-  ({ className, children, ...props }, ref) => {
+  function CarouselTrigger({ className, children, ...props }, ref) {
     const carouselContext = React.useContext(CarouselContext)
     const itemContext = React.useContext(CarouselItemContext)
 
@@ -125,12 +123,11 @@ export const CarouselTrigger = React.forwardRef<HTMLButtonElement, CarouselTrigg
     )
   }
 )
-CarouselTrigger.displayName = 'CarouselTrigger'
 
 export interface CarouselContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentProps>(
-  ({ className, children, ...props }, ref) => {
+  function CarouselContent({ className, children, ...props }, ref) {
     const itemContext = React.useContext(CarouselItemContext)
     if (!itemContext) {
       devWarn(
@@ -156,4 +153,3 @@ export const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentP
     )
   }
 )
-CarouselContent.displayName = 'CarouselContent'

--- a/packages/react-checkbox/src/checkbox.tsx
+++ b/packages/react-checkbox/src/checkbox.tsx
@@ -21,7 +21,7 @@ export interface CheckboxProps extends Omit<React.ButtonHTMLAttributes<HTMLButto
  * Uses the headless @refraction-ui/checkbox core for state, ARIA, and keyboard handling.
  */
 export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
-  ({ checked = false, onCheckedChange, disabled = false, size = 'default', className, ...props }, ref) => {
+  function Checkbox({ checked = false, onCheckedChange, disabled = false, size = 'default', className, ...props }, ref) {
     const api = createCheckbox({ checked, disabled })
 
     const checkedVariant = checked === 'indeterminate' ? 'indeterminate' : checked ? 'true' : 'false'
@@ -93,5 +93,3 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
     )
   },
 )
-
-Checkbox.displayName = 'Checkbox'

--- a/packages/react-checklist/src/checklist.tsx
+++ b/packages/react-checklist/src/checklist.tsx
@@ -40,7 +40,7 @@ export interface ChecklistProps
  * Logic and styles come from the headless `@refraction-ui/checklist` core.
  */
 export const Checklist = React.forwardRef<HTMLDivElement, ChecklistProps>(
-  (
+  function Checklist(
     {
       items: itemsProp,
       defaultItems,
@@ -51,7 +51,7 @@ export const Checklist = React.forwardRef<HTMLDivElement, ChecklistProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = itemsProp !== undefined
     const [internal, setInternal] = React.useState<ChecklistItemData[]>(
       defaultItems ?? [],
@@ -136,5 +136,3 @@ export const Checklist = React.forwardRef<HTMLDivElement, ChecklistProps>(
     )
   },
 )
-
-Checklist.displayName = 'Checklist'

--- a/packages/react-code-block/src/code-block.tsx
+++ b/packages/react-code-block/src/code-block.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from '@refraction-ui/shared'
 
 export const CodeBlock = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CodeBlock({ className, ...props }, ref) {
     const api = createCodeBlock()
     return (
       <div
@@ -22,10 +22,9 @@ export const CodeBlock = React.forwardRef<HTMLDivElement, React.HTMLAttributes<H
     )
   },
 )
-CodeBlock.displayName = 'CodeBlock'
 
 export const CodeBlockHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function CodeBlockHeader({ className, ...props }, ref) {
     const api = createCodeBlockHeader()
     return (
       <div
@@ -37,10 +36,9 @@ export const CodeBlockHeader = React.forwardRef<HTMLDivElement, React.HTMLAttrib
     )
   },
 )
-CodeBlockHeader.displayName = 'CodeBlockHeader'
 
 export const CodeBlockContent = React.forwardRef<HTMLPreElement, React.HTMLAttributes<HTMLPreElement>>(
-  ({ className, ...props }, ref) => {
+  function CodeBlockContent({ className, ...props }, ref) {
     const api = createCodeBlockContent()
     return (
       <pre
@@ -52,4 +50,3 @@ export const CodeBlockContent = React.forwardRef<HTMLPreElement, React.HTMLAttri
     )
   },
 )
-CodeBlockContent.displayName = 'CodeBlockContent'

--- a/packages/react-code-editor/src/CodeEditor.tsx
+++ b/packages/react-code-editor/src/CodeEditor.tsx
@@ -26,7 +26,7 @@ export interface CodeEditorProps {
  * label and optional action buttons. Syntax highlighting is a future enhancement.
  */
 export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
-  (
+  function CodeEditor(
     {
       value = '',
       onChange,
@@ -38,7 +38,7 @@ export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
       actions,
     },
     ref,
-  ) => {
+  ) {
     const api = createCodeEditor({ value, onChange, language, readOnly, theme })
     const containerClasses = cn(codeEditorVariants({ theme }), className)
 
@@ -81,5 +81,3 @@ export const CodeEditor = React.forwardRef<HTMLDivElement, CodeEditorProps>(
     )
   },
 )
-
-CodeEditor.displayName = 'CodeEditor'

--- a/packages/react-collapsible/src/collapsible.tsx
+++ b/packages/react-collapsible/src/collapsible.tsx
@@ -100,8 +100,6 @@ export function Collapsible({
   )
 }
 
-Collapsible.displayName = 'Collapsible'
-
 // ---------------------------------------------------------------------------
 // CollapsibleTrigger
 // ---------------------------------------------------------------------------
@@ -112,7 +110,7 @@ export interface CollapsibleTriggerProps
 export const CollapsibleTrigger = React.forwardRef<
   HTMLButtonElement,
   CollapsibleTriggerProps
->(({ onClick, disabled: disabledProp, children, ...props }, ref) => {
+>(function CollapsibleTrigger({ onClick, disabled: disabledProp, children, ...props }, ref) {
   const { open, onOpenChange, disabled: ctxDisabled, contentId } =
     useCollapsibleContext()
   const disabled = disabledProp ?? ctxDisabled
@@ -141,8 +139,6 @@ export const CollapsibleTrigger = React.forwardRef<
   )
 })
 
-CollapsibleTrigger.displayName = 'CollapsibleTrigger'
-
 // ---------------------------------------------------------------------------
 // CollapsibleContent
 // ---------------------------------------------------------------------------
@@ -153,7 +149,7 @@ export interface CollapsibleContentProps
 export const CollapsibleContent = React.forwardRef<
   HTMLDivElement,
   CollapsibleContentProps
->(({ className, children, ...props }, ref) => {
+>(function CollapsibleContent({ className, children, ...props }, ref) {
   const { open, contentId } = useCollapsibleContext()
   const dataState = open ? 'open' : 'closed'
 
@@ -175,5 +171,3 @@ export const CollapsibleContent = React.forwardRef<
     children,
   )
 })
-
-CollapsibleContent.displayName = 'CollapsibleContent'

--- a/packages/react-combobox/src/combobox.tsx
+++ b/packages/react-combobox/src/combobox.tsx
@@ -347,8 +347,6 @@ export function Combobox({
   )
 }
 
-Combobox.displayName = 'Combobox'
-
 /* ─── ComboboxTrigger ──────────────────────────────────────────── */
 
 export interface ComboboxTriggerProps
@@ -360,7 +358,7 @@ export interface ComboboxTriggerProps
 export const ComboboxTrigger = React.forwardRef<
   HTMLButtonElement,
   ComboboxTriggerProps
->(({ className, children, size = 'default', placeholder = 'Select…', ...props }, forwardedRef) => {
+>(function ComboboxTrigger({ className, children, size = 'default', placeholder = 'Select…', ...props }, forwardedRef) {
   const ctx = useComboboxContext()
   const { open, setOpen, disabled, ids, selectedLabel, triggerRef } = ctx
 
@@ -436,7 +434,6 @@ export const ComboboxTrigger = React.forwardRef<
     </button>
   )
 })
-ComboboxTrigger.displayName = 'ComboboxTrigger'
 
 /* ─── ComboboxContent ──────────────────────────────────────────── */
 
@@ -446,7 +443,7 @@ export interface ComboboxContentProps extends React.HTMLAttributes<HTMLDivElemen
 }
 
 export const ComboboxContent = React.forwardRef<HTMLDivElement, ComboboxContentProps>(
-  ({ className, children, portal = true, ...props }, forwardedRef) => {
+  function ComboboxContent({ className, children, portal = true, ...props }, forwardedRef) {
     const ctx = useComboboxContext()
     const { open, ids, contentRef, hasOptions, options, inputRef } = ctx
 
@@ -506,14 +503,13 @@ export const ComboboxContent = React.forwardRef<HTMLDivElement, ComboboxContentP
     return content
   },
 )
-ComboboxContent.displayName = 'ComboboxContent'
 
 /* ─── ComboboxInput ────────────────────────────────────────────── */
 
 export interface ComboboxInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputProps>(
-  ({ className, onChange, onKeyDown, placeholder = 'Search…', ...props }, forwardedRef) => {
+  function ComboboxInput({ className, onChange, onKeyDown, placeholder = 'Search…', ...props }, forwardedRef) {
     const ctx = useComboboxContext()
     const {
       query,
@@ -633,14 +629,13 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
     )
   },
 )
-ComboboxInput.displayName = 'ComboboxInput'
 
 /* ─── ComboboxList ─────────────────────────────────────────────── */
 
 export interface ComboboxListProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const ComboboxList = React.forwardRef<HTMLDivElement, ComboboxListProps>(
-  ({ className, children, ...props }, ref) => {
+  function ComboboxList({ className, children, ...props }, ref) {
     const { ids } = useComboboxContext()
     return (
       <div
@@ -655,7 +650,6 @@ export const ComboboxList = React.forwardRef<HTMLDivElement, ComboboxListProps>(
     )
   },
 )
-ComboboxList.displayName = 'ComboboxList'
 
 /* ─── ComboboxItem ─────────────────────────────────────────────── */
 
@@ -667,10 +661,10 @@ export interface ComboboxItemProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const ComboboxItem = React.forwardRef<HTMLDivElement, ComboboxItemProps>(
-  (
+  function ComboboxItem(
     { className, children, value: itemValue, disabled: itemDisabled = false, label, ...props },
     ref,
-  ) => {
+  ) {
     const ctx = useComboboxContext()
     const {
       value,
@@ -749,14 +743,13 @@ export const ComboboxItem = React.forwardRef<HTMLDivElement, ComboboxItemProps>(
     )
   },
 )
-ComboboxItem.displayName = 'ComboboxItem'
 
 /* ─── ComboboxEmpty ────────────────────────────────────────────── */
 
 export interface ComboboxEmptyProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const ComboboxEmpty = React.forwardRef<HTMLDivElement, ComboboxEmptyProps>(
-  ({ className, children, ...props }, ref) => {
+  function ComboboxEmpty({ className, children, ...props }, ref) {
     const ctx = useComboboxContext()
     const { contentRef, query, options, hasOptions, filter } = ctx
 
@@ -796,4 +789,3 @@ export const ComboboxEmpty = React.forwardRef<HTMLDivElement, ComboboxEmptyProps
     )
   },
 )
-ComboboxEmpty.displayName = 'ComboboxEmpty'

--- a/packages/react-command-input/src/command-input.tsx
+++ b/packages/react-command-input/src/command-input.tsx
@@ -16,7 +16,7 @@ export interface CommandInputProps extends Omit<HTMLAttributes<HTMLDivElement>, 
 }
 
 export const CommandInput = forwardRef<HTMLDivElement, CommandInputProps>(
-  (
+  function CommandInput(
     {
       value = '',
       onChange,
@@ -26,7 +26,7 @@ export const CommandInput = forwardRef<HTMLDivElement, CommandInputProps>(
       ...props
     },
     ref
-  ) => {
+  ) {
     const localRef = useRef<HTMLDivElement>(null);
     const containerRef = (ref || localRef) as RefObject<HTMLDivElement>;
     
@@ -100,5 +100,3 @@ export const CommandInput = forwardRef<HTMLDivElement, CommandInputProps>(
     );
   }
 );
-
-CommandInput.displayName = 'CommandInput';

--- a/packages/react-command/src/command.tsx
+++ b/packages/react-command/src/command.tsx
@@ -157,8 +157,6 @@ export function Command({
   )
 }
 
-Command.displayName = 'Command'
-
 // ---------------------------------------------------------------------------
 // CommandInput
 // ---------------------------------------------------------------------------
@@ -166,7 +164,7 @@ Command.displayName = 'Command'
 export interface CommandInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 export const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
-  ({ className, onChange, ...props }, ref) => {
+  function CommandInput({ className, onChange, ...props }, ref) {
     const { search, onSearch, inputId, listId } = useCommandContext()
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -189,8 +187,6 @@ export const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps
   },
 )
 
-CommandInput.displayName = 'CommandInput'
-
 // ---------------------------------------------------------------------------
 // CommandList
 // ---------------------------------------------------------------------------
@@ -198,7 +194,7 @@ CommandInput.displayName = 'CommandInput'
 export interface CommandListProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const CommandList = React.forwardRef<HTMLDivElement, CommandListProps>(
-  ({ className, children, ...props }, ref) => {
+  function CommandList({ className, children, ...props }, ref) {
     const { listId } = useCommandContext()
 
     return React.createElement(
@@ -216,8 +212,6 @@ export const CommandList = React.forwardRef<HTMLDivElement, CommandListProps>(
   },
 )
 
-CommandList.displayName = 'CommandList'
-
 // ---------------------------------------------------------------------------
 // CommandEmpty
 // ---------------------------------------------------------------------------
@@ -225,7 +219,7 @@ CommandList.displayName = 'CommandList'
 export interface CommandEmptyProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const CommandEmpty = React.forwardRef<HTMLDivElement, CommandEmptyProps>(
-  ({ className, children, ...props }, ref) => {
+  function CommandEmpty({ className, children, ...props }, ref) {
     const { filteredItems } = useCommandContext()
 
     if (filteredItems.length > 0) return null
@@ -243,8 +237,6 @@ export const CommandEmpty = React.forwardRef<HTMLDivElement, CommandEmptyProps>(
   },
 )
 
-CommandEmpty.displayName = 'CommandEmpty'
-
 // ---------------------------------------------------------------------------
 // CommandGroup
 // ---------------------------------------------------------------------------
@@ -254,7 +246,7 @@ export interface CommandGroupProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const CommandGroup = React.forwardRef<HTMLDivElement, CommandGroupProps>(
-  ({ className, heading, children, ...props }, ref) => {
+  function CommandGroup({ className, heading, children, ...props }, ref) {
     return React.createElement(
       'div',
       {
@@ -276,8 +268,6 @@ export const CommandGroup = React.forwardRef<HTMLDivElement, CommandGroupProps>(
   },
 )
 
-CommandGroup.displayName = 'CommandGroup'
-
 // ---------------------------------------------------------------------------
 // CommandItem
 // ---------------------------------------------------------------------------
@@ -289,7 +279,7 @@ export interface CommandItemProps extends Omit<React.HTMLAttributes<HTMLDivEleme
 }
 
 export const CommandItem = React.forwardRef<HTMLDivElement, CommandItemProps>(
-  ({ className, value, disabled, onSelect: onItemSelect, children, ...props }, ref) => {
+  function CommandItem({ className, value, disabled, onSelect: onItemSelect, children, ...props }, ref) {
     const state = disabled ? 'disabled' : 'default'
 
     return React.createElement(
@@ -313,8 +303,6 @@ export const CommandItem = React.forwardRef<HTMLDivElement, CommandItemProps>(
   },
 )
 
-CommandItem.displayName = 'CommandItem'
-
 // ---------------------------------------------------------------------------
 // CommandSeparator
 // ---------------------------------------------------------------------------
@@ -322,7 +310,7 @@ CommandItem.displayName = 'CommandItem'
 export interface CommandSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const CommandSeparator = React.forwardRef<HTMLDivElement, CommandSeparatorProps>(
-  ({ className, ...props }, ref) => {
+  function CommandSeparator({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       role: 'separator',
@@ -331,5 +319,3 @@ export const CommandSeparator = React.forwardRef<HTMLDivElement, CommandSeparato
     })
   },
 )
-
-CommandSeparator.displayName = 'CommandSeparator'

--- a/packages/react-composer/src/composer.tsx
+++ b/packages/react-composer/src/composer.tsx
@@ -288,7 +288,7 @@ function IconSmiley() {
  * textarea; the core is reachable through `apiRef`.
  */
 export const RefractionComposer = React.forwardRef<HTMLTextAreaElement, RefractionComposerProps>(
-  (
+  function RefractionComposer(
     {
       value: valueProp,
       defaultValue,
@@ -335,7 +335,7 @@ export const RefractionComposer = React.forwardRef<HTMLTextAreaElement, Refracti
       ...rest
     },
     forwardedRef,
-  ) => {
+  ) {
     const strings = React.useMemo(
       () => ({ ...DEFAULT_COMPOSER_STRINGS, ...stringsProp }),
       [stringsProp],
@@ -1099,5 +1099,3 @@ export const RefractionComposer = React.forwardRef<HTMLTextAreaElement, Refracti
     )
   },
 )
-
-RefractionComposer.displayName = 'RefractionComposer'

--- a/packages/react-content-protection/src/content-protection.tsx
+++ b/packages/react-content-protection/src/content-protection.tsx
@@ -25,7 +25,7 @@ export interface ContentProtectionProps extends React.HTMLAttributes<HTMLDivElem
  * Uses the headless @refraction-ui/content-protection core for event handlers.
  */
 export const ContentProtection = React.forwardRef<HTMLDivElement, ContentProtectionProps>(
-  (
+  function ContentProtection(
     {
       enabled,
       disableCopy,
@@ -36,7 +36,7 @@ export const ContentProtection = React.forwardRef<HTMLDivElement, ContentProtect
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createContentProtection({
       enabled,
       disableCopy,
@@ -104,5 +104,3 @@ export const ContentProtection = React.forwardRef<HTMLDivElement, ContentProtect
     )
   },
 )
-
-ContentProtection.displayName = 'ContentProtection'

--- a/packages/react-conversation/src/chat.tsx
+++ b/packages/react-conversation/src/chat.tsx
@@ -419,7 +419,7 @@ function ModeToggle({ conversation }: { conversation: UseConversationResult }) {
  * with `/` commands, `@` mentions, `:` emoji, and a formatting toolbar.
  */
 export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
-  ({ conversation, showConversationList = true, showModeToggle = true, placeholder, currentUserId, emptyState, className, slashCommands, mentions, onSlashCommand, composerToolbar = true }: ChatProps, ref) => {
+  function Chat({ conversation, showConversationList = true, showModeToggle = true, placeholder, currentUserId, emptyState, className, slashCommands, mentions, onSlashCommand, composerToolbar = true }: ChatProps, ref) {
   const { state, sendMessage } = conversation
   const timeline = selectMainTimeline(state.messages, state.threadingMode)
   const activeConv = state.conversations.find((c) => c.id === state.activeConversationId)
@@ -496,5 +496,3 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
   )
   },
 )
-
-Chat.displayName = 'Chat'

--- a/packages/react-conversation/src/composer.tsx
+++ b/packages/react-conversation/src/composer.tsx
@@ -160,7 +160,7 @@ function detectTrigger(text: string, caret: number): TriggerState | null {
  * and `/` command, `@` mention, and `:` emoji autocomplete menus.
  */
 export const Composer = React.forwardRef<HTMLDivElement, ComposerProps>(
-  ({ placeholder = 'Send a message…', busy = false, slashCommands = [], mentions, toolbar = true, emoji = true, attachments = true, error, onRetry, onSubmit, onStop, onSlashCommand, autoFocus }: ComposerProps, ref) => {
+  function Composer({ placeholder = 'Send a message…', busy = false, slashCommands = [], mentions, toolbar = true, emoji = true, attachments = true, error, onRetry, onSubmit, onStop, onSlashCommand, autoFocus }: ComposerProps, ref) {
   const [value, setValue] = React.useState('')
   const [pending, setPending] = React.useState<MessageAttachment[]>([])
   const [trigger, setTrigger] = React.useState<TriggerState | null>(null)
@@ -489,5 +489,3 @@ export const Composer = React.forwardRef<HTMLDivElement, ComposerProps>(
   )
   },
 )
-
-Composer.displayName = 'Composer'

--- a/packages/react-cookie-consent/src/cookie-consent.tsx
+++ b/packages/react-cookie-consent/src/cookie-consent.tsx
@@ -76,7 +76,7 @@ function CookieIcon() {
  * Renders nothing once the user has consented.
  */
 export const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps>(
-  ({
+  function CookieConsent({
     consent,
     position = 'bottom',
     title = 'We use cookies',
@@ -84,7 +84,7 @@ export const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps
     policyUrl,
     policyLabel = 'Cookie policy',
     className,
-  }: CookieConsentProps, ref) => {
+  }: CookieConsentProps, ref) {
   const { state, acceptAll, rejectAll, savePreferences, setPreference } = consent
   const [settings, setSettings] = React.useState(false)
 
@@ -175,5 +175,3 @@ export const CookieConsent = React.forwardRef<HTMLDivElement, CookieConsentProps
   )
   },
 )
-
-CookieConsent.displayName = 'CookieConsent'

--- a/packages/react-data-table/src/DataTable.tsx
+++ b/packages/react-data-table/src/DataTable.tsx
@@ -181,5 +181,3 @@ export function DataTable<T = Record<string, unknown>>({
     )
   )
 }
-
-DataTable.displayName = 'DataTable'

--- a/packages/react-date-picker/src/date-picker.tsx
+++ b/packages/react-date-picker/src/date-picker.tsx
@@ -14,7 +14,7 @@ export interface DatePickerProps extends Omit<React.InputHTMLAttributes<HTMLInpu
 }
 
 export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
-  ({ value, onChange, minDate, maxDate, showTime = false, format, placeholder, className, disabled = false, ...props }, ref) => {
+  function DatePicker({ value, onChange, minDate, maxDate, showTime = false, format, placeholder, className, disabled = false, ...props }, ref) {
 
     // Native date inputs expect YYYY-MM-DD or YYYY-MM-DDTHH:mm
     const dateToString = (date?: Date) => {
@@ -63,5 +63,3 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     )
   }
 )
-
-DatePicker.displayName = 'DatePicker'

--- a/packages/react-device-frame/src/device-frame.tsx
+++ b/packages/react-device-frame/src/device-frame.tsx
@@ -20,7 +20,7 @@ export interface DeviceFrameProps {
 }
 
 export const DeviceFrame = React.forwardRef<HTMLDivElement, DeviceFrameProps>(
-  ({ device, orientation = 'portrait', className, children }, ref) => {
+  function DeviceFrame({ device, orientation = 'portrait', className, children }, ref) {
   const api = createDeviceFrame({ device, orientation })
 
   return React.createElement(
@@ -63,5 +63,3 @@ export const DeviceFrame = React.forwardRef<HTMLDivElement, DeviceFrameProps>(
   )
   },
 )
-
-DeviceFrame.displayName = 'DeviceFrame'

--- a/packages/react-dialog/src/dialog.tsx
+++ b/packages/react-dialog/src/dialog.tsx
@@ -90,8 +90,6 @@ export function Dialog({
   return React.createElement(DialogContext.Provider, { value: ctx }, children)
 }
 
-Dialog.displayName = 'Dialog'
-
 // ---------------------------------------------------------------------------
 // DialogTrigger
 // ---------------------------------------------------------------------------
@@ -101,7 +99,7 @@ export interface DialogTriggerProps extends React.ButtonHTMLAttributes<HTMLButto
 }
 
 export const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function DialogTrigger({ onClick, children, ...props }, ref) {
     const { open, onOpenChange, contentId } = useDialogContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -125,8 +123,6 @@ export const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerPr
   },
 )
 
-DialogTrigger.displayName = 'DialogTrigger'
-
 // ---------------------------------------------------------------------------
 // DialogOverlay
 // ---------------------------------------------------------------------------
@@ -134,7 +130,7 @@ DialogTrigger.displayName = 'DialogTrigger'
 export interface DialogOverlayProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps>(
-  ({ className, onClick, ...props }, ref) => {
+  function DialogOverlay({ className, onClick, ...props }, ref) {
     const { open, onOpenChange } = useDialogContext()
 
     if (!open) return null
@@ -157,8 +153,6 @@ export const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps
   },
 )
 
-DialogOverlay.displayName = 'DialogOverlay'
-
 // ---------------------------------------------------------------------------
 // DialogContent
 // ---------------------------------------------------------------------------
@@ -166,7 +160,7 @@ DialogOverlay.displayName = 'DialogOverlay'
 export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
-  ({ className, children, onKeyDown, ...props }, ref) => {
+  function DialogContent({ className, children, onKeyDown, ...props }, ref) {
     const { open, onOpenChange, modal, contentId, titleId, descriptionId } =
       useDialogContext()
 
@@ -215,8 +209,6 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
   },
 )
 
-DialogContent.displayName = 'DialogContent'
-
 // ---------------------------------------------------------------------------
 // DialogHeader
 // ---------------------------------------------------------------------------
@@ -224,7 +216,7 @@ DialogContent.displayName = 'DialogContent'
 export interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
-  ({ className, ...props }, ref) => {
+  function DialogHeader({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       className: cn('flex flex-col space-y-1.5 text-center sm:text-left', className),
@@ -233,8 +225,6 @@ export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
   },
 )
 
-DialogHeader.displayName = 'DialogHeader'
-
 // ---------------------------------------------------------------------------
 // DialogFooter
 // ---------------------------------------------------------------------------
@@ -242,7 +232,7 @@ DialogHeader.displayName = 'DialogHeader'
 export interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
-  ({ className, ...props }, ref) => {
+  function DialogFooter({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       className: cn(
@@ -254,8 +244,6 @@ export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
   },
 )
 
-DialogFooter.displayName = 'DialogFooter'
-
 // ---------------------------------------------------------------------------
 // DialogTitle
 // ---------------------------------------------------------------------------
@@ -263,7 +251,7 @@ DialogFooter.displayName = 'DialogFooter'
 export interface DialogTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
 
 export const DialogTitle = React.forwardRef<HTMLHeadingElement, DialogTitleProps>(
-  ({ className, ...props }, ref) => {
+  function DialogTitle({ className, ...props }, ref) {
     const { titleId } = useDialogContext()
 
     return React.createElement('h2', {
@@ -275,8 +263,6 @@ export const DialogTitle = React.forwardRef<HTMLHeadingElement, DialogTitleProps
   },
 )
 
-DialogTitle.displayName = 'DialogTitle'
-
 // ---------------------------------------------------------------------------
 // DialogDescription
 // ---------------------------------------------------------------------------
@@ -286,7 +272,7 @@ export interface DialogDescriptionProps extends React.HTMLAttributes<HTMLParagra
 export const DialogDescription = React.forwardRef<
   HTMLParagraphElement,
   DialogDescriptionProps
->(({ className, ...props }, ref) => {
+>(function DialogDescription({ className, ...props }, ref) {
   const { descriptionId } = useDialogContext()
 
   return React.createElement('p', {
@@ -297,8 +283,6 @@ export const DialogDescription = React.forwardRef<
   })
 })
 
-DialogDescription.displayName = 'DialogDescription'
-
 // ---------------------------------------------------------------------------
 // DialogClose
 // ---------------------------------------------------------------------------
@@ -306,7 +290,7 @@ DialogDescription.displayName = 'DialogDescription'
 export interface DialogCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function DialogClose({ onClick, children, ...props }, ref) {
     const { onOpenChange } = useDialogContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -326,5 +310,3 @@ export const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>
     )
   },
 )
-
-DialogClose.displayName = 'DialogClose'

--- a/packages/react-dialog/src/radix-adapter.tsx
+++ b/packages/react-dialog/src/radix-adapter.tsx
@@ -16,36 +16,33 @@ export function Dialog(props: DialogProps) {
   return React.createElement(RadixDialog.Root, props)
 }
 
-Dialog.displayName = 'Dialog'
-
 export interface DialogTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean
 }
 
 export const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
-  (props, ref) => React.createElement(RadixDialog.Trigger, { ...props, ref })
+  function DialogTrigger(props, ref) {
+    return React.createElement(RadixDialog.Trigger, { ...props, ref })
+  }
 )
-
-DialogTrigger.displayName = 'DialogTrigger'
 
 export interface DialogOverlayProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps>(
-  ({ className, ...props }, ref) =>
-    React.createElement(RadixDialog.Overlay, {
+  function DialogOverlay({ className, ...props }, ref) {
+    return React.createElement(RadixDialog.Overlay, {
       className: cn(overlayStyles, className),
       ...props,
       ref,
     })
+  }
 )
-
-DialogOverlay.displayName = 'DialogOverlay'
 
 export interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
-  ({ className, children, ...props }, ref) =>
-    React.createElement(
+  function DialogContent({ className, children, ...props }, ref) {
+    return React.createElement(
       RadixDialog.Portal,
       null,
       React.createElement(
@@ -58,28 +55,26 @@ export const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps
         children
       )
     )
+  }
 )
-
-DialogContent.displayName = 'DialogContent'
 
 export interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
-  ({ className, ...props }, ref) =>
-    React.createElement('div', {
+  function DialogHeader({ className, ...props }, ref) {
+    return React.createElement('div', {
       className: cn('flex flex-col space-y-1.5 text-center sm:text-left', className),
       ...props,
       ref,
     })
+  }
 )
-
-DialogHeader.displayName = 'DialogHeader'
 
 export interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
-  ({ className, ...props }, ref) =>
-    React.createElement('div', {
+  function DialogFooter({ className, ...props }, ref) {
+    return React.createElement('div', {
       className: cn(
         'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
         className
@@ -87,40 +82,37 @@ export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
       ...props,
       ref,
     })
+  }
 )
-
-DialogFooter.displayName = 'DialogFooter'
 
 export interface DialogTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
 
 export const DialogTitle = React.forwardRef<HTMLHeadingElement, DialogTitleProps>(
-  ({ className, ...props }, ref) =>
-    React.createElement(RadixDialog.Title, {
+  function DialogTitle({ className, ...props }, ref) {
+    return React.createElement(RadixDialog.Title, {
       className: cn('text-lg font-semibold leading-none tracking-tight', className),
       ...props,
       ref,
     })
+  }
 )
-
-DialogTitle.displayName = 'DialogTitle'
 
 export interface DialogDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 export const DialogDescription = React.forwardRef<HTMLParagraphElement, DialogDescriptionProps>(
-  ({ className, ...props }, ref) =>
-    React.createElement(RadixDialog.Description, {
+  function DialogDescription({ className, ...props }, ref) {
+    return React.createElement(RadixDialog.Description, {
       className: cn('text-sm text-muted-foreground', className),
       ...props,
       ref,
     })
+  }
 )
-
-DialogDescription.displayName = 'DialogDescription'
 
 export interface DialogCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
-  (props, ref) => React.createElement(RadixDialog.Close, { ...props, ref })
+  function DialogClose(props, ref) {
+    return React.createElement(RadixDialog.Close, { ...props, ref })
+  }
 )
-
-DialogClose.displayName = 'DialogClose'

--- a/packages/react-diff-viewer/src/DiffViewer.tsx
+++ b/packages/react-diff-viewer/src/DiffViewer.tsx
@@ -69,7 +69,7 @@ const MonacoDiffEditor = React.lazy(() =>
 // ---------------------------------------------------------------------------
 
 export const DiffViewer = React.forwardRef<HTMLDivElement, DiffViewerProps>(
-  (
+  function DiffViewer(
     {
       files,
       original = '',
@@ -91,7 +91,7 @@ export const DiffViewer = React.forwardRef<HTMLDivElement, DiffViewerProps>(
       editorOptions,
     },
     ref,
-  ) => {
+  ) {
     const [activeIdx, setActiveIdx] = React.useState(controlledIndex)
     const [sidebarOpen, setSidebarOpen] = React.useState(showSidebar)
     const [viewMode, setViewMode] = React.useState<DiffViewMode>(controlledViewMode)
@@ -276,5 +276,3 @@ export const DiffViewer = React.forwardRef<HTMLDivElement, DiffViewerProps>(
     )
   },
 )
-
-DiffViewer.displayName = 'DiffViewer'

--- a/packages/react-dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/react-dropdown-menu/src/dropdown-menu.tsx
@@ -83,8 +83,6 @@ export function DropdownMenu({
   return React.createElement(DropdownMenuContext.Provider, { value: ctx }, children)
 }
 
-DropdownMenu.displayName = 'DropdownMenu'
-
 // ---------------------------------------------------------------------------
 // DropdownMenuTrigger
 // ---------------------------------------------------------------------------
@@ -98,7 +96,7 @@ export interface DropdownMenuTriggerProps extends React.ButtonHTMLAttributes<HTM
 }
 
 export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, DropdownMenuTriggerProps>(
-  ({ asChild = false, onClick, children, ...props }, ref) => {
+  function DropdownMenuTrigger({ asChild = false, onClick, children, ...props }, ref) {
     const { open, onOpenChange, contentId } = useDropdownMenuContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -151,8 +149,6 @@ export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, DropdownM
   },
 )
 
-DropdownMenuTrigger.displayName = 'DropdownMenuTrigger'
-
 // ---------------------------------------------------------------------------
 // DropdownMenuContent
 // ---------------------------------------------------------------------------
@@ -160,7 +156,7 @@ DropdownMenuTrigger.displayName = 'DropdownMenuTrigger'
 export interface DropdownMenuContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenuContentProps>(
-  ({ className, children, onKeyDown, ...props }, ref) => {
+  function DropdownMenuContent({ className, children, onKeyDown, ...props }, ref) {
     const { open, onOpenChange, contentId } = useDropdownMenuContext()
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -201,8 +197,6 @@ export const DropdownMenuContent = React.forwardRef<HTMLDivElement, DropdownMenu
   },
 )
 
-DropdownMenuContent.displayName = 'DropdownMenuContent'
-
 // ---------------------------------------------------------------------------
 // DropdownMenuItem
 // ---------------------------------------------------------------------------
@@ -213,7 +207,7 @@ export interface DropdownMenuItemProps extends Omit<React.HTMLAttributes<HTMLDiv
 }
 
 export const DropdownMenuItem = React.forwardRef<HTMLDivElement, DropdownMenuItemProps>(
-  ({ className, disabled, onSelect, onClick, children, ...props }, ref) => {
+  function DropdownMenuItem({ className, disabled, onSelect, onClick, children, ...props }, ref) {
     const { onOpenChange } = useDropdownMenuContext()
 
     const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -250,8 +244,6 @@ export const DropdownMenuItem = React.forwardRef<HTMLDivElement, DropdownMenuIte
   },
 )
 
-DropdownMenuItem.displayName = 'DropdownMenuItem'
-
 // ---------------------------------------------------------------------------
 // DropdownMenuSeparator
 // ---------------------------------------------------------------------------
@@ -259,7 +251,7 @@ DropdownMenuItem.displayName = 'DropdownMenuItem'
 export interface DropdownMenuSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DropdownMenuSeparator = React.forwardRef<HTMLDivElement, DropdownMenuSeparatorProps>(
-  ({ className, ...props }, ref) => {
+  function DropdownMenuSeparator({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       role: 'separator',
@@ -269,8 +261,6 @@ export const DropdownMenuSeparator = React.forwardRef<HTMLDivElement, DropdownMe
   },
 )
 
-DropdownMenuSeparator.displayName = 'DropdownMenuSeparator'
-
 // ---------------------------------------------------------------------------
 // DropdownMenuLabel
 // ---------------------------------------------------------------------------
@@ -278,7 +268,7 @@ DropdownMenuSeparator.displayName = 'DropdownMenuSeparator'
 export interface DropdownMenuLabelProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const DropdownMenuLabel = React.forwardRef<HTMLDivElement, DropdownMenuLabelProps>(
-  ({ className, ...props }, ref) => {
+  function DropdownMenuLabel({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       className: cn('px-2 py-1.5 text-sm font-semibold', className),
@@ -286,5 +276,3 @@ export const DropdownMenuLabel = React.forwardRef<HTMLDivElement, DropdownMenuLa
     })
   },
 )
-
-DropdownMenuLabel.displayName = 'DropdownMenuLabel'

--- a/packages/react-editor-status-bar/src/editor-status-bar.tsx
+++ b/packages/react-editor-status-bar/src/editor-status-bar.tsx
@@ -100,7 +100,7 @@ export const EditorStatusBar = React.forwardRef<
   HTMLDivElement,
   EditorStatusBarProps
 >(
-  (
+  function EditorStatusBar(
     {
       segments: segmentsProp,
       line,
@@ -114,7 +114,7 @@ export const EditorStatusBar = React.forwardRef<
       ...props
     },
     ref,
-  ) => {
+  ) {
     const segments = segmentsProp ?? buildSegmentsFromConvenienceProps({
       line,
       col,
@@ -160,5 +160,3 @@ export const EditorStatusBar = React.forwardRef<
     )
   },
 )
-
-EditorStatusBar.displayName = 'EditorStatusBar'

--- a/packages/react-editor-tabs/src/editor-tabs.tsx
+++ b/packages/react-editor-tabs/src/editor-tabs.tsx
@@ -34,7 +34,7 @@ export interface EditorTabsProps
  * headless `@refraction-ui/editor-tabs` core helper.
  */
 export const EditorTabs = React.forwardRef<HTMLDivElement, EditorTabsProps>(
-  ({ tabs, activeId, onSelect, onClose, className, ...props }, ref) => {
+  function EditorTabs({ tabs, activeId, onSelect, onClose, className, ...props }, ref) {
     const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([])
 
     const activeIndex = tabs.findIndex((t) => t.id === activeId)
@@ -122,5 +122,3 @@ export const EditorTabs = React.forwardRef<HTMLDivElement, EditorTabsProps>(
     )
   },
 )
-
-EditorTabs.displayName = 'EditorTabs'

--- a/packages/react-emoji-picker/src/emoji-picker.tsx
+++ b/packages/react-emoji-picker/src/emoji-picker.tsx
@@ -111,7 +111,7 @@ export interface EmojiPickerProps {
 const RECENT_LIMIT = 20
 
 export const EmojiPicker = React.forwardRef<HTMLDivElement, EmojiPickerProps>(
-  ({ onSelect, onStickerSelect, recentEmojis: initialRecent = [], className, emojiRenderer, twemojiBaseUrl, stickerSets = [STARTER_STICKER_SET], stickerRenderer = defaultStickerRenderer }: EmojiPickerProps, ref) => {
+  function EmojiPicker({ onSelect, onStickerSelect, recentEmojis: initialRecent = [], className, emojiRenderer, twemojiBaseUrl, stickerSets = [STARTER_STICKER_SET], stickerRenderer = defaultStickerRenderer }: EmojiPickerProps, ref) {
   const [search, setSearch] = React.useState('')
   const [activeCategory, setActiveCategory] = React.useState<EmojiCategory>('smileys')
   const [mode, setMode] = React.useState<'emoji' | 'sticker'>('emoji')
@@ -300,5 +300,3 @@ function StickerPanel({
     </div>
   )
 }
-
-EmojiPicker.displayName = 'EmojiPicker'

--- a/packages/react-empty-state/src/empty-state.tsx
+++ b/packages/react-empty-state/src/empty-state.tsx
@@ -37,7 +37,7 @@ export interface EmptyStateProps
  * core (no inline class literals here).
  */
 export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
-  (
+  function EmptyState(
     {
       icon,
       tone = 'neutral',
@@ -49,7 +49,7 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createEmptyState({ tone })
 
     return (
@@ -79,8 +79,6 @@ export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
   },
 )
 
-EmptyState.displayName = 'EmptyState'
-
 export interface ConfirmationCardProps extends EmptyStateProps {}
 
 /**
@@ -90,8 +88,8 @@ export interface ConfirmationCardProps extends EmptyStateProps {}
 export const ConfirmationCard = React.forwardRef<
   HTMLDivElement,
   ConfirmationCardProps
->(({ bordered = true, ...props }, ref) => (
-  <EmptyState ref={ref} bordered={bordered} {...props} />
-))
-
-ConfirmationCard.displayName = 'ConfirmationCard'
+>(function ConfirmationCard({ bordered = true, ...props }, ref) {
+    return (
+    <EmptyState ref={ref} bordered={bordered} {...props} />
+  )
+  })

--- a/packages/react-feedback-dialog/src/FeedbackDialog.tsx
+++ b/packages/react-feedback-dialog/src/FeedbackDialog.tsx
@@ -193,8 +193,6 @@ export function FeedbackDialog({
   )
 }
 
-FeedbackDialog.displayName = 'FeedbackDialog'
-
 // ---------------------------------------------------------------------------
 // FeedbackButton
 // ---------------------------------------------------------------------------
@@ -204,7 +202,7 @@ export interface FeedbackButtonProps extends React.ButtonHTMLAttributes<HTMLButt
 }
 
 export const FeedbackButton = React.forwardRef<HTMLButtonElement, FeedbackButtonProps>(
-  ({ children, ...props }, ref) => {
+  function FeedbackButton({ children, ...props }, ref) {
     return React.createElement(
       'button',
       {
@@ -217,5 +215,3 @@ export const FeedbackButton = React.forwardRef<HTMLButtonElement, FeedbackButton
     )
   },
 )
-
-FeedbackButton.displayName = 'FeedbackButton'

--- a/packages/react-file-tree/src/react-file-tree.tsx
+++ b/packages/react-file-tree/src/react-file-tree.tsx
@@ -118,7 +118,7 @@ function TreeItems({ nodes, depth, api, state, firstVisibleId }: TreeItemsProps)
  * `selectedId`) and uncontrolled usage.
  */
 export const FileTree = React.forwardRef<HTMLDivElement, FileTreeProps>(
-  (
+  function FileTree(
     {
       className,
       nodes = [],
@@ -132,7 +132,7 @@ export const FileTree = React.forwardRef<HTMLDivElement, FileTreeProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     // The headless core owns expansion/selection/focus; it is created once and
     // props are synced into it below.
     const apiRef = React.useRef<FileTreeAPI | null>(null)
@@ -190,4 +190,3 @@ export const FileTree = React.forwardRef<HTMLDivElement, FileTreeProps>(
     )
   },
 )
-FileTree.displayName = 'FileTree'

--- a/packages/react-file-upload/src/file-upload.tsx
+++ b/packages/react-file-upload/src/file-upload.tsx
@@ -25,7 +25,7 @@ export interface FileUploadProps {
 }
 
 export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
-  ({ accept, maxSize, maxFiles, multiple = false, onFilesSelected, onError, className, children }, ref) => {
+  function FileUpload({ accept, maxSize, maxFiles, multiple = false, onFilesSelected, onError, className, children }, ref) {
   const [files, setFiles] = React.useState<FileEntry[]>([])
   const [isDragging, setIsDragging] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -207,5 +207,3 @@ export const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
   )
   },
 )
-
-FileUpload.displayName = 'FileUpload'

--- a/packages/react-floating-reactions/src/floating-reactions.tsx
+++ b/packages/react-floating-reactions/src/floating-reactions.tsx
@@ -41,7 +41,7 @@ export interface FloatingReactionsProps
 export const FloatingReactions = React.forwardRef<
   HTMLDivElement,
   FloatingReactionsProps
->(({ reactions, lanes = 5, className, ...props }, ref) => {
+>(function FloatingReactions({ reactions, lanes = 5, className, ...props }, ref) {
   const { ariaProps, dataAttributes } = createFloatingReactions()
 
   return (
@@ -69,8 +69,6 @@ export const FloatingReactions = React.forwardRef<
     </div>
   )
 })
-
-FloatingReactions.displayName = 'FloatingReactions'
 
 // ---------------------------------------------------------------------------
 // ReactionBurst — convenience alias for a single burst item (for story use).

--- a/packages/react-flow-editor/src/flow-editor.tsx
+++ b/packages/react-flow-editor/src/flow-editor.tsx
@@ -50,7 +50,7 @@ export interface FlowEditorProps
  * Node drag is kept deliberately simple (pointer events, no external dep).
  */
 export const FlowEditor = React.forwardRef<HTMLDivElement, FlowEditorProps>(
-  (
+  function FlowEditor(
     {
       nodes,
       edges,
@@ -64,7 +64,7 @@ export const FlowEditor = React.forwardRef<HTMLDivElement, FlowEditorProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createFlowEditor()
 
     // Track pointer-drag state without triggering re-renders mid-drag.
@@ -185,5 +185,3 @@ export const FlowEditor = React.forwardRef<HTMLDivElement, FlowEditorProps>(
     )
   },
 )
-
-FlowEditor.displayName = 'FlowEditor'

--- a/packages/react-footer/src/footer.tsx
+++ b/packages/react-footer/src/footer.tsx
@@ -22,7 +22,7 @@ export interface FooterProps extends React.HTMLAttributes<HTMLElement> {
  * Uses the headless @refraction-ui/footer core for state and ARIA attributes.
  */
 export const Footer = React.forwardRef<HTMLElement, FooterProps>(
-  (
+  function Footer(
     {
       copyright,
       socialLinks = [],
@@ -31,7 +31,7 @@ export const Footer = React.forwardRef<HTMLElement, FooterProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createFooter({ copyright, socialLinks, columns })
     const classes = cn(footerVariants(), className)
 
@@ -81,5 +81,3 @@ export const Footer = React.forwardRef<HTMLElement, FooterProps>(
     )
   },
 )
-
-Footer.displayName = 'Footer'

--- a/packages/react-form/src/form.tsx
+++ b/packages/react-form/src/form.tsx
@@ -133,7 +133,7 @@ const formItemVariants = cva({ base: 'space-y-2' })
 interface FormItemProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
-  ({ className, ...props }, ref) => {
+  function FormItem({ className, ...props }, ref) {
     const id = React.useId()
     return (
       <FormItemContext.Provider value={{ id }}>
@@ -142,7 +142,6 @@ const FormItem = React.forwardRef<HTMLDivElement, FormItemProps>(
     )
   },
 )
-FormItem.displayName = 'FormItem'
 
 // -----------------------------------------------------------------------------
 // FormLabel
@@ -164,7 +163,7 @@ const formLabelVariants = cva({
 interface FormLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
 
 const FormLabel = React.forwardRef<HTMLLabelElement, FormLabelProps>(
-  ({ className, ...props }, ref) => {
+  function FormLabel({ className, ...props }, ref) {
     const { invalid, formItemId } = useFormField()
     return (
       <label
@@ -177,7 +176,6 @@ const FormLabel = React.forwardRef<HTMLLabelElement, FormLabelProps>(
     )
   },
 )
-FormLabel.displayName = 'FormLabel'
 
 // -----------------------------------------------------------------------------
 // FormControl — Slot that injects id/aria-describedby/aria-invalid.
@@ -188,7 +186,7 @@ interface FormControlProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 const FormControl = React.forwardRef<HTMLElement, FormControlProps>(
-  ({ ...props }, ref) => {
+  function FormControl({ ...props }, ref) {
     const { invalid, formItemId, formDescriptionId, formMessageId } =
       useFormField()
     return (
@@ -206,7 +204,6 @@ const FormControl = React.forwardRef<HTMLElement, FormControlProps>(
     )
   },
 )
-FormControl.displayName = 'FormControl'
 
 // -----------------------------------------------------------------------------
 // FormDescription
@@ -218,7 +215,7 @@ interface FormDescriptionProps
 const FormDescription = React.forwardRef<
   HTMLParagraphElement,
   FormDescriptionProps
->(({ className, ...props }, ref) => {
+>(function FormDescription({ className, ...props }, ref) {
   const { formDescriptionId } = useFormField()
   return (
     <p
@@ -229,7 +226,6 @@ const FormDescription = React.forwardRef<
     />
   )
 })
-FormDescription.displayName = 'FormDescription'
 
 // -----------------------------------------------------------------------------
 // FormMessage
@@ -238,7 +234,7 @@ FormDescription.displayName = 'FormDescription'
 interface FormMessageProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 const FormMessage = React.forwardRef<HTMLParagraphElement, FormMessageProps>(
-  ({ className, children, ...props }, ref) => {
+  function FormMessage({ className, children, ...props }, ref) {
     const { error, formMessageId } = useFormField()
     const body = error?.message ? String(error.message) : children
     if (!body) return null
@@ -254,7 +250,6 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, FormMessageProps>(
     )
   },
 )
-FormMessage.displayName = 'FormMessage'
 
 export {
   Form,

--- a/packages/react-form/src/slot.tsx
+++ b/packages/react-form/src/slot.tsx
@@ -54,8 +54,6 @@ export const Slot = React.forwardRef<HTMLElement, SlotProps>(function Slot(
   )
 })
 
-Slot.displayName = 'Slot'
-
 function mergeProps(
   slotProps: Record<string, unknown>,
   childProps: Record<string, unknown>,

--- a/packages/react-graph-view/src/graph-view.tsx
+++ b/packages/react-graph-view/src/graph-view.tsx
@@ -50,7 +50,7 @@ export interface GraphViewProps
  * but never mutates the `nodes` array — the caller owns the data.
  */
 export const GraphView = React.forwardRef<HTMLDivElement, GraphViewProps>(
-  ({ nodes, edges, onNodeClick, showLegend = false, className, ...props }, ref) => {
+  function GraphView({ nodes, edges, onNodeClick, showLegend = false, className, ...props }, ref) {
     const api = createGraphView()
     const summary = React.useMemo(() => summarizeStates(nodes), [nodes])
 
@@ -143,5 +143,3 @@ export const GraphView = React.forwardRef<HTMLDivElement, GraphViewProps>(
     )
   },
 )
-
-GraphView.displayName = 'GraphView'

--- a/packages/react-infinite-canvas/src/infinite-canvas.tsx
+++ b/packages/react-infinite-canvas/src/infinite-canvas.tsx
@@ -51,7 +51,7 @@ export interface InfiniteCanvasProps
  * pointer handlers are registered after mount so they are SSR-safe.
  */
 export const InfiniteCanvas = React.forwardRef<HTMLDivElement, InfiniteCanvasProps>(
-  (
+  function InfiniteCanvas(
     {
       zoom: zoomProp,
       x: xProp,
@@ -68,7 +68,7 @@ export const InfiniteCanvas = React.forwardRef<HTMLDivElement, InfiniteCanvasPro
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled =
       zoomProp !== undefined || xProp !== undefined || yProp !== undefined
 
@@ -241,5 +241,3 @@ export const InfiniteCanvas = React.forwardRef<HTMLDivElement, InfiniteCanvasPro
     )
   },
 )
-
-InfiniteCanvas.displayName = 'InfiniteCanvas'

--- a/packages/react-inline-editor/src/InlineEditor.tsx
+++ b/packages/react-inline-editor/src/InlineEditor.tsx
@@ -20,7 +20,7 @@ export interface InlineEditorProps {
 }
 
 export const InlineEditor = React.forwardRef<HTMLDivElement, InlineEditorProps>(
-  ({ value: initialValue, onSave, onCancel, className }, ref) => {
+  function InlineEditor({ value: initialValue, onSave, onCancel, className }, ref) {
   const [isEditing, setIsEditing] = React.useState(false)
   const [editValue, setEditValue] = React.useState(initialValue)
 
@@ -137,5 +137,3 @@ export const InlineEditor = React.forwardRef<HTMLDivElement, InlineEditorProps>(
   )
   },
 )
-
-InlineEditor.displayName = 'InlineEditor'

--- a/packages/react-input-group/src/input-group.tsx
+++ b/packages/react-input-group/src/input-group.tsx
@@ -17,7 +17,7 @@ export interface InputGroupProps extends React.HTMLAttributes<HTMLDivElement> {
  * Handles border-radius clipping on first/last children.
  */
 export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
-  ({ orientation = 'horizontal', className, children, ...props }, ref) => {
+  function InputGroup({ orientation = 'horizontal', className, children, ...props }, ref) {
     const api = createInputGroup({
       orientation,
       id: props.id,
@@ -39,8 +39,6 @@ export const InputGroup = React.forwardRef<HTMLDivElement, InputGroupProps>(
   },
 )
 
-InputGroup.displayName = 'InputGroup'
-
 export interface InputGroupAddonProps extends React.HTMLAttributes<HTMLDivElement> {
   orientation?: InputGroupOrientation
 }
@@ -49,7 +47,7 @@ export interface InputGroupAddonProps extends React.HTMLAttributes<HTMLDivElemen
  * InputGroupAddon — decorative text or icon addon (e.g., "$", "@", icons).
  */
 export const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonProps>(
-  ({ orientation = 'horizontal', className, children, ...props }, ref) => {
+  function InputGroupAddon({ orientation = 'horizontal', className, children, ...props }, ref) {
     return (
       <div
         ref={ref}
@@ -62,15 +60,13 @@ export const InputGroupAddon = React.forwardRef<HTMLDivElement, InputGroupAddonP
   },
 )
 
-InputGroupAddon.displayName = 'InputGroupAddon'
-
 export interface InputGroupTextProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 /**
  * InputGroupText — inline text label within an input group.
  */
 export const InputGroupText = React.forwardRef<HTMLSpanElement, InputGroupTextProps>(
-  ({ className, children, ...props }, ref) => {
+  function InputGroupText({ className, children, ...props }, ref) {
     return (
       <span
         ref={ref}
@@ -83,8 +79,6 @@ export const InputGroupText = React.forwardRef<HTMLSpanElement, InputGroupTextPr
   },
 )
 
-InputGroupText.displayName = 'InputGroupText'
-
 export interface InputGroupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   orientation?: InputGroupOrientation
 }
@@ -93,7 +87,7 @@ export interface InputGroupButtonProps extends React.ButtonHTMLAttributes<HTMLBu
  * InputGroupButton — a button styled to sit flush inside an input group.
  */
 export const InputGroupButton = React.forwardRef<HTMLButtonElement, InputGroupButtonProps>(
-  ({ orientation = 'horizontal', className, children, ...props }, ref) => {
+  function InputGroupButton({ orientation = 'horizontal', className, children, ...props }, ref) {
     return (
       <button
         ref={ref}
@@ -106,5 +100,3 @@ export const InputGroupButton = React.forwardRef<HTMLButtonElement, InputGroupBu
     )
   },
 )
-
-InputGroupButton.displayName = 'InputGroupButton'

--- a/packages/react-input/src/input.tsx
+++ b/packages/react-input/src/input.tsx
@@ -63,7 +63,7 @@ const CheckIcon = (
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (
+  function Input(
     {
       type = 'text',
       size,
@@ -77,7 +77,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     // The core owns the `aria-invalid` derivation and the validation border
     // tokens; the React layer only does DOM composition (wrapper + icons).
     const api = createInput({
@@ -132,5 +132,3 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     )
   },
 )
-
-Input.displayName = 'Input'

--- a/packages/react-install-prompt/src/install-prompt.tsx
+++ b/packages/react-install-prompt/src/install-prompt.tsx
@@ -46,7 +46,7 @@ function createLocalStorage(): StorageAdapter {
  * Listens for the `beforeinstallprompt` browser event.
  */
 export const InstallPrompt = React.forwardRef<HTMLDivElement, InstallPromptProps>(
-  (
+  function InstallPrompt(
     {
       delay = 3000,
       storageKey,
@@ -57,7 +57,7 @@ export const InstallPrompt = React.forwardRef<HTMLDivElement, InstallPromptProps
       ...props
     },
     ref,
-  ) => {
+  ) {
     const storageRef = React.useRef<StorageAdapter | undefined>(undefined)
     if (typeof window !== 'undefined' && !storageRef.current) {
       storageRef.current = createLocalStorage()
@@ -121,5 +121,3 @@ export const InstallPrompt = React.forwardRef<HTMLDivElement, InstallPromptProps
     )
   },
 )
-
-InstallPrompt.displayName = 'InstallPrompt'

--- a/packages/react-kanban-board/src/kanban-board.tsx
+++ b/packages/react-kanban-board/src/kanban-board.tsx
@@ -38,7 +38,7 @@ export interface KanbanCardProps
  * an `onClick` handler for interaction. Children define the card content.
  */
 export const KanbanCard = React.forwardRef<HTMLDivElement, KanbanCardProps>(
-  ({ accent, clickable = false, className, style, children, ...props }, ref) => {
+  function KanbanCard({ accent, clickable = false, className, style, children, ...props }, ref) {
     const accentStyle: React.CSSProperties = accent
       ? { borderTopColor: accent, borderTopWidth: '2px', ...style }
       : (style ?? {})
@@ -58,7 +58,6 @@ export const KanbanCard = React.forwardRef<HTMLDivElement, KanbanCardProps>(
     )
   },
 )
-KanbanCard.displayName = 'KanbanCard'
 
 // ---------------------------------------------------------------------------
 // KanbanColumn
@@ -79,7 +78,7 @@ export interface KanbanColumnProps
  * `React.Children.count(children)` when `count` is not provided.
  */
 export const KanbanColumn = React.forwardRef<HTMLDivElement, KanbanColumnProps>(
-  ({ def, count, className, children, style, ...props }, ref) => {
+  function KanbanColumn({ def, count, className, children, style, ...props }, ref) {
     const derivedCount =
       count !== undefined ? count : React.Children.count(children)
 
@@ -122,7 +121,6 @@ export const KanbanColumn = React.forwardRef<HTMLDivElement, KanbanColumnProps>(
     )
   },
 )
-KanbanColumn.displayName = 'KanbanColumn'
 
 // ---------------------------------------------------------------------------
 // KanbanBoard

--- a/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
+++ b/packages/react-keyboard-shortcut/src/keyboard-shortcut.tsx
@@ -89,7 +89,7 @@ export interface ShortcutHintProps extends Omit<ShortcutBadgeProps, 'keys'> {
 }
 
 export const ShortcutHint = React.forwardRef<HTMLDivElement, ShortcutHintProps>(
-  ({ shortcut, action, className, platform = true, ...props }, ref) => {
+  function ShortcutHint({ shortcut, action, className, platform = true, ...props }, ref) {
   const showHints = React.useContext(ShortcutContext);
 
   const keys = React.useMemo(() => {
@@ -111,8 +111,6 @@ export const ShortcutHint = React.forwardRef<HTMLDivElement, ShortcutHintProps>(
   );
   },
 )
-
-ShortcutHint.displayName = 'ShortcutHint'
 
 export interface KeyboardShortcutProps {
   /** Key combination */
@@ -158,8 +156,6 @@ export function KeyboardShortcut({
   return null
 }
 
-KeyboardShortcut.displayName = 'KeyboardShortcut'
-
 // ---------------------------------------------------------------------------
 // ShortcutBadge — visual display of a keyboard shortcut (e.g., Ctrl+K)
 // ---------------------------------------------------------------------------
@@ -199,5 +195,3 @@ export function ShortcutBadge({ keys, platform = true, className }: ShortcutBadg
         ),
   )
 }
-
-ShortcutBadge.displayName = 'ShortcutBadge'

--- a/packages/react-language-selector/src/language-selector.tsx
+++ b/packages/react-language-selector/src/language-selector.tsx
@@ -49,7 +49,7 @@ export interface LanguageSelectorProps {
 }
 
 export const LanguageSelector = React.forwardRef<HTMLDivElement, LanguageSelectorProps>(
-  ({ value: controlledValue, onValueChange, options, multiple = false, placeholder = 'Select language...', className }: LanguageSelectorProps, ref) => {
+  function LanguageSelector({ value: controlledValue, onValueChange, options, multiple = false, placeholder = 'Select language...', className }: LanguageSelectorProps, ref) {
   const initialValues = Array.isArray(controlledValue)
     ? controlledValue
     : controlledValue
@@ -258,5 +258,3 @@ export const LanguageSelector = React.forwardRef<HTMLDivElement, LanguageSelecto
   )
   },
 )
-
-LanguageSelector.displayName = 'LanguageSelector'

--- a/packages/react-link-card/src/link-card.tsx
+++ b/packages/react-link-card/src/link-card.tsx
@@ -3,7 +3,7 @@ import { createLinkCard } from '@refraction-ui/link-card'
 import { cn } from '@refraction-ui/shared'
 
 export const LinkCard = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement>>(
-  ({ className, ...props }, ref) => {
+  function LinkCard({ className, ...props }, ref) {
     const api = createLinkCard(props)
     return (
       <a
@@ -15,4 +15,3 @@ export const LinkCard = React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttr
     )
   }
 )
-LinkCard.displayName = 'LinkCard'

--- a/packages/react-live-captions/src/live-captions.tsx
+++ b/packages/react-live-captions/src/live-captions.tsx
@@ -36,7 +36,7 @@ export interface LiveCaptionsProps
  * Logic and styles come from the headless `@refraction-ui/live-captions` core.
  */
 export const LiveCaptions = React.forwardRef<HTMLDivElement, LiveCaptionsProps>(
-  ({ cues, maxLines = 2, position = 'static', className, ...props }, ref) => {
+  function LiveCaptions({ cues, maxLines = 2, position = 'static', className, ...props }, ref) {
     const { ariaProps, dataAttributes } = createLiveCaptions()
     const shown = visibleCues(cues, maxLines)
 
@@ -69,5 +69,3 @@ export const LiveCaptions = React.forwardRef<HTMLDivElement, LiveCaptionsProps>(
     )
   },
 )
-
-LiveCaptions.displayName = 'LiveCaptions'

--- a/packages/react-live-cursors/src/live-cursors.tsx
+++ b/packages/react-live-cursors/src/live-cursors.tsx
@@ -89,7 +89,7 @@ export interface LiveCursorsProps
  * decorative presence indicators, not interactive elements.
  */
 export const LiveCursors = React.forwardRef<HTMLDivElement, LiveCursorsProps>(
-  ({ cursors, className, ...props }, ref) => {
+  function LiveCursors({ cursors, className, ...props }, ref) {
     const api = createLiveCursors()
 
     return (
@@ -113,5 +113,3 @@ export const LiveCursors = React.forwardRef<HTMLDivElement, LiveCursorsProps>(
     )
   },
 )
-
-LiveCursors.displayName = 'LiveCursors'

--- a/packages/react-live-transcript/src/live-transcript.tsx
+++ b/packages/react-live-transcript/src/live-transcript.tsx
@@ -34,7 +34,7 @@ export interface LiveTranscriptProps
 export const LiveTranscript = React.forwardRef<
   HTMLDivElement,
   LiveTranscriptProps
->(({ entries, compact = false, className, ...props }, ref) => {
+>(function LiveTranscript({ entries, compact = false, className, ...props }, ref) {
   const api = createLiveTranscript()
   const blocks = React.useMemo(
     () => groupConsecutiveBySpeaker(entries),
@@ -79,5 +79,3 @@ export const LiveTranscript = React.forwardRef<
     </div>
   )
 })
-
-LiveTranscript.displayName = 'LiveTranscript'

--- a/packages/react-location-selector/src/location-selector.tsx
+++ b/packages/react-location-selector/src/location-selector.tsx
@@ -11,7 +11,7 @@ export interface LocationSelectorProps {
 }
 
 export const LocationSelector = React.forwardRef<HTMLDivElement, LocationSelectorProps>(
-  ({ defaultCountry = 'US', defaultLanguage = 'en', onCountryChange, onLanguageChange, className }, ref) => {
+  function LocationSelector({ defaultCountry = 'US', defaultLanguage = 'en', onCountryChange, onLanguageChange, className }, ref) {
   const [country, setCountry] = React.useState(defaultCountry)
   const [language, setLanguage] = React.useState(defaultLanguage)
 
@@ -84,5 +84,3 @@ export const LocationSelector = React.forwardRef<HTMLDivElement, LocationSelecto
   )
   },
 )
-
-LocationSelector.displayName = 'LocationSelector'

--- a/packages/react-markdown-renderer/src/MarkdownRenderer.tsx
+++ b/packages/react-markdown-renderer/src/MarkdownRenderer.tsx
@@ -46,7 +46,7 @@ function sanitizeHtml(html: string): string {
  * XSS sanitization is applied before rendering via dangerouslySetInnerHTML.
  */
 export const MarkdownRenderer = React.forwardRef<HTMLDivElement, MarkdownRendererProps>(
-  ({ content, components, linkResolver, className, size }, ref) => {
+  function MarkdownRenderer({ content, components, linkResolver, className, size }, ref) {
     const coreProps: CoreProps = { content, components, linkResolver }
     const api = createMarkdownRenderer(coreProps)
     const classes = cn(proseVariants({ size }), className)
@@ -62,5 +62,3 @@ export const MarkdownRenderer = React.forwardRef<HTMLDivElement, MarkdownRendere
     )
   },
 )
-
-MarkdownRenderer.displayName = 'MarkdownRenderer'

--- a/packages/react-marquee-strip/src/marquee-strip.tsx
+++ b/packages/react-marquee-strip/src/marquee-strip.tsx
@@ -41,7 +41,7 @@ export interface MarqueeStripProps
  * data attributes come from the headless `@refraction-ui/marquee-strip` core.
  */
 export const MarqueeStrip = React.forwardRef<HTMLDivElement, MarqueeStripProps>(
-  ({ label, items, scroll = false, className, ...props }, ref) => {
+  function MarqueeStrip({ label, items, scroll = false, className, ...props }, ref) {
     const api = createMarqueeStrip({ scroll })
 
     return (
@@ -78,5 +78,3 @@ export const MarqueeStrip = React.forwardRef<HTMLDivElement, MarqueeStripProps>(
     )
   },
 )
-
-MarqueeStrip.displayName = 'MarqueeStrip'

--- a/packages/react-mascot/src/mascot.tsx
+++ b/packages/react-mascot/src/mascot.tsx
@@ -36,7 +36,7 @@ export interface MascotProps extends Omit<React.SVGProps<SVGSVGElement>, 'size'>
  * States and theme styling are driven by the headless core `@refraction-ui/mascot`.
  */
 export const Mascot = React.forwardRef<SVGSVGElement, MascotProps>(
-  (
+  function Mascot(
     {
       mood = 'happy',
       animation = 'none',
@@ -50,7 +50,7 @@ export const Mascot = React.forwardRef<SVGSVGElement, MascotProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const [isBlinking, setIsBlinking] = React.useState(false)
 
     const shouldBob = animateBobbing ?? animate
@@ -339,5 +339,3 @@ export const Mascot = React.forwardRef<SVGSVGElement, MascotProps>(
     )
   },
 )
-
-Mascot.displayName = 'Mascot'

--- a/packages/react-mastery-bar/src/mastery-bar.tsx
+++ b/packages/react-mastery-bar/src/mastery-bar.tsx
@@ -35,7 +35,7 @@ export interface MasteryBarProps
  * and styles come from the headless `@refraction-ui/mastery-bar` core.
  */
 export const MasteryBar = React.forwardRef<HTMLDivElement, MasteryBarProps>(
-  (
+  function MasteryBar(
     {
       value,
       label,
@@ -46,7 +46,7 @@ export const MasteryBar = React.forwardRef<HTMLDivElement, MasteryBarProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const clamped = clampPercent(value)
     const { ariaProps, dataAttributes } = createMasteryBar({ value })
     const hasHeader = leadingLabel != null || label != null
@@ -77,5 +77,3 @@ export const MasteryBar = React.forwardRef<HTMLDivElement, MasteryBarProps>(
     )
   },
 )
-
-MasteryBar.displayName = 'MasteryBar'

--- a/packages/react-meta/package.json
+++ b/packages/react-meta/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && cp src/styles.css dist/styles.css && node ./scripts/embed-internal-types.mjs && node ./scripts/ensure-use-client.mjs",
+    "build": "tsup && node ./scripts/build-esm-split.mjs && cp src/styles.css dist/styles.css && node ./scripts/embed-internal-types.mjs && node ./scripts/ensure-use-client.mjs",
     "dev": "tsup --watch",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",

--- a/packages/react-meta/scripts/build-esm-split.mjs
+++ b/packages/react-meta/scripts/build-esm-split.mjs
@@ -82,6 +82,7 @@ const result = await esbuild.build({
   external: ['react', 'react-dom', 'react/jsx-runtime', 'react-hook-form'],
   sourcemap: true,
   target: 'es2022',
+  metafile: true,
   logLevel: 'warning',
 })
 if (result.errors.length > 0) {

--- a/packages/react-meta/scripts/build-esm-split.mjs
+++ b/packages/react-meta/scripts/build-esm-split.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * build-esm-split.mjs — module-granular ESM build for `@refraction-ui/react`.
+ *
+ * Why this exists (tree-shaking):
+ * tsup collapses all ~128 private react-* adapters into ONE dist/index.js.
+ * That single module is full of impure top-level calls (`React.forwardRef`,
+ * `cva`, `createContext`, …), and bundlers cannot drop unused impure
+ * statements *within* a module — `sideEffects: false` only works at module
+ * granularity. Result: `import { Button } from '@refraction-ui/react'`
+ * bundled the entire library (~500 kB minified).
+ *
+ * This script emits the ESM build as one module per adapter
+ * (dist/react-button.js, …) with shared headless cores auto-split into
+ * chunks, then generates dist/index.js as pure re-export statements (the
+ * exact export surface of src/index.ts, types stripped). Unused adapter
+ * modules never enter a consumer's module graph, so `sideEffects: false`
+ * tree-shakes them away — importing a single component now costs ~8 kB.
+ *
+ * The CJS build (dist/index.cjs) intentionally stays a single bundled file
+ * (require() graphs are not tree-shaken), and d.ts emission is unchanged —
+ * both still come from tsup.
+ *
+ * Runs AFTER `tsup` in the package build script (tsup `clean`s dist first,
+ * and the adapter dists it depends on are built earlier by the turbo graph).
+ */
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireFromMeta = createRequire(join(pkgDir, 'package.json'))
+const ts = requireFromMeta('typescript')
+// esbuild is not a direct dep of this package; borrow tsup's instance.
+const requireFromTsup = createRequire(requireFromMeta.resolve('tsup'))
+const esbuild = requireFromTsup('esbuild')
+
+const srcFile = join(pkgDir, 'src', 'index.ts')
+const distDir = join(pkgDir, 'dist')
+
+// 1. Strip types from the source export surface (pure re-export module).
+//    removeComments: dist must not carry the src doc comments (the meta
+//    regression test asserts the built entry contains no 'react-hook-form'
+//    string — the comments mention it; bundling used to strip them).
+const srcText = readFileSync(srcFile, 'utf8')
+let jsText = ts.transpileModule(srcText, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+    removeComments: true,
+  },
+}).outputText
+
+// 2. Collect every adapter specifier (`export … from '@refraction-ui/react-x'`).
+const SPECIFIER = /from\s+['"]@refraction-ui\/(react-[a-z0-9-]+)['"]/g
+const shortNames = [...new Set([...jsText.matchAll(SPECIFIER)].map((m) => m[1]))].sort()
+if (shortNames.length < 100) {
+  throw new Error(`expected 100+ adapter specifiers in src/index.ts, found ${shortNames.length}`)
+}
+
+// 3. Bundle each adapter dist as an entry; shared deps split into chunks.
+const entryPoints = {}
+for (const short of shortNames) {
+  const adapterDist = join(pkgDir, '..', short, 'dist', 'index.js')
+  if (!existsSync(adapterDist)) {
+    throw new Error(`missing adapter build: ${adapterDist} (run turbo build first)`)
+  }
+  entryPoints[short] = adapterDist
+}
+
+const result = await esbuild.build({
+  entryPoints,
+  bundle: true,
+  splitting: true,
+  format: 'esm',
+  outdir: distDir,
+  entryNames: '[name]',
+  chunkNames: 'chunk-[hash]',
+  // Keep parity with the tsup build's externals (+ react/jsx-runtime, which
+  // the adapter dists import directly and tsup externalises automatically).
+  external: ['react', 'react-dom', 'react/jsx-runtime', 'react-hook-form'],
+  sourcemap: true,
+  target: 'es2022',
+  logLevel: 'warning',
+})
+if (result.errors.length > 0) {
+  throw new Error(`esbuild split build failed: ${result.errors.length} errors`)
+}
+
+// 4. Generate dist/index.js: the same export surface, pointing at the
+//    per-adapter modules. Kept as pure re-export statements so every
+//    unused module stays droppable by consumer bundlers. This overwrites
+//    tsup's single-file ESM bundle (kept in the tsup config only so d.ts
+//    output is unchanged); its now-stale sourcemap is removed.
+jsText = jsText.replace(SPECIFIER, (match, short) => match.replace(`@refraction-ui/${short}`, `./${short}.js`))
+writeFileSync(join(distDir, 'index.js'), jsText.endsWith('\n') ? jsText : jsText + '\n')
+if (existsSync(join(distDir, 'index.js.map'))) {
+  rmSync(join(distDir, 'index.js.map'))
+}
+
+console.log(
+  `[build-esm-split] wrote dist/index.js + ${shortNames.length} adapter entries, ` +
+    `${Object.keys(result.metafile?.outputs ?? {}).length} total output files`,
+)

--- a/packages/react-meta/tsup.config.ts
+++ b/packages/react-meta/tsup.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: ['src/index.ts', 'src/theme.ts', 'src/form.ts'],
-  format: ['esm', 'cjs'],
+// The root ESM build from tsup (a single bundled dist/index.js) defeats
+// tree-shaking (one module full of impure top-level `forwardRef`/`cva`
+// calls — bundlers can only drop whole modules). It is kept here only for
+// d.ts parity (tsup emits index.d.ts + index.d.cts); scripts/
+// build-esm-split.mjs then OVERWRITES dist/index.js with the
+// module-granular ESM build. The CJS root build stays bundled (require()
+// graphs are not tree-shaken).
+const shared = {
   dts: true,
   sourcemap: true,
-  clean: true,
   treeshake: true,
   // RSC: the `'use client'` directive lives at the top of each source entry
   // (src/index.ts, src/theme.ts, src/form.ts), NOT here as an esbuild
@@ -17,4 +21,20 @@ export default defineConfig({
   // Only external deps (React and RHF for the form subpath) remain as peer deps.
   noExternal: [/@refraction-ui\//],
   external: ['react', 'react-dom', 'react-hook-form'],
-})
+} as const
+
+export default defineConfig([
+  {
+    ...shared,
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    clean: true,
+  },
+  {
+    ...shared,
+    entry: ['src/theme.ts', 'src/form.ts'],
+    format: ['esm', 'cjs'],
+    // Never clean here — it would wipe the root build from the first config.
+    clean: false,
+  },
+])

--- a/packages/react-mini-map/src/mini-map.tsx
+++ b/packages/react-mini-map/src/mini-map.tsx
@@ -46,7 +46,7 @@ export interface MiniMapProps
  * and rendering. SSR-safe (no `Math.random` or `Date.now`).
  */
 export const MiniMap = React.forwardRef<HTMLDivElement, MiniMapProps>(
-  (
+  function MiniMap(
     {
       items,
       viewport,
@@ -58,7 +58,7 @@ export const MiniMap = React.forwardRef<HTMLDivElement, MiniMapProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const containerRef = React.useRef<HTMLDivElement | null>(null)
     const isDragging = React.useRef(false)
 
@@ -181,5 +181,3 @@ export const MiniMap = React.forwardRef<HTMLDivElement, MiniMapProps>(
     )
   },
 )
-
-MiniMap.displayName = 'MiniMap'

--- a/packages/react-mobile-nav/src/mobile-nav.tsx
+++ b/packages/react-mobile-nav/src/mobile-nav.tsx
@@ -47,7 +47,7 @@ export interface MobileNavProps extends React.HTMLAttributes<HTMLElement> {
  * Supports both controlled (open + onOpenChange) and uncontrolled (defaultOpen) usage.
  */
 export const MobileNav = React.forwardRef<HTMLElement, MobileNavProps>(
-  ({ open: controlledOpen, onOpenChange, defaultOpen = false, className, children, ...props }, ref) => {
+  function MobileNav({ open: controlledOpen, onOpenChange, defaultOpen = false, className, children, ...props }, ref) {
     const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen)
     const isControlled = controlledOpen !== undefined
     const open = isControlled ? controlledOpen : uncontrolledOpen
@@ -89,8 +89,6 @@ export const MobileNav = React.forwardRef<HTMLElement, MobileNavProps>(
   },
 )
 
-MobileNav.displayName = 'MobileNav'
-
 /* ------------------------------------------------------------------ */
 /*  MobileNavTrigger                                                   */
 /* ------------------------------------------------------------------ */
@@ -101,7 +99,7 @@ export interface MobileNavTriggerProps extends React.ButtonHTMLAttributes<HTMLBu
  * MobileNavTrigger — hamburger button that toggles the mobile nav.
  */
 export const MobileNavTrigger = React.forwardRef<HTMLButtonElement, MobileNavTriggerProps>(
-  ({ className, children, ...props }, ref) => {
+  function MobileNavTrigger({ className, children, ...props }, ref) {
     const { open, setOpen, contentId } = useMobileNavContext()
 
     return (
@@ -146,8 +144,6 @@ export const MobileNavTrigger = React.forwardRef<HTMLButtonElement, MobileNavTri
   },
 )
 
-MobileNavTrigger.displayName = 'MobileNavTrigger'
-
 /* ------------------------------------------------------------------ */
 /*  MobileNavContent                                                   */
 /* ------------------------------------------------------------------ */
@@ -158,7 +154,7 @@ export interface MobileNavContentProps extends React.HTMLAttributes<HTMLDivEleme
  * MobileNavContent — the collapsible dropdown panel that holds nav links.
  */
 export const MobileNavContent = React.forwardRef<HTMLDivElement, MobileNavContentProps>(
-  ({ className, children, ...props }, ref) => {
+  function MobileNavContent({ className, children, ...props }, ref) {
     const { open, contentId } = useMobileNavContext()
     const state = open ? 'open' : 'closed'
 
@@ -177,8 +173,6 @@ export const MobileNavContent = React.forwardRef<HTMLDivElement, MobileNavConten
   },
 )
 
-MobileNavContent.displayName = 'MobileNavContent'
-
 /* ------------------------------------------------------------------ */
 /*  MobileNavLink                                                      */
 /* ------------------------------------------------------------------ */
@@ -189,7 +183,7 @@ export interface MobileNavLinkProps extends React.AnchorHTMLAttributes<HTMLAncho
  * MobileNavLink — a styled link inside the mobile nav dropdown.
  */
 export const MobileNavLink = React.forwardRef<HTMLAnchorElement, MobileNavLinkProps>(
-  ({ className, children, ...props }, ref) => {
+  function MobileNavLink({ className, children, ...props }, ref) {
     return (
       <a
         ref={ref}
@@ -202,5 +196,3 @@ export const MobileNavLink = React.forwardRef<HTMLAnchorElement, MobileNavLinkPr
     )
   },
 )
-
-MobileNavLink.displayName = 'MobileNavLink'

--- a/packages/react-navbar/src/navbar.tsx
+++ b/packages/react-navbar/src/navbar.tsx
@@ -28,7 +28,7 @@ export interface NavbarProps extends React.HTMLAttributes<HTMLElement> {
  * Hidden on mobile (links use md:flex).
  */
 export const Navbar = React.forwardRef<HTMLElement, NavbarProps>(
-  (
+  function Navbar(
     {
       links = [],
       currentPath,
@@ -39,7 +39,7 @@ export const Navbar = React.forwardRef<HTMLElement, NavbarProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createNavbar({ links, currentPath, variant })
     const classes = cn(navbarVariants({ variant }), className)
 
@@ -71,5 +71,3 @@ export const Navbar = React.forwardRef<HTMLElement, NavbarProps>(
     )
   },
 )
-
-Navbar.displayName = 'Navbar'

--- a/packages/react-numbered-steps/src/numbered-steps.tsx
+++ b/packages/react-numbered-steps/src/numbered-steps.tsx
@@ -36,7 +36,7 @@ export interface NumberedStepsProps
 export const NumberedSteps = React.forwardRef<
   HTMLDivElement,
   NumberedStepsProps
->(({ items, columns, className, ...props }, ref) => {
+>(function NumberedSteps({ items, columns, className, ...props }, ref) {
   const cols = columns ?? stepColumns(items.length)
   const { ariaProps, dataAttributes } = createNumberedSteps()
 
@@ -61,5 +61,3 @@ export const NumberedSteps = React.forwardRef<
     </div>
   )
 })
-
-NumberedSteps.displayName = 'NumberedSteps'

--- a/packages/react-otp-input/src/otp-input.tsx
+++ b/packages/react-otp-input/src/otp-input.tsx
@@ -23,7 +23,7 @@ export interface OtpInputProps extends Omit<React.HTMLAttributes<HTMLDivElement>
  * Features: auto-advance on type, backspace navigation, paste support, numeric/text mode.
  */
 export const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
-  ({
+  function OtpInput({
     length = 6,
     value = '',
     onChange,
@@ -33,7 +33,7 @@ export const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
     size = 'default',
     className,
     ...props
-  }, ref) => {
+  }, ref) {
     const inputRefs = React.useRef<(HTMLInputElement | null)[]>([])
     const [focusedIndex, setFocusedIndex] = React.useState(autoFocus ? 0 : -1)
     const [values, setValues] = React.useState<string[]>(() =>
@@ -169,5 +169,3 @@ export const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
     )
   },
 )
-
-OtpInput.displayName = 'OtpInput'

--- a/packages/react-pagination/src/pagination.tsx
+++ b/packages/react-pagination/src/pagination.tsx
@@ -33,7 +33,7 @@ export interface PaginationProps
  * controls instead of the generated ones.
  */
 export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
-  (
+  function Pagination(
     {
       className,
       page: controlledPage,
@@ -46,7 +46,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = controlledPage !== undefined
     const [internalPage, setInternalPage] = React.useState(defaultPage ?? 1)
 
@@ -121,4 +121,3 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
     )
   },
 )
-Pagination.displayName = 'Pagination'

--- a/packages/react-password-input/src/password-input.tsx
+++ b/packages/react-password-input/src/password-input.tsx
@@ -59,7 +59,7 @@ const EyeOffIcon = (
  * to the underlying element, including the `ref`.
  */
 export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
-  ({ revealLabel = 'Show password', hideLabel = 'Hide password', className, ...props }, ref) => {
+  function PasswordInput({ revealLabel = 'Show password', hideLabel = 'Hide password', className, ...props }, ref) {
     const [revealed, setRevealed] = React.useState(false)
 
     // The core owns the type/label/pressed derivation; React owns the toggle state.
@@ -90,5 +90,3 @@ export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputPro
     )
   },
 )
-
-PasswordInput.displayName = 'PasswordInput'

--- a/packages/react-payment/src/payment.tsx
+++ b/packages/react-payment/src/payment.tsx
@@ -7,7 +7,7 @@ export interface PaymentProps extends React.HTMLAttributes<HTMLDivElement>, Core
 }
 
 export const Payment = React.forwardRef<HTMLDivElement, PaymentProps>(
-  ({ className, disabled, ...props }, ref) => {
+  function Payment({ className, disabled, ...props }, ref) {
     const api = createPayment({ disabled });
 
     return (
@@ -24,65 +24,70 @@ export const Payment = React.forwardRef<HTMLDivElement, PaymentProps>(
     );
   }
 );
-Payment.displayName = 'Payment';
 
 export interface PaymentHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const PaymentHeader = React.forwardRef<HTMLDivElement, PaymentHeaderProps>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("mb-6 flex flex-col gap-1.5", className)} {...props} />
-  )
+  function PaymentHeader({ className, ...props }, ref) {
+    return (
+      <div ref={ref} className={cn("mb-6 flex flex-col gap-1.5", className)} {...props} />
+    )
+  }
 );
-PaymentHeader.displayName = 'PaymentHeader';
 
 export interface PaymentTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
 
 export const PaymentTitle = React.forwardRef<HTMLHeadingElement, PaymentTitleProps>(
-  ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("text-xl font-semibold leading-none tracking-tight", className)} {...props} />
-  )
+  function PaymentTitle({ className, ...props }, ref) {
+    return (
+      <h3 ref={ref} className={cn("text-xl font-semibold leading-none tracking-tight", className)} {...props} />
+    )
+  }
 );
-PaymentTitle.displayName = 'PaymentTitle';
 
 export interface PaymentDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 export const PaymentDescription = React.forwardRef<HTMLParagraphElement, PaymentDescriptionProps>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
-  )
+  function PaymentDescription({ className, ...props }, ref) {
+    return (
+      <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+    )
+  }
 );
-PaymentDescription.displayName = 'PaymentDescription';
 
 export interface PaymentContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const PaymentContent = React.forwardRef<HTMLDivElement, PaymentContentProps>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-4", className)} {...props} />
-  )
+  function PaymentContent({ className, ...props }, ref) {
+    return (
+      <div ref={ref} className={cn("flex flex-col gap-4", className)} {...props} />
+    )
+  }
 );
-PaymentContent.displayName = 'PaymentContent';
 
 export interface PaymentFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const PaymentFooter = React.forwardRef<HTMLDivElement, PaymentFooterProps>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("mt-6 flex flex-col gap-3", className)} {...props} />
-  )
+  function PaymentFooter({ className, ...props }, ref) {
+    return (
+      <div ref={ref} className={cn("mt-6 flex flex-col gap-3", className)} {...props} />
+    )
+  }
 );
-PaymentFooter.displayName = 'PaymentFooter';
 
 export interface PaymentButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const PaymentButton = React.forwardRef<HTMLButtonElement, PaymentButtonProps>(
-  ({ className, ...props }, ref) => (
-    <button
-      ref={ref}
-      className={cn(
-        "inline-flex w-full items-center justify-center whitespace-nowrap rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
-        className
-      )}
-      {...props}
-    />
-  )
+  function PaymentButton({ className, ...props }, ref) {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex w-full items-center justify-center whitespace-nowrap rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
 );
-PaymentButton.displayName = 'PaymentButton';

--- a/packages/react-popover/src/popover.tsx
+++ b/packages/react-popover/src/popover.tsx
@@ -72,8 +72,6 @@ export function Popover({ open: controlledOpen, defaultOpen = false, onOpenChang
   return React.createElement(PopoverContext.Provider, { value: ctx }, children)
 }
 
-Popover.displayName = 'Popover'
-
 /* ------------------------------------------------------------------ */
 /*  PopoverTrigger                                                     */
 /* ------------------------------------------------------------------ */
@@ -81,7 +79,7 @@ Popover.displayName = 'Popover'
 export interface PopoverTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const PopoverTrigger = React.forwardRef<HTMLButtonElement, PopoverTriggerProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function PopoverTrigger({ onClick, children, ...props }, ref) {
     const { api, setOpen, open } = usePopoverContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -105,8 +103,6 @@ export const PopoverTrigger = React.forwardRef<HTMLButtonElement, PopoverTrigger
   },
 )
 
-PopoverTrigger.displayName = 'PopoverTrigger'
-
 /* ------------------------------------------------------------------ */
 /*  PopoverContent                                                     */
 /* ------------------------------------------------------------------ */
@@ -116,7 +112,7 @@ export interface PopoverContentProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
-  ({ side, className, children, onKeyDown, ...props }, ref) => {
+  function PopoverContent({ side, className, children, onKeyDown, ...props }, ref) {
     const { api, open, setOpen } = usePopoverContext()
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -149,8 +145,6 @@ export const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentPro
   },
 )
 
-PopoverContent.displayName = 'PopoverContent'
-
 /* ------------------------------------------------------------------ */
 /*  PopoverClose                                                       */
 /* ------------------------------------------------------------------ */
@@ -158,7 +152,7 @@ PopoverContent.displayName = 'PopoverContent'
 export interface PopoverCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const PopoverClose = React.forwardRef<HTMLButtonElement, PopoverCloseProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function PopoverClose({ onClick, children, ...props }, ref) {
     const { setOpen } = usePopoverContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -173,5 +167,3 @@ export const PopoverClose = React.forwardRef<HTMLButtonElement, PopoverCloseProp
     )
   },
 )
-
-PopoverClose.displayName = 'PopoverClose'

--- a/packages/react-pre-call-lobby/src/pre-call-lobby.tsx
+++ b/packages/react-pre-call-lobby/src/pre-call-lobby.tsx
@@ -64,7 +64,7 @@ export interface PreCallLobbyProps
  * All device controls are plain HTML elements — no external component deps.
  */
 export const PreCallLobby = React.forwardRef<HTMLDivElement, PreCallLobbyProps>(
-  (
+  function PreCallLobby(
     {
       cameraOn,
       micOn,
@@ -85,7 +85,7 @@ export const PreCallLobby = React.forwardRef<HTMLDivElement, PreCallLobbyProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createPreCallLobby({ cameraOn, micOn })
     const litBars = micLevelToBars(micLevel, MIC_BAR_COUNT)
 
@@ -300,5 +300,3 @@ export const PreCallLobby = React.forwardRef<HTMLDivElement, PreCallLobbyProps>(
     )
   },
 )
-
-PreCallLobby.displayName = 'PreCallLobby'

--- a/packages/react-presence-indicator/src/presence-indicator.tsx
+++ b/packages/react-presence-indicator/src/presence-indicator.tsx
@@ -17,7 +17,7 @@ export interface PresenceIndicatorProps {
 }
 
 export const PresenceIndicator = React.forwardRef<HTMLSpanElement, PresenceIndicatorProps>(
-  ({ status, showLabel = false, label, size = 'md', className }, ref) => {
+  function PresenceIndicator({ status, showLabel = false, label, size = 'md', className }, ref) {
   const api = createPresence({ status, showLabel, label })
 
   return React.createElement(
@@ -31,5 +31,3 @@ export const PresenceIndicator = React.forwardRef<HTMLSpanElement, PresenceIndic
   )
   },
 )
-
-PresenceIndicator.displayName = 'PresenceIndicator'

--- a/packages/react-pricing-card/src/pricing-card.tsx
+++ b/packages/react-pricing-card/src/pricing-card.tsx
@@ -53,7 +53,7 @@ export interface PricingCardProps
  * the headless `@refraction-ui/pricing-card` core.
  */
 export const PricingCard = React.forwardRef<HTMLDivElement, PricingCardProps>(
-  (
+  function PricingCard(
     {
       badge,
       name,
@@ -70,7 +70,7 @@ export const PricingCard = React.forwardRef<HTMLDivElement, PricingCardProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const { ariaProps, dataAttributes } = createPricingCard({ featured })
 
     return (
@@ -142,5 +142,3 @@ export const PricingCard = React.forwardRef<HTMLDivElement, PricingCardProps>(
     )
   },
 )
-
-PricingCard.displayName = 'PricingCard'

--- a/packages/react-progress-display/src/progress-display.tsx
+++ b/packages/react-progress-display/src/progress-display.tsx
@@ -21,7 +21,7 @@ export interface StatsGridProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const StatsGrid = React.forwardRef<HTMLDivElement, StatsGridProps>(
-  ({ stats, badges = [], className, ...props }, ref) => {
+  function StatsGrid({ stats, badges = [], className, ...props }, ref) {
     const api = createProgressDisplay({ stats, badges })
 
     return (
@@ -48,8 +48,6 @@ export const StatsGrid = React.forwardRef<HTMLDivElement, StatsGridProps>(
   },
 )
 
-StatsGrid.displayName = 'StatsGrid'
-
 /* ------------------------------------------------------------------ */
 /*  ProgressBar                                                        */
 /* ------------------------------------------------------------------ */
@@ -61,7 +59,7 @@ export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
-  ({ value, max = 100, size, className, ...props }, ref) => {
+  function ProgressBar({ value, max = 100, size, className, ...props }, ref) {
     const percent = Math.min(100, Math.max(0, (value / max) * 100))
 
     return (
@@ -83,8 +81,6 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   },
 )
 
-ProgressBar.displayName = 'ProgressBar'
-
 /* ------------------------------------------------------------------ */
 /*  BadgeDisplay                                                       */
 /* ------------------------------------------------------------------ */
@@ -94,7 +90,7 @@ export interface BadgeDisplayProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const BadgeDisplay = React.forwardRef<HTMLDivElement, BadgeDisplayProps>(
-  ({ badges, className, ...props }, ref) => {
+  function BadgeDisplay({ badges, className, ...props }, ref) {
     const api = createProgressDisplay({ stats: [], badges })
 
     return (
@@ -122,5 +118,3 @@ export const BadgeDisplay = React.forwardRef<HTMLDivElement, BadgeDisplayProps>(
     )
   },
 )
-
-BadgeDisplay.displayName = 'BadgeDisplay'

--- a/packages/react-radial-gauge/src/radial-gauge.tsx
+++ b/packages/react-radial-gauge/src/radial-gauge.tsx
@@ -60,7 +60,7 @@ export interface RadialGaugeProps extends React.SVGAttributes<SVGSVGElement> {
  * Accessibility: `role="meter"` with `aria-valuenow/min/max` on the SVG.
  */
 export const RadialGauge = React.forwardRef<SVGSVGElement, RadialGaugeProps>(
-  (
+  function RadialGauge(
     {
       value,
       min = 0,
@@ -75,7 +75,7 @@ export const RadialGauge = React.forwardRef<SVGSVGElement, RadialGaugeProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const diameter = GAUGE_SIZE_PX[size]
     const cx = diameter / 2
     const cy = diameter / 2
@@ -169,5 +169,3 @@ export const RadialGauge = React.forwardRef<SVGSVGElement, RadialGaugeProps>(
     )
   },
 )
-
-RadialGauge.displayName = 'RadialGauge'

--- a/packages/react-radio/src/radio.tsx
+++ b/packages/react-radio/src/radio.tsx
@@ -23,7 +23,7 @@ export interface RadioGroupProps extends CoreRadioGroupProps {
 }
 
 export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
-  ({ children, className, value: controlledValue, defaultValue, onValueChange, name, disabled = false, orientation = 'vertical' }: RadioGroupProps, ref) => {
+  function RadioGroup({ children, className, value: controlledValue, defaultValue, onValueChange, name, disabled = false, orientation = 'vertical' }: RadioGroupProps, ref) {
   const [internalValue, setInternalValue] = React.useState(defaultValue)
   const isControlled = controlledValue !== undefined
   const currentValue = isControlled ? controlledValue : internalValue
@@ -63,7 +63,7 @@ export interface RadioItemProps {
 }
 
 export const RadioItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(
-  ({ value, children, disabled = false, className }, ref) => {
+  function RadioItem({ value, children, disabled = false, className }, ref) {
   const ctx = React.useContext(RadioContext)
   if (!ctx) {
     devWarn(
@@ -105,6 +105,3 @@ export const RadioItem = React.forwardRef<HTMLLabelElement, RadioItemProps>(
   )
   },
 )
-
-RadioGroup.displayName = 'RadioGroup'
-RadioItem.displayName = 'RadioItem'

--- a/packages/react-rating-scale/src/rating-scale.tsx
+++ b/packages/react-rating-scale/src/rating-scale.tsx
@@ -48,7 +48,7 @@ export interface RatingScaleProps
  * come from the headless `@refraction-ui/rating-scale` core.
  */
 export const RatingScale = React.forwardRef<HTMLDivElement, RatingScaleProps>(
-  (
+  function RatingScale(
     {
       value: valueProp,
       defaultValue,
@@ -63,7 +63,7 @@ export const RatingScale = React.forwardRef<HTMLDivElement, RatingScaleProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const resolved = React.useMemo(
       () => resolveRatingPoints(points, count),
       [points, count],
@@ -149,5 +149,3 @@ export const RatingScale = React.forwardRef<HTMLDivElement, RatingScaleProps>(
     )
   },
 )
-
-RatingScale.displayName = 'RatingScale'

--- a/packages/react-reaction-bar/src/reaction-bar.tsx
+++ b/packages/react-reaction-bar/src/reaction-bar.tsx
@@ -19,7 +19,7 @@ export interface ReactionBarProps {
 }
 
 export const ReactionBar = React.forwardRef<HTMLDivElement, ReactionBarProps>(
-  ({ reactions, onToggle, onAdd, showAddButton = true, className }, ref) => {
+  function ReactionBar({ reactions, onToggle, onAdd, showAddButton = true, className }, ref) {
   const api = createReactionBar({ reactions, onToggle, onAdd })
 
   return React.createElement(
@@ -55,5 +55,3 @@ export const ReactionBar = React.forwardRef<HTMLDivElement, ReactionBarProps>(
   )
   },
 )
-
-ReactionBar.displayName = 'ReactionBar'

--- a/packages/react-resizable-layout/src/resizable-layout.tsx
+++ b/packages/react-resizable-layout/src/resizable-layout.tsx
@@ -53,7 +53,7 @@ export interface ResizableLayoutProps extends Omit<React.HTMLAttributes<HTMLDivE
  * Uses pointer events for cross-platform drag support.
  */
 export const ResizableLayout = React.forwardRef<HTMLDivElement, ResizableLayoutProps>(
-  (
+  function ResizableLayout(
     {
       orientation = 'horizontal',
       defaultSizes = [50, 50],
@@ -67,7 +67,7 @@ export const ResizableLayout = React.forwardRef<HTMLDivElement, ResizableLayoutP
       ...props
     },
     ref,
-  ) => {
+  ) {
     const apiRef = React.useRef<ResizableLayoutAPI | null>(null)
 
     if (!apiRef.current) {
@@ -120,8 +120,6 @@ export const ResizableLayout = React.forwardRef<HTMLDivElement, ResizableLayoutP
   },
 )
 
-ResizableLayout.displayName = 'ResizableLayout'
-
 /* ------------------------------------------------------------------ */
 /*  ResizablePane                                                      */
 /* ------------------------------------------------------------------ */
@@ -135,7 +133,7 @@ export interface ResizablePaneProps extends React.HTMLAttributes<HTMLDivElement>
  * ResizablePane — a single pane whose size is driven by CSS custom properties.
  */
 export const ResizablePane = React.forwardRef<HTMLDivElement, ResizablePaneProps>(
-  ({ index, className, style, children, ...props }, ref) => {
+  function ResizablePane({ index, className, style, children, ...props }, ref) {
     const { orientation, sizes } = useResizableLayoutContext()
     const size = sizes[index] ?? 50
 
@@ -160,8 +158,6 @@ export const ResizablePane = React.forwardRef<HTMLDivElement, ResizablePaneProps
   },
 )
 
-ResizablePane.displayName = 'ResizablePane'
-
 /* ------------------------------------------------------------------ */
 /*  ResizableDivider                                                   */
 /* ------------------------------------------------------------------ */
@@ -176,7 +172,7 @@ export interface ResizableDividerProps extends React.HTMLAttributes<HTMLDivEleme
  * Uses pointer events for cross-platform drag support (mouse + touch).
  */
 export const ResizableDivider = React.forwardRef<HTMLDivElement, ResizableDividerProps>(
-  ({ index, className, ...props }, ref) => {
+  function ResizableDivider({ index, className, ...props }, ref) {
     const { api, orientation, setSizes } = useResizableLayoutContext()
     const startPosRef = React.useRef<number>(0)
     const containerSizeRef = React.useRef<number>(0)
@@ -242,5 +238,3 @@ export const ResizableDivider = React.forwardRef<HTMLDivElement, ResizableDivide
     )
   },
 )
-
-ResizableDivider.displayName = 'ResizableDivider'

--- a/packages/react-search-bar/src/search-bar.tsx
+++ b/packages/react-search-bar/src/search-bar.tsx
@@ -48,7 +48,7 @@ export interface SearchBarProps extends Omit<React.InputHTMLAttributes<HTMLInput
 }
 
 export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
-  ({ value: controlledValue, defaultValue = '', onValueChange, onSearch, debounceMs = 300, loading = false, placeholder, className, children, ...inputProps }, ref) => {
+  function SearchBar({ value: controlledValue, defaultValue = '', onValueChange, onSearch, debounceMs = 300, loading = false, placeholder, className, children, ...inputProps }, ref) {
   const [internalValue, setInternalValue] = React.useState(controlledValue ?? defaultValue)
   const isControlled = controlledValue !== undefined
   const currentValue = isControlled ? controlledValue : internalValue
@@ -175,8 +175,6 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
   },
 )
 
-SearchBar.displayName = 'SearchBar'
-
 /* ------------------------------------------------------------------ */
 /*  SearchResults (dropdown list)                                      */
 /* ------------------------------------------------------------------ */
@@ -184,7 +182,7 @@ SearchBar.displayName = 'SearchBar'
 export interface SearchResultsProps extends React.HTMLAttributes<HTMLUListElement> {}
 
 export const SearchResults = React.forwardRef<HTMLUListElement, SearchResultsProps>(
-  ({ className, children, ...props }, ref) => {
+  function SearchResults({ className, children, ...props }, ref) {
     const { api, value } = useSearchBarContext()
 
     if (value.length === 0) return null
@@ -203,8 +201,6 @@ export const SearchResults = React.forwardRef<HTMLUListElement, SearchResultsPro
   },
 )
 
-SearchResults.displayName = 'SearchResults'
-
 /* ------------------------------------------------------------------ */
 /*  SearchResultItem                                                   */
 /* ------------------------------------------------------------------ */
@@ -212,7 +208,7 @@ SearchResults.displayName = 'SearchResults'
 export interface SearchResultItemProps extends React.LiHTMLAttributes<HTMLLIElement> {}
 
 export const SearchResultItem = React.forwardRef<HTMLLIElement, SearchResultItemProps>(
-  ({ className, children, ...props }, ref) => {
+  function SearchResultItem({ className, children, ...props }, ref) {
     return React.createElement(
       'li',
       {
@@ -225,5 +221,3 @@ export const SearchResultItem = React.forwardRef<HTMLLIElement, SearchResultItem
     )
   },
 )
-
-SearchResultItem.displayName = 'SearchResultItem'

--- a/packages/react-section-head/src/section-head.tsx
+++ b/packages/react-section-head/src/section-head.tsx
@@ -34,7 +34,7 @@ export interface SectionHeadProps
  * `@refraction-ui/section-head` core.
  */
 export const SectionHead = React.forwardRef<HTMLDivElement, SectionHeadProps>(
-  (
+  function SectionHead(
     {
       kicker,
       title,
@@ -45,7 +45,7 @@ export const SectionHead = React.forwardRef<HTMLDivElement, SectionHeadProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const { dataAttributes } = createSectionHead({ align })
 
     return (
@@ -66,5 +66,3 @@ export const SectionHead = React.forwardRef<HTMLDivElement, SectionHeadProps>(
     )
   },
 )
-
-SectionHead.displayName = 'SectionHead'

--- a/packages/react-segmented-control/src/segmented-control.tsx
+++ b/packages/react-segmented-control/src/segmented-control.tsx
@@ -64,7 +64,7 @@ export const SegmentedControl = React.forwardRef<
   HTMLDivElement,
   SegmentedControlProps
 >(
-  (
+  function SegmentedControl(
     {
       value: valueProp,
       defaultValue,
@@ -75,7 +75,7 @@ export const SegmentedControl = React.forwardRef<
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = valueProp !== undefined
     const [internalValue, setInternalValue] = React.useState<
       string | undefined
@@ -140,8 +140,6 @@ export const SegmentedControl = React.forwardRef<
   },
 )
 
-SegmentedControl.displayName = 'SegmentedControl'
-
 export interface SegmentedControlItemProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {
   /** Value identifying this item; selected when it matches the group value. */
@@ -158,7 +156,7 @@ export interface SegmentedControlItemProps
 export const SegmentedControlItem = React.forwardRef<
   HTMLButtonElement,
   SegmentedControlItemProps
->(({ value, className, children, onKeyDown, onClick, ...props }, ref) => {
+>(function SegmentedControlItem({ value, className, children, onKeyDown, onClick, ...props }, ref) {
   const ctx = useSegmentedControlContext('SegmentedControlItem')
   const selected = ctx.value === value
 
@@ -227,5 +225,3 @@ export const SegmentedControlItem = React.forwardRef<
     </button>
   )
 })
-
-SegmentedControlItem.displayName = 'SegmentedControlItem'

--- a/packages/react-select/src/select.tsx
+++ b/packages/react-select/src/select.tsx
@@ -120,7 +120,7 @@ export interface SelectTriggerProps extends React.ButtonHTMLAttributes<HTMLButto
 }
 
 export const SelectTrigger = React.forwardRef<HTMLButtonElement, SelectTriggerProps>(
-  ({ className, children, size = 'default', ...props }, ref) => {
+  function SelectTrigger({ className, children, size = 'default', ...props }, ref) {
     const { open, setOpen, disabled, triggerId, contentId } = useSelectContext('SelectTrigger')
 
     const api = createSelect({ disabled, open })
@@ -177,13 +177,12 @@ export const SelectTrigger = React.forwardRef<HTMLButtonElement, SelectTriggerPr
     )
   },
 )
-SelectTrigger.displayName = 'SelectTrigger'
 
 /* ─── SelectContent ────────────────────────────────────────────── */
 export interface SelectContentProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
-  ({ className, children, ...props }, forwardedRef) => {
+  function SelectContent({ className, children, ...props }, forwardedRef) {
     const { open, contentId, triggerId, setOpen } = useSelectContext('SelectContent')
     const containerRef = React.useRef<HTMLDivElement>(null)
 
@@ -254,7 +253,6 @@ export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps
     )
   },
 )
-SelectContent.displayName = 'SelectContent'
 
 /* ─── SelectItem ───────────────────────────────────────────────── */
 export interface SelectItemProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -263,7 +261,7 @@ export interface SelectItemProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
-  ({ className, children, value: itemValue, disabled: itemDisabled = false, ...props }, ref) => {
+  function SelectItem({ className, children, value: itemValue, disabled: itemDisabled = false, ...props }, ref) {
     const { value, onValueChange, setOpen, triggerId } = useSelectContext('SelectItem')
     const isSelected = value === itemValue
 
@@ -322,4 +320,3 @@ export const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
     )
   },
 )
-SelectItem.displayName = 'SelectItem'

--- a/packages/react-separator/src/separator.tsx
+++ b/packages/react-separator/src/separator.tsx
@@ -33,7 +33,7 @@ export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
  * via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
-  (
+  function Separator(
     {
       orientation = 'horizontal',
       label,
@@ -42,7 +42,7 @@ export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     // Labeled divider — decorative chrome wrapping a centered label.
     if (orientation === 'horizontal' && label != null) {
       return (
@@ -75,5 +75,3 @@ export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
     )
   },
 )
-
-Separator.displayName = 'Separator'

--- a/packages/react-sheet/src/sheet.tsx
+++ b/packages/react-sheet/src/sheet.tsx
@@ -127,8 +127,6 @@ export function Sheet({
   return React.createElement(SheetContext.Provider, { value: ctx }, children)
 }
 
-Sheet.displayName = 'Sheet'
-
 // ---------------------------------------------------------------------------
 // SheetTrigger
 // ---------------------------------------------------------------------------
@@ -136,7 +134,7 @@ Sheet.displayName = 'Sheet'
 export interface SheetTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const SheetTrigger = React.forwardRef<HTMLButtonElement, SheetTriggerProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function SheetTrigger({ onClick, children, ...props }, ref) {
     const { open, onOpenChange, contentId, triggerRef } = useSheetContext()
 
     const setRefs = React.useCallback(
@@ -172,8 +170,6 @@ export const SheetTrigger = React.forwardRef<HTMLButtonElement, SheetTriggerProp
   },
 )
 
-SheetTrigger.displayName = 'SheetTrigger'
-
 // ---------------------------------------------------------------------------
 // SheetOverlay
 // ---------------------------------------------------------------------------
@@ -181,7 +177,7 @@ SheetTrigger.displayName = 'SheetTrigger'
 export interface SheetOverlayProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const SheetOverlay = React.forwardRef<HTMLDivElement, SheetOverlayProps>(
-  ({ className, onClick, ...props }, ref) => {
+  function SheetOverlay({ className, onClick, ...props }, ref) {
     const { open, onOpenChange } = useSheetContext()
 
     if (!open) return null
@@ -203,8 +199,6 @@ export const SheetOverlay = React.forwardRef<HTMLDivElement, SheetOverlayProps>(
   },
 )
 
-SheetOverlay.displayName = 'SheetOverlay'
-
 // ---------------------------------------------------------------------------
 // SheetContent
 // ---------------------------------------------------------------------------
@@ -223,7 +217,7 @@ export interface SheetContentProps extends React.HTMLAttributes<HTMLDivElement> 
 }
 
 export const SheetContent = React.forwardRef<HTMLDivElement, SheetContentProps>(
-  (
+  function SheetContent(
     {
       className,
       children,
@@ -233,7 +227,7 @@ export const SheetContent = React.forwardRef<HTMLDivElement, SheetContentProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const {
       open,
       onOpenChange,
@@ -339,8 +333,6 @@ export const SheetContent = React.forwardRef<HTMLDivElement, SheetContentProps>(
   },
 )
 
-SheetContent.displayName = 'SheetContent'
-
 // ---------------------------------------------------------------------------
 // SheetHeader
 // ---------------------------------------------------------------------------
@@ -348,7 +340,7 @@ SheetContent.displayName = 'SheetContent'
 export interface SheetHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const SheetHeader = React.forwardRef<HTMLDivElement, SheetHeaderProps>(
-  ({ className, ...props }, ref) => {
+  function SheetHeader({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       className: cn('flex flex-col space-y-2 text-center sm:text-left', className),
@@ -357,8 +349,6 @@ export const SheetHeader = React.forwardRef<HTMLDivElement, SheetHeaderProps>(
   },
 )
 
-SheetHeader.displayName = 'SheetHeader'
-
 // ---------------------------------------------------------------------------
 // SheetFooter
 // ---------------------------------------------------------------------------
@@ -366,7 +356,7 @@ SheetHeader.displayName = 'SheetHeader'
 export interface SheetFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const SheetFooter = React.forwardRef<HTMLDivElement, SheetFooterProps>(
-  ({ className, ...props }, ref) => {
+  function SheetFooter({ className, ...props }, ref) {
     return React.createElement('div', {
       ref,
       className: cn(
@@ -378,8 +368,6 @@ export const SheetFooter = React.forwardRef<HTMLDivElement, SheetFooterProps>(
   },
 )
 
-SheetFooter.displayName = 'SheetFooter'
-
 // ---------------------------------------------------------------------------
 // SheetTitle
 // ---------------------------------------------------------------------------
@@ -387,7 +375,7 @@ SheetFooter.displayName = 'SheetFooter'
 export interface SheetTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
 
 export const SheetTitle = React.forwardRef<HTMLHeadingElement, SheetTitleProps>(
-  ({ className, ...props }, ref) => {
+  function SheetTitle({ className, ...props }, ref) {
     const { titleId } = useSheetContext()
     return React.createElement('h2', {
       ref,
@@ -397,8 +385,6 @@ export const SheetTitle = React.forwardRef<HTMLHeadingElement, SheetTitleProps>(
     })
   },
 )
-
-SheetTitle.displayName = 'SheetTitle'
 
 // ---------------------------------------------------------------------------
 // SheetDescription
@@ -410,7 +396,7 @@ export interface SheetDescriptionProps
 export const SheetDescription = React.forwardRef<
   HTMLParagraphElement,
   SheetDescriptionProps
->(({ className, ...props }, ref) => {
+>(function SheetDescription({ className, ...props }, ref) {
   const { descriptionId } = useSheetContext()
   return React.createElement('p', {
     ref,
@@ -420,8 +406,6 @@ export const SheetDescription = React.forwardRef<
   })
 })
 
-SheetDescription.displayName = 'SheetDescription'
-
 // ---------------------------------------------------------------------------
 // SheetClose
 // ---------------------------------------------------------------------------
@@ -429,7 +413,7 @@ SheetDescription.displayName = 'SheetDescription'
 export interface SheetCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const SheetClose = React.forwardRef<HTMLButtonElement, SheetCloseProps>(
-  ({ onClick, children, ...props }, ref) => {
+  function SheetClose({ onClick, children, ...props }, ref) {
     const { onOpenChange } = useSheetContext()
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -449,5 +433,3 @@ export const SheetClose = React.forwardRef<HTMLButtonElement, SheetCloseProps>(
     )
   },
 )
-
-SheetClose.displayName = 'SheetClose'

--- a/packages/react-sidebar/src/sidebar.tsx
+++ b/packages/react-sidebar/src/sidebar.tsx
@@ -26,7 +26,7 @@ export interface SidebarProps extends React.HTMLAttributes<HTMLElement> {
  * Hidden on mobile (hidden md:flex via styles).
  */
 export const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
-  (
+  function Sidebar(
     {
       sections = [],
       currentPath,
@@ -36,7 +36,7 @@ export const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createSidebar({ sections, currentPath, collapsed, userRoles })
     const classes = cn(
       sidebarVariants({ collapsed: collapsed ? 'true' : 'false' }),
@@ -79,5 +79,3 @@ export const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
     )
   },
 )
-
-Sidebar.displayName = 'Sidebar'

--- a/packages/react-skeleton/src/skeleton.tsx
+++ b/packages/react-skeleton/src/skeleton.tsx
@@ -21,7 +21,7 @@ export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
-  ({ shape, width, height, animate, className, style, ...props }, ref) => {
+  function Skeleton({ shape, width, height, animate, className, style, ...props }, ref) {
     const api = createSkeleton({ shape, animate })
     const classes = cn(skeletonVariants({ shape }), className)
 
@@ -42,8 +42,6 @@ export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
   },
 )
 
-Skeleton.displayName = 'Skeleton'
-
 // ---------------------------------------------------------------------------
 // SkeletonText
 // ---------------------------------------------------------------------------
@@ -63,7 +61,7 @@ const lineWidths = ['100%', '92%', '85%', '96%', '78%', '88%', '94%', '82%']
  * slight width variations for a natural loading appearance.
  */
 export const SkeletonText = React.forwardRef<HTMLDivElement, SkeletonTextProps>(
-  ({ lines = 3, animate, className, ...props }, ref) => {
+  function SkeletonText({ lines = 3, animate, className, ...props }, ref) {
     const children: React.ReactElement[] = []
 
     for (let i = 0; i < lines; i++) {
@@ -89,5 +87,3 @@ export const SkeletonText = React.forwardRef<HTMLDivElement, SkeletonTextProps>(
     )
   },
 )
-
-SkeletonText.displayName = 'SkeletonText'

--- a/packages/react-skip-to-content/src/skip-to-content.tsx
+++ b/packages/react-skip-to-content/src/skip-to-content.tsx
@@ -11,7 +11,7 @@ export interface SkipToContentProps extends React.AnchorHTMLAttributes<HTMLAncho
 }
 
 export const SkipToContent = React.forwardRef<HTMLAnchorElement, SkipToContentProps>(
-  ({ className, targetId = 'main-content', children = 'Skip to content', ...props }, ref) => {
+  function SkipToContent({ className, targetId = 'main-content', children = 'Skip to content', ...props }, ref) {
     const api = createSkipToContent()
     return (
       <a
@@ -26,4 +26,3 @@ export const SkipToContent = React.forwardRef<HTMLAnchorElement, SkipToContentPr
     )
   },
 )
-SkipToContent.displayName = 'SkipToContent'

--- a/packages/react-slide-viewer/src/SlideViewer.tsx
+++ b/packages/react-slide-viewer/src/SlideViewer.tsx
@@ -30,7 +30,7 @@ export interface SlideViewerProps {
  * Uses the headless @refraction-ui/slide-viewer core for state and navigation.
  */
 export const SlideViewer = React.forwardRef<HTMLDivElement, SlideViewerProps>(
-  (
+  function SlideViewer(
     {
       slides,
       initialSlide,
@@ -41,7 +41,7 @@ export const SlideViewer = React.forwardRef<HTMLDivElement, SlideViewerProps>(
       renderSlide,
     },
     ref,
-  ) => {
+  ) {
     const [, setTick] = React.useState(0)
     const rerender = () => setTick((t) => t + 1)
 
@@ -159,5 +159,3 @@ export const SlideViewer = React.forwardRef<HTMLDivElement, SlideViewerProps>(
     )
   },
 )
-
-SlideViewer.displayName = 'SlideViewer'

--- a/packages/react-slider/src/slider.tsx
+++ b/packages/react-slider/src/slider.tsx
@@ -32,7 +32,7 @@ export interface SliderProps
  * non-native adapters).
  */
 export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
-  (
+  function Slider(
     {
       className,
       variant: _variant,
@@ -47,7 +47,7 @@ export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = controlledValue !== undefined
     const [internalValue, setInternalValue] = React.useState(() =>
       clampSliderValue(roundToStep(defaultValue ?? min, min, step), min, max),
@@ -87,4 +87,3 @@ export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
     )
   },
 )
-Slider.displayName = 'Slider'

--- a/packages/react-slot-picker/src/slot-picker.tsx
+++ b/packages/react-slot-picker/src/slot-picker.tsx
@@ -44,7 +44,7 @@ export interface SlotPickerProps
  * when the previously-chosen slot is not available on the new day.
  */
 export const SlotPicker = React.forwardRef<HTMLDivElement, SlotPickerProps>(
-  (
+  function SlotPicker(
     {
       days,
       slotsByDay,
@@ -57,7 +57,7 @@ export const SlotPicker = React.forwardRef<HTMLDivElement, SlotPickerProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = valueProp !== undefined
     const [internal, setInternal] = React.useState<SlotSelection | undefined>(
       defaultValue,
@@ -167,5 +167,3 @@ export const SlotPicker = React.forwardRef<HTMLDivElement, SlotPickerProps>(
     )
   },
 )
-
-SlotPicker.displayName = 'SlotPicker'

--- a/packages/react-social-auth-button/src/social-auth-button.tsx
+++ b/packages/react-social-auth-button/src/social-auth-button.tsx
@@ -49,7 +49,7 @@ export interface SocialAuthButtonProps
 export const SocialAuthButton = React.forwardRef<
   HTMLButtonElement,
   SocialAuthButtonProps
->(({ provider, lastUsed, loading, disabled, className, ...props }, ref) => {
+>(function SocialAuthButton({ provider, lastUsed, loading, disabled, className, ...props }, ref) {
   const { label, mono, dataAttributes } = createSocialAuthButton({ provider })
   const Icon = PROVIDER_ICONS[provider]
 
@@ -72,8 +72,6 @@ export const SocialAuthButton = React.forwardRef<
   )
 })
 
-SocialAuthButton.displayName = 'SocialAuthButton'
-
 export interface SocialAuthRowProps
   extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode
@@ -84,15 +82,15 @@ export interface SocialAuthRowProps
  * columns from the `sm` breakpoint up.
  */
 export const SocialAuthRow = React.forwardRef<HTMLDivElement, SocialAuthRowProps>(
-  ({ className, children, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(socialAuthRowVariants(), className)}
-      {...props}
-    >
-      {children}
-    </div>
-  ),
+  function SocialAuthRow({ className, children, ...props }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={cn(socialAuthRowVariants(), className)}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  },
 )
-
-SocialAuthRow.displayName = 'SocialAuthRow'

--- a/packages/react-sortable-list/src/sortable-list.tsx
+++ b/packages/react-sortable-list/src/sortable-list.tsx
@@ -185,5 +185,3 @@ function SortableListInner<T>(
 export const SortableList = React.forwardRef(SortableListInner) as <T>(
   props: SortableListProps<T> & { ref?: React.ForwardedRef<HTMLDivElement> },
 ) => React.ReactElement | null
-
-;(SortableList as { displayName?: string }).displayName = 'SortableList'

--- a/packages/react-stat-grid/src/stat-grid.tsx
+++ b/packages/react-stat-grid/src/stat-grid.tsx
@@ -38,7 +38,7 @@ export interface StatGridProps
  * accessible enumeration.
  */
 export const StatGrid = React.forwardRef<HTMLDivElement, StatGridProps>(
-  ({ items, columns, className, ...props }, ref) => {
+  function StatGrid({ items, columns, className, ...props }, ref) {
     const cols = columns ?? statColumns(items.length)
     const { ariaProps, dataAttributes } = createStatGrid()
 
@@ -64,5 +64,3 @@ export const StatGrid = React.forwardRef<HTMLDivElement, StatGridProps>(
     )
   },
 )
-
-StatGrid.displayName = 'StatGrid'

--- a/packages/react-status-indicator/src/status-indicator.tsx
+++ b/packages/react-status-indicator/src/status-indicator.tsx
@@ -34,7 +34,7 @@ function deriveAriaLabel(
 }
 
 export const StatusIndicator = React.forwardRef<HTMLSpanElement, StatusIndicatorProps>(
-  ({ type, label, children, pulse, showLabel = true, className }, ref) => {
+  function StatusIndicator({ type, label, children, pulse, showLabel = true, className }, ref) {
   const api = createStatusIndicator({ type, label, pulse })
   const ariaLabel = deriveAriaLabel(label, children, api.label)
   const visibleLabel: React.ReactNode = label ?? children ?? api.label
@@ -56,5 +56,3 @@ export const StatusIndicator = React.forwardRef<HTMLSpanElement, StatusIndicator
   )
   },
 )
-
-StatusIndicator.displayName = 'StatusIndicator'

--- a/packages/react-steps/src/steps.tsx
+++ b/packages/react-steps/src/steps.tsx
@@ -19,7 +19,7 @@ export interface StepsProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Steps = React.forwardRef<HTMLDivElement, StepsProps>(
-  ({ className, orientation, ...props }, ref) => {
+  function Steps({ className, orientation, ...props }, ref) {
     const api = createSteps()
     return (
       <div
@@ -31,14 +31,13 @@ export const Steps = React.forwardRef<HTMLDivElement, StepsProps>(
     )
   },
 )
-Steps.displayName = 'Steps'
 
 export interface StepProps extends React.HTMLAttributes<HTMLDivElement> {
   status?: 'completed' | 'active' | 'upcoming'
 }
 
 export const Step = React.forwardRef<HTMLDivElement, StepProps>(
-  ({ className, status, ...props }, ref) => {
+  function Step({ className, status, ...props }, ref) {
     const api = createStep()
     return (
       <div
@@ -50,14 +49,13 @@ export const Step = React.forwardRef<HTMLDivElement, StepProps>(
     )
   },
 )
-Step.displayName = 'Step'
 
 export interface StepIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
   status?: 'completed' | 'active' | 'upcoming'
 }
 
 export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps>(
-  ({ className, status, ...props }, ref) => {
+  function StepIndicator({ className, status, ...props }, ref) {
     const api = createStepIndicator()
     return (
       <div
@@ -69,10 +67,9 @@ export const StepIndicator = React.forwardRef<HTMLDivElement, StepIndicatorProps
     )
   },
 )
-StepIndicator.displayName = 'StepIndicator'
 
 export const StepContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
+  function StepContent({ className, ...props }, ref) {
     const api = createStepContent()
     return (
       <div
@@ -84,10 +81,9 @@ export const StepContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes
     )
   },
 )
-StepContent.displayName = 'StepContent'
 
 export const StepTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => {
+  function StepTitle({ className, ...props }, ref) {
     const api = createStepTitle()
     return (
       <h4
@@ -99,10 +95,9 @@ export const StepTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttribut
     )
   },
 )
-StepTitle.displayName = 'StepTitle'
 
 export const StepDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => {
+  function StepDescription({ className, ...props }, ref) {
     const api = createStepDescription()
     return (
       <p
@@ -114,4 +109,3 @@ export const StepDescription = React.forwardRef<HTMLParagraphElement, React.HTML
     )
   },
 )
-StepDescription.displayName = 'StepDescription'

--- a/packages/react-sticky-note/src/sticky-note.tsx
+++ b/packages/react-sticky-note/src/sticky-note.tsx
@@ -42,7 +42,7 @@ export interface StickyNoteProps
  * - Forwards the ref to the outer `<div>`.
  */
 export const StickyNote = React.forwardRef<HTMLDivElement, StickyNoteProps>(
-  (
+  function StickyNote(
     {
       color = 'yellow',
       text,
@@ -58,7 +58,7 @@ export const StickyNote = React.forwardRef<HTMLDivElement, StickyNoteProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const { ariaProps, dataAttributes } = createStickyNote({ color })
 
     // Drag state — kept in refs to avoid re-renders during drag.
@@ -128,5 +128,3 @@ export const StickyNote = React.forwardRef<HTMLDivElement, StickyNoteProps>(
     )
   },
 )
-
-StickyNote.displayName = 'StickyNote'

--- a/packages/react-switch/src/switch.tsx
+++ b/packages/react-switch/src/switch.tsx
@@ -19,7 +19,7 @@ export interface SwitchProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonE
  * Uses the headless @refraction-ui/switch core for state, ARIA, and keyboard handling.
  */
 export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ checked = false, onCheckedChange, disabled = false, size = 'default', className, ...props }, ref) => {
+  function Switch({ checked = false, onCheckedChange, disabled = false, size = 'default', className, ...props }, ref) {
     const api = createSwitch({ checked, disabled })
 
     const handleClick = () => {
@@ -56,5 +56,3 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
     )
   },
 )
-
-Switch.displayName = 'Switch'

--- a/packages/react-table-of-contents/src/table-of-contents.tsx
+++ b/packages/react-table-of-contents/src/table-of-contents.tsx
@@ -9,7 +9,7 @@ export interface TableOfContentsProps extends React.HTMLAttributes<HTMLDivElemen
 }
 
 export const TableOfContents = React.forwardRef<HTMLDivElement, TableOfContentsProps>(
-  ({ className, containerRef, selectors = 'h2, h3, h4', onActiveIdChange, ...props }, ref) => {
+  function TableOfContents({ className, containerRef, selectors = 'h2, h3, h4', onActiveIdChange, ...props }, ref) {
     const [headings, setHeadings] = React.useState<TocItem[]>([])
     const [activeId, setActiveId] = React.useState<string>('')
 
@@ -61,4 +61,3 @@ export const TableOfContents = React.forwardRef<HTMLDivElement, TableOfContentsP
     )
   }
 )
-TableOfContents.displayName = 'TableOfContents'

--- a/packages/react-tabs/src/tabs.tsx
+++ b/packages/react-tabs/src/tabs.tsx
@@ -46,7 +46,7 @@ export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
-  ({ value: controlledValue, defaultValue = '', onValueChange, orientation = 'horizontal', className, children, ...props }: TabsProps, ref) => {
+  function Tabs({ value: controlledValue, defaultValue = '', onValueChange, orientation = 'horizontal', className, children, ...props }: TabsProps, ref) {
   const [uncontrolledValue, setUncontrolledValue] = React.useState(defaultValue)
   const isControlled = controlledValue !== undefined
   const value = isControlled ? controlledValue : uncontrolledValue
@@ -86,8 +86,6 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   },
 )
 
-Tabs.displayName = 'Tabs'
-
 // ---------------------------------------------------------------------------
 // TabsList
 // ---------------------------------------------------------------------------
@@ -95,7 +93,7 @@ Tabs.displayName = 'Tabs'
 export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
-  ({ className, ...props }, ref) => {
+  function TabsList({ className, ...props }, ref) {
     const { orientation } = useTabsContext()
 
     return React.createElement('div', {
@@ -108,8 +106,6 @@ export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
   },
 )
 
-TabsList.displayName = 'TabsList'
-
 // ---------------------------------------------------------------------------
 // TabsTrigger
 // ---------------------------------------------------------------------------
@@ -119,7 +115,7 @@ export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonE
 }
 
 export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
-  ({ value, className, onClick, onKeyDown, children, ...props }, ref) => {
+  function TabsTrigger({ value, className, onClick, onKeyDown, children, ...props }, ref) {
     const { value: activeValue, onValueChange, orientation, idPrefix } = useTabsContext()
 
     const isSelected = activeValue === value
@@ -158,8 +154,6 @@ export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>
   },
 )
 
-TabsTrigger.displayName = 'TabsTrigger'
-
 // ---------------------------------------------------------------------------
 // TabsContent
 // ---------------------------------------------------------------------------
@@ -169,7 +163,7 @@ export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
-  ({ value, className, children, ...props }, ref) => {
+  function TabsContent({ value, className, children, ...props }, ref) {
     const { value: activeValue, idPrefix } = useTabsContext()
 
     const isSelected = activeValue === value
@@ -194,5 +188,3 @@ export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
     )
   },
 )
-
-TabsContent.displayName = 'TabsContent'

--- a/packages/react-terminal/src/terminal.tsx
+++ b/packages/react-terminal/src/terminal.tsx
@@ -45,7 +45,7 @@ export interface TerminalProps extends React.HTMLAttributes<HTMLDivElement> {
  * handle keyboard input (v1). Pass new lines from the parent to stream output.
  */
 export const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
-  (
+  function Terminal(
     {
       lines,
       promptSymbol = '$',
@@ -55,7 +55,7 @@ export const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createTerminal({ label: ariaLabel })
 
     return (
@@ -85,5 +85,3 @@ export const Terminal = React.forwardRef<HTMLDivElement, TerminalProps>(
     )
   },
 )
-
-Terminal.displayName = 'Terminal'

--- a/packages/react-test-results/src/test-results.tsx
+++ b/packages/react-test-results/src/test-results.tsx
@@ -34,7 +34,7 @@ export interface TestResultsProps
  * Logic and styles come from the headless `@refraction-ui/test-results` core.
  */
 export const TestResults = React.forwardRef<HTMLDivElement, TestResultsProps>(
-  ({ results, showSummary = true, className, ...props }, ref) => {
+  function TestResults({ results, showSummary = true, className, ...props }, ref) {
     const summary = React.useMemo(() => summarizeTests(results), [results])
     const { ariaProps, dataAttributes } = createTestResults()
 
@@ -100,5 +100,3 @@ export const TestResults = React.forwardRef<HTMLDivElement, TestResultsProps>(
     )
   },
 )
-
-TestResults.displayName = 'TestResults'

--- a/packages/react-textarea/src/textarea.tsx
+++ b/packages/react-textarea/src/textarea.tsx
@@ -17,7 +17,7 @@ export interface TextareaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
  * Styling via Tailwind utility classes (no external CSS-in-JS).
  */
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ size, className, disabled, readOnly, required, rows, maxRows, 'aria-invalid': ariaInvalid, ...props }, ref) => {
+  function Textarea({ size, className, disabled, readOnly, required, rows, maxRows, 'aria-invalid': ariaInvalid, ...props }, ref) {
     const api = createTextarea({
       disabled,
       readOnly,
@@ -44,5 +44,3 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     )
   },
 )
-
-Textarea.displayName = 'Textarea'

--- a/packages/react-thread-view/src/thread-view.tsx
+++ b/packages/react-thread-view/src/thread-view.tsx
@@ -125,7 +125,7 @@ function MessageComponent({
 }
 
 export const ThreadView = React.forwardRef<HTMLDivElement, ThreadViewProps>(
-  ({ messages, onReply, onReact, currentUserId, className }, ref) => {
+  function ThreadView({ messages, onReply, onReact, currentUserId, className }, ref) {
   const api = createThreadView({ messages, onReply, onReact, currentUserId })
 
   return React.createElement(
@@ -141,5 +141,3 @@ export const ThreadView = React.forwardRef<HTMLDivElement, ThreadViewProps>(
   )
   },
 )
-
-ThreadView.displayName = 'ThreadView'

--- a/packages/react-timeline/src/timeline.tsx
+++ b/packages/react-timeline/src/timeline.tsx
@@ -31,7 +31,7 @@ export interface TimelineItemProps {
 
 /** A single event entry inside a Timeline. */
 export const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>(
-  ({ item, orientation, isLast }, ref) => {
+  function TimelineItem({ item, orientation, isLast }, ref) {
     const itemAria = getTimelineItemAria()
     return (
       <li
@@ -63,8 +63,6 @@ export const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>(
   },
 )
 
-TimelineItem.displayName = 'TimelineItem'
-
 export interface TimelineProps
   extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'> {
   /** Ordered list of events to render. */
@@ -90,7 +88,7 @@ export interface TimelineProps
  * Pass `renderItem` to take full control of individual entries.
  */
 export const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(
-  ({ items, orientation = 'vertical', renderItem, className, ...props }, ref) => {
+  function Timeline({ items, orientation = 'vertical', renderItem, className, ...props }, ref) {
     const resolved = React.useMemo(() => resolveTimelineItems(items), [items])
     const api = createTimeline({ orientation })
 
@@ -124,5 +122,3 @@ export const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(
     )
   },
 )
-
-Timeline.displayName = 'Timeline'

--- a/packages/react-toast/src/toast.tsx
+++ b/packages/react-toast/src/toast.tsx
@@ -53,8 +53,6 @@ export function ToastProvider({ children }: ToastProviderProps) {
   return React.createElement(ToastContext.Provider, { value: ctx }, children)
 }
 
-ToastProvider.displayName = 'ToastProvider'
-
 // ---------------------------------------------------------------------------
 // useToast hook
 // ---------------------------------------------------------------------------
@@ -96,7 +94,7 @@ export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
-  ({ entry, onDismiss, className, children, onMouseEnter, onMouseLeave, ...props }, ref) => {
+  function Toast({ entry, onDismiss, className, children, onMouseEnter, onMouseLeave, ...props }, ref) {
     const api = React.useMemo(
       () => createToast({ variant: entry.variant, duration: entry.duration }),
       [entry.variant, entry.duration],
@@ -145,8 +143,6 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
   },
 )
 
-Toast.displayName = 'Toast'
-
 // ---------------------------------------------------------------------------
 // Toaster (container that renders all active toasts)
 // ---------------------------------------------------------------------------
@@ -154,7 +150,7 @@ Toast.displayName = 'Toast'
 export interface ToasterProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const Toaster = React.forwardRef<HTMLDivElement, ToasterProps>(
-  ({ className, ...props }, ref) => {
+  function Toaster({ className, ...props }, ref) {
     const { toasts, dismiss } = useToast()
 
     return React.createElement(
@@ -177,5 +173,3 @@ export const Toaster = React.forwardRef<HTMLDivElement, ToasterProps>(
     )
   },
 )
-
-Toaster.displayName = 'Toaster'

--- a/packages/react-tooltip/src/tooltip.tsx
+++ b/packages/react-tooltip/src/tooltip.tsx
@@ -111,8 +111,6 @@ export function Tooltip({
   return React.createElement(TooltipContext.Provider, { value: ctx }, children)
 }
 
-Tooltip.displayName = 'Tooltip'
-
 /* ------------------------------------------------------------------ */
 /*  TooltipTrigger                                                     */
 /* ------------------------------------------------------------------ */
@@ -120,7 +118,7 @@ Tooltip.displayName = 'Tooltip'
 export interface TooltipTriggerProps extends React.HTMLAttributes<HTMLSpanElement> {}
 
 export const TooltipTrigger = React.forwardRef<HTMLSpanElement, TooltipTriggerProps>(
-  ({ onMouseEnter, onMouseLeave, onFocus, onBlur, children, ...props }, ref) => {
+  function TooltipTrigger({ onMouseEnter, onMouseLeave, onFocus, onBlur, children, ...props }, ref) {
     const { api, setOpen, openWithDelay, cancelDelay } = useTooltipContext()
 
     const handleMouseEnter = (e: React.MouseEvent<HTMLSpanElement>) => {
@@ -161,8 +159,6 @@ export const TooltipTrigger = React.forwardRef<HTMLSpanElement, TooltipTriggerPr
   },
 )
 
-TooltipTrigger.displayName = 'TooltipTrigger'
-
 /* ------------------------------------------------------------------ */
 /*  TooltipContent                                                     */
 /* ------------------------------------------------------------------ */
@@ -172,7 +168,7 @@ export interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentProps>(
-  ({ side, className, children, ...props }, ref) => {
+  function TooltipContent({ side, className, children, ...props }, ref) {
     const { api, open } = useTooltipContext()
 
     if (!open) return null
@@ -196,5 +192,3 @@ export const TooltipContent = React.forwardRef<HTMLDivElement, TooltipContentPro
     return content
   },
 )
-
-TooltipContent.displayName = 'TooltipContent'

--- a/packages/react-version-selector/src/version-selector.tsx
+++ b/packages/react-version-selector/src/version-selector.tsx
@@ -48,7 +48,7 @@ export interface VersionSelectorProps {
 }
 
 export const VersionSelector = React.forwardRef<HTMLDivElement, VersionSelectorProps>(
-  ({ value: controlledValue, onValueChange, versions, placeholder = 'Select version...', className }: VersionSelectorProps, ref) => {
+  function VersionSelector({ value: controlledValue, onValueChange, versions, placeholder = 'Select version...', className }: VersionSelectorProps, ref) {
   const [selectedVersion, setSelectedVersion] = React.useState(controlledValue ?? '')
   const [isOpen, setIsOpen] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
@@ -197,5 +197,3 @@ export const VersionSelector = React.forwardRef<HTMLDivElement, VersionSelectorP
   )
   },
 )
-
-VersionSelector.displayName = 'VersionSelector'

--- a/packages/react-video-grid/src/video-grid.tsx
+++ b/packages/react-video-grid/src/video-grid.tsx
@@ -40,7 +40,7 @@ export interface VideoGridProps
  * shared with the Astro adapter.
  */
 export const VideoGrid = React.forwardRef<HTMLDivElement, VideoGridProps>(
-  (
+  function VideoGrid(
     {
       participants,
       layout = 'auto',
@@ -50,7 +50,7 @@ export const VideoGrid = React.forwardRef<HTMLDivElement, VideoGridProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const count = participants.length
 
     // Resolve effective layout: 'auto' with ≤1 participant shows speaker view.
@@ -132,5 +132,3 @@ export const VideoGrid = React.forwardRef<HTMLDivElement, VideoGridProps>(
     )
   },
 )
-
-VideoGrid.displayName = 'VideoGrid'

--- a/packages/react-video-player/src/video-player.tsx
+++ b/packages/react-video-player/src/video-player.tsx
@@ -13,7 +13,7 @@ export interface VideoPlayerProps
     CoreVideoPlayerProps {}
 
 export const VideoPlayer = React.forwardRef<HTMLDivElement, VideoPlayerProps>(
-  (
+  function VideoPlayer(
     {
       src,
       poster,
@@ -24,7 +24,7 @@ export const VideoPlayer = React.forwardRef<HTMLDivElement, VideoPlayerProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const [, setTick] = React.useState(0)
     const rerender = React.useCallback(() => setTick((t) => t + 1), [])
 
@@ -120,5 +120,3 @@ export const VideoPlayer = React.forwardRef<HTMLDivElement, VideoPlayerProps>(
     )
   },
 )
-
-VideoPlayer.displayName = 'VideoPlayer'

--- a/packages/react-video-tile/src/video-tile.tsx
+++ b/packages/react-video-tile/src/video-tile.tsx
@@ -52,7 +52,7 @@ export interface VideoTileProps
  * Logic and styles come from the headless `@refraction-ui/video-tile` core.
  */
 export const VideoTile = React.forwardRef<HTMLDivElement, VideoTileProps>(
-  (
+  function VideoTile(
     {
       name,
       micState = 'on',
@@ -65,7 +65,7 @@ export const VideoTile = React.forwardRef<HTMLDivElement, VideoTileProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createVideoTile({ speaking, pinned })
     const initials = getInitials(name)
     const isMuted = micState === 'muted'
@@ -146,5 +146,3 @@ export const VideoTile = React.forwardRef<HTMLDivElement, VideoTileProps>(
     )
   },
 )
-
-VideoTile.displayName = 'VideoTile'

--- a/packages/react-voice-pill/src/voice-pill.tsx
+++ b/packages/react-voice-pill/src/voice-pill.tsx
@@ -22,7 +22,7 @@ export interface VoicePillProps
 }
 
 export const VoicePill = React.forwardRef<HTMLDivElement, VoicePillProps>(
-  (
+  function VoicePill(
     {
       speaker,
       label,
@@ -37,7 +37,7 @@ export const VoicePill = React.forwardRef<HTMLDivElement, VoicePillProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const api = createVoicePill({
       speaker,
       label,
@@ -121,8 +121,6 @@ export const VoicePill = React.forwardRef<HTMLDivElement, VoicePillProps>(
     )
   },
 )
-
-VoicePill.displayName = 'VoicePill'
 
 function renderMuteIcon(muted: boolean): React.ReactElement {
   return React.createElement(

--- a/packages/react-waveform/src/waveform.tsx
+++ b/packages/react-waveform/src/waveform.tsx
@@ -30,7 +30,7 @@ interface WaveformSize {
 }
 
 export const Waveform = React.forwardRef<HTMLDivElement, WaveformProps>(
-  (
+  function Waveform(
     {
       source,
       samples,
@@ -48,7 +48,7 @@ export const Waveform = React.forwardRef<HTMLDivElement, WaveformProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const rootRef = React.useRef<HTMLDivElement | null>(null)
     const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
     const previousSamplesRef = React.useRef<Float32Array | null>(null)
@@ -265,8 +265,6 @@ export const Waveform = React.forwardRef<HTMLDivElement, WaveformProps>(
     )
   },
 )
-
-Waveform.displayName = 'Waveform'
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false)

--- a/packages/react-wizard/src/wizard.tsx
+++ b/packages/react-wizard/src/wizard.tsx
@@ -94,7 +94,7 @@ export interface WizardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
  * ```
  */
 export const Wizard = React.forwardRef<HTMLDivElement, WizardProps>(
-  (
+  function Wizard(
     {
       steps,
       step: stepProp,
@@ -111,7 +111,7 @@ export const Wizard = React.forwardRef<HTMLDivElement, WizardProps>(
       ...props
     },
     ref,
-  ) => {
+  ) {
     const isControlled = stepProp !== undefined
     const [internal, setInternal] = React.useState(defaultStep)
     const currentIndex = isControlled ? stepProp : internal
@@ -251,8 +251,6 @@ export const Wizard = React.forwardRef<HTMLDivElement, WizardProps>(
     )
   },
 )
-
-Wizard.displayName = 'Wizard'
 
 // ---------------------------------------------------------------------------
 // useWizard hook (for children that need context access)

--- a/packages/tailwind-config/__tests__/preset.test.ts
+++ b/packages/tailwind-config/__tests__/preset.test.ts
@@ -140,6 +140,16 @@ describe('colors', () => {
     expect(colors.destructive.foreground).toBe('hsl(var(--destructive-foreground))')
   })
 
+  it('success DEFAULT and foreground are defined', () => {
+    expect(colors.success.DEFAULT).toBe('hsl(var(--success))')
+    expect(colors.success.foreground).toBe('hsl(var(--success-foreground))')
+  })
+
+  it('warning DEFAULT and foreground are defined', () => {
+    expect(colors.warning.DEFAULT).toBe('hsl(var(--warning))')
+    expect(colors.warning.foreground).toBe('hsl(var(--warning-foreground))')
+  })
+
   it('sidebar colors all defined', () => {
     expect(colors.sidebar.DEFAULT).toBe('hsl(var(--sidebar-background))')
     expect(colors.sidebar.foreground).toBe('hsl(var(--sidebar-foreground))')
@@ -239,11 +249,15 @@ describe('utilitiesPlugin', () => {
 // ---------------------------------------------------------------------------
 
 describe('borderRadius', () => {
-  it('all border radius values reference --radius CSS variable', () => {
+  it('lg and md reference the --radius CSS variable', () => {
     const br = refractionPreset.theme.extend.borderRadius
     expect(br.lg).toContain('var(--radius)')
     expect(br.md).toContain('var(--radius)')
-    expect(br.sm).toContain('var(--radius)')
+  })
+
+  it('sm is a fixed absolute so small elements keep their shape at large --radius', () => {
+    const br = refractionPreset.theme.extend.borderRadius
+    expect(br.sm).toBe('2px')
   })
 })
 

--- a/packages/tailwind-config/src/colors.ts
+++ b/packages/tailwind-config/src/colors.ts
@@ -9,6 +9,8 @@ export const colors = {
   muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
   accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
   destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
+  success: { DEFAULT: 'hsl(var(--success))', foreground: 'hsl(var(--success-foreground))' },
+  warning: { DEFAULT: 'hsl(var(--warning))', foreground: 'hsl(var(--warning-foreground))' },
   border: 'hsl(var(--border))',
   input: 'hsl(var(--input))',
   ring: 'hsl(var(--ring))',

--- a/packages/tailwind-config/src/preset.ts
+++ b/packages/tailwind-config/src/preset.ts
@@ -30,7 +30,11 @@ export const refractionPreset = {
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
+        // Fixed absolute, not calc(var(--radius) - 4px): on small elements
+        // (e.g. a 16px checkbox) a relative sm collapses toward a circle at
+        // large --radius (1rem → 12px ≈ radio button). 2px keeps the default
+        // theme pixel-identical (--radius: 0.375rem → calc(6px - 4px) = 2px).
+        sm: '2px',
       },
       fontFamily: {
         sans: ['var(--font-sans)', 'system-ui', '-apple-system', 'sans-serif'],


### PR DESCRIPTION
## Summary
Fixes the three confirmed bugs from the external review (verified present in our codebase):

1. **Tree-shaking was broken** — importing only Button bundled 494 kB. Two compounding causes fixed: (a) 249 top-level `X.displayName =` side-effect assignments → named function expressions (DevTools names preserved structurally; devWarn verified to not read displayName); (b) the meta shipped ONE single-file dist full of impure top-level forwardRef/cva calls — `sideEffects:false` only works at module granularity, so the meta now emits a **module-granular ESM build** (per-adapter modules + code splitting, exact same export surface: 539/539 exports identical, CJS unchanged). Measured result: **494.3 kB → 8.1 kB** for a Button-only bundle. Full graph build (256), lint/typecheck (766), meta tests (28/28), and a real docs-site next build all pass.
2. **success/warning utilities added to the preset** (the --success/--warning vars existed but no utilities mapped to them), and **Badge/Callout success/warning variants now use those tokens** instead of hardcoded bg-green-500/bg-yellow-500 (dark: overrides dropped — the vars flip per mode, the established pattern). NOTE: success/warning pixels shift slightly by design (token hues vs green-500) — badge/callout baselines need a regen on this branch.
3. **sm radius fixed**: `calc(var(--radius) - 4px)` → fixed `2px` — at --radius: 1rem a 16px checkbox got 12px radius (≈circle, read as a radio). The repo's default theme is 0.375rem (so old sm = 2px) — default theme renders pixel-identical; only large-radius themes change (intended).

## Checklist
- [x] Tests added or updated (preset mapping/radius tests, badge/callout class assertions, meta guardrails green)
- [x] Axe/Accessibility checks pass (no ARIA changes)
- [x] Docs updated (n/a)
- [x] Changesets added: patch @refraction-ui/react (treeshake + badge/callout tokens), patch @refraction-ui/astro (badge/callout tokens), minor @refraction-ui/tailwind-config (new utilities + radius fix)

## Breaking changes?
None. Export surface byte-identical; default theme pixel-identical; success/warning variant hues shift slightly (intended, themeable).