### PR TITLE
ci: fix O(n²) eslint program construction + per-job turbo cache keys

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,21 +6,18 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: ['./packages/*/tsconfig.json', './tsconfig.json'],
-    tsconfigRootDir: __dirname,
+    // Deliberately NO `project` here: the enabled rules (eslint:recommended +
+    // @typescript-eslint/recommended) contain no type-aware rules, so building
+    // a TypeScript program per lint task was pure cost. With the old
+    // `project: ['./packages/*/tsconfig.json']` glob, every one of the ~260
+    // per-package lint tasks constructed programs spanning the whole monorepo
+    // (~390 tsconfigs) — O(packages²) work that dominated the CI react job
+    // (≈37 CPU-min of ≈84 total, ~14s median per tiny package).
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   ignorePatterns: ['dist', 'node_modules'],
-  overrides: [
-    {
-      files: ['packages/*/vitest.config.ts', 'packages/*/tsup.config.ts'],
-      parserOptions: {
-        project: null,
-      },
-    },
-  ],
   rules: {
     '@typescript-eslint/no-unused-vars': [
       'warn',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,12 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          # Restore this job's own most recent cache first. The bare
+          # `turbo-<os>-` prefix alone matched EVERY job's cache across all
+          # workflows (whichever saved last), so jobs routinely restored a
+          # foreign, near-useless snapshot.
           restore-keys: |
+            turbo-${{ runner.os }}-${{ github.job }}-
             turbo-${{ runner.os }}-
       - name: Install deps
         run: make install
@@ -103,7 +108,12 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          # Restore this job's own most recent cache first. The bare
+          # `turbo-<os>-` prefix alone matched EVERY job's cache across all
+          # workflows (whichever saved last), so jobs routinely restored a
+          # foreign, near-useless snapshot.
           restore-keys: |
+            turbo-${{ runner.os }}-${{ github.job }}-
             turbo-${{ runner.os }}-
       - name: Install deps
         run: make install

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -86,7 +86,10 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-validation-${{ github.sha }}
+          # Restore the validation job's own most recent cache first; the
+          # bare `turbo-<os>-` prefix stays as a cross-job fallback only.
           restore-keys: |
+            turbo-${{ runner.os }}-validation-
             turbo-${{ runner.os }}-
       - run: make install
       - name: Run CI

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -31,7 +31,12 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          # Restore this job's own most recent cache first. The bare
+          # `turbo-<os>-` prefix alone matched EVERY job's cache (react,
+          # astro, browser-tests — whichever saved last), so jobs routinely
+          # restored a foreign, near-useless snapshot.
           restore-keys: |
+            turbo-${{ runner.os }}-${{ github.job }}-
             turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
@@ -63,7 +68,12 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          # Restore this job's own most recent cache first. The bare
+          # `turbo-<os>-` prefix alone matched EVERY job's cache (react,
+          # astro, browser-tests — whichever saved last), so jobs routinely
+          # restored a foreign, near-useless snapshot.
           restore-keys: |
+            turbo-${{ runner.os }}-${{ github.job }}-
             turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install
@@ -109,7 +119,12 @@ jobs:
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          # Restore this job's own most recent cache first. The bare
+          # `turbo-<os>-` prefix alone matched EVERY job's cache (react,
+          # astro, browser-tests — whichever saved last), so jobs routinely
+          # restored a foreign, near-useless snapshot.
           restore-keys: |
+            turbo-${{ runner.os }}-${{ github.job }}-
             turbo-${{ runner.os }}-
       - name: Install dependencies
         run: make install


### PR DESCRIPTION
## Summary
Measured root-cause fix for the Test Matrix react job going ~10 min → ~40 min.

- **Lint was 44% of CI CPU** (37.4 CPU-min of ~84): `.eslintrc.cjs` set `parserOptions.project: ['./packages/*/tsconfig.json']`, so each of the 262 per-package lint tasks built a TS program spanning ALL ~390 tsconfigs — O(packages²). Zero type-aware rules are enabled, so the programs were pure waste. Removed (plus the dead overrides block). **lint 37.4 → 3.6 CPU-min, median 14s → 0.8s per package.** Full cold make-ci graph: 1056/1056 green, 5m33s wall.
- **Turbo cache was near-useless on CI**: every job in test-matrix/ci/pr-validation restored whichever job's cache was saved last. Restore keys now try job-scoped `turbo-<os>-<job>-` first, broad fallback kept (post-merge run still hits old caches, then per-job lineages establish).

Expected: cold mega-runs ~40 → ~20–24 min; steady-state PR/main runs back near ~10 min via cache hits.

Not done (deliberate): no test sharding (diminishing returns after the lint fix; next lever if test CPU keeps growing); flagged but untouched — ci.yml, test-matrix.yml, and pr-validation.yml each run the full graph on every PR (3× duplication), a maintainer decision.

No workflow/job renamed; release.yml's workflow_run on "Test Matrix" unaffected; all gates still run.

## Checklist
- [x] Tests added or updated (full graph green after change; lint probe verified)
- [x] Axe/Accessibility checks pass (n/a)
- [x] Docs updated (n/a)
- [ ] Changeset added (CI/config only)

## Breaking changes?
None.