### PR TITLE
feat(astro): 1:1 parity — real Pagination/FileTree/Slider/SkipToContent/Steps + prop parity

### DIFF
--- a/.changeset/astro-parity.md
+++ b/.changeset/astro-parity.md
@@ -1,0 +1,31 @@
+---
+"@refraction-ui/astro": minor
+---
+
+feat(astro): real Pagination, FileTree, Slider, SkipToContent and Steps components
+
+Replaces the placeholder astro adapters with real SSR implementations on the
+shared headless cores, mirroring the React adapters' markup and ARIA:
+
+- **Pagination** — `role="navigation"` landmark with windowed page ranges,
+  ellipses, `aria-current="page"` and prev/next edge semantics from
+  `@refraction-ui/pagination`. Activation is delivered as a bubbling
+  `rfr-page-change` CustomEvent; consumers re-render (or navigate) with the
+  requested page.
+- **FileTree** — nested `role="tree"` / `treeitem` / `group` markup with
+  level/expansion/selection ARIA from `@refraction-ui/file-tree`. Expansion and
+  selection are static SSR props (`expandedIds` / `selectedId`); activation is
+  delivered as `rfr-file-tree-select` / `rfr-file-tree-toggle` CustomEvents.
+- **Slider** — new `Slider.astro` (the package previously shipped no
+  component): a native `<input type="range">` with core-normalized value and
+  slider ARIA; value changes are delivered as `rfr-value-change` CustomEvents.
+- **SkipToContent** — visually-hidden-until-focused skip link from
+  `@refraction-ui/skip-to-content`.
+- **Steps** — real `Steps` / `Step` wrappers consuming `@refraction-ui/steps`
+  variants and data-slot hooks, alongside the existing step partials.
+
+Prop-parity fixes: `Calendar` accepts a `today` ISO string (injected reference
+date for `isToday` / `aria-current` and the initial month, keeping SSR and
+client hydration in agreement), and `DatePicker` renders the formatted-date
+text next to the native input when `format` is set, matching the React
+adapter.

--- a/packages/astro-calendar/src/Calendar.astro
+++ b/packages/astro-calendar/src/Calendar.astro
@@ -16,21 +16,26 @@ interface Props extends astroHTML.JSX.HTMLAttributes {
   maxDate?: string
   /** Disabled date ISO strings */
   disabledDates?: string[]
+  /** Reference "today" (ISO string) for isToday/aria-current and the initial
+   *  month — inject to keep SSR and client hydration in agreement. */
+  today?: string
 }
 
-const { value, minDate, maxDate, disabledDates = [], class: className, ...props } = Astro.props
+const { value, minDate, maxDate, disabledDates = [], today, class: className, ...props } = Astro.props
 
 const parsedValue = value ? new Date(value) : undefined
 const parsedMin = minDate ? new Date(minDate) : undefined
 const parsedMax = maxDate ? new Date(maxDate) : undefined
 const parsedDisabled = disabledDates.map((d: string) => new Date(d))
+const parsedToday = today ? new Date(today) : undefined
 
 const api = createCalendar({
   value: parsedValue,
-  month: parsedValue ?? new Date(),
+  month: parsedValue ?? parsedToday,
   minDate: parsedMin,
   maxDate: parsedMax,
   disabledDates: parsedDisabled,
+  today: parsedToday,
 })
 
 const MONTH_NAMES = [

--- a/packages/astro-date-picker/src/DatePicker.astro
+++ b/packages/astro-date-picker/src/DatePicker.astro
@@ -1,6 +1,6 @@
 ---
 import { cn } from '@refraction-ui/shared'
-import { datePickerTriggerStyles } from '@refraction-ui/date-picker'
+import { datePickerTriggerStyles, formatDate } from '@refraction-ui/date-picker'
 
 interface Props extends astroHTML.JSX.HTMLAttributes {
   /** Selected date value (ISO string) */
@@ -11,7 +11,7 @@ interface Props extends astroHTML.JSX.HTMLAttributes {
   maxDate?: string
   /** Show time selection inputs */
   showTime?: boolean
-  /** Date format string (ignored by native input, but kept for interface compatibility) */
+  /** Display format for the selected-date text shown next to the input (e.g. 'DD/MM/YYYY'). The native input value itself stays ISO (`YYYY-MM-DD`). */
   format?: string
   /** Placeholder text */
   placeholder?: string
@@ -49,6 +49,11 @@ function formatDateStr(isoStr?: string) {
 const parsedValue = formatDateStr(value)
 const parsedMin = formatDateStr(minDate)
 const parsedMax = formatDateStr(maxDate)
+
+// A custom display format cannot be honored by the native input itself (the
+// browser locale controls its presentation), so the formatted date renders as
+// adjacent text via the core's formatter — mirroring the React adapter.
+const formattedDisplay = format && value ? formatDate(new Date(value), format, showTime) : undefined
 ---
 
 <input
@@ -62,6 +67,9 @@ const parsedMax = formatDateStr(maxDate)
   data-rfr-datepicker
   {...props}
 />
+{formattedDisplay && (
+  <span class="text-sm text-muted-foreground">{formattedDisplay}</span>
+)}
 
 <script>
   document.querySelectorAll<HTMLInputElement>('[data-rfr-datepicker]').forEach((input) => {

--- a/packages/astro-file-tree/package.json
+++ b/packages/astro-file-tree/package.json
@@ -5,5 +5,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@refraction-ui/file-tree": "workspace:*",
+    "@refraction-ui/shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "astro": ">=4.0.0"
+  }
 }

--- a/packages/astro-file-tree/src/FileTree.astro
+++ b/packages/astro-file-tree/src/FileTree.astro
@@ -1,0 +1,86 @@
+---
+import {
+  createFileTree,
+  fileTreeVariants,
+  type FileTreeNode,
+} from '@refraction-ui/file-tree'
+import { cn } from '@refraction-ui/shared'
+import FileTreeItems from './FileTreeItems.astro'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Root-level nodes of the tree. */
+  nodes?: FileTreeNode[]
+  /** Expanded node ids (static SSR expansion state). */
+  expandedIds?: string[]
+  /** Initial expanded node ids (alias of `expandedIds` for uncontrolled usage). */
+  defaultExpandedIds?: string[]
+  /** Selected node id (`null` = none). */
+  selectedId?: string | null
+  /** Initial selected node id (alias of `selectedId` for uncontrolled usage). */
+  defaultSelectedId?: string | null
+  /** Accessible label for the tree (default `'File tree'`). */
+  'aria-label'?: string
+}
+
+const {
+  nodes = [],
+  expandedIds,
+  defaultExpandedIds,
+  selectedId,
+  defaultSelectedId,
+  class: className,
+  'aria-label': ariaLabel,
+  ...props
+} = Astro.props
+
+// The headless core resolves the node model, expansion, selection, and the
+// treeview ARIA objects; SSR renders the resulting visible rows statically.
+const api = createFileTree({
+  nodes,
+  expandedIds: expandedIds ?? defaultExpandedIds,
+  selectedId: selectedId ?? defaultSelectedId,
+  'aria-label': ariaLabel,
+})
+
+const state = api.getState()
+const firstVisibleId = api.getVisibleItems()[0]?.node.id
+---
+
+<div class={cn(fileTreeVariants(), className)} {...props}>
+  <ul {...api.getTreeAria()} class="m-0 p-0" data-rfr-file-tree>
+    <FileTreeItems
+      nodes={state.nodes}
+      depth={1}
+      api={api}
+      expandedIds={state.expandedIds}
+      selectedId={state.selectedId}
+      firstVisibleId={firstVisibleId}
+    />
+  </ul>
+</div>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-rfr-file-tree]').forEach((root) => {
+    if (root.hasAttribute('data-rfr-file-tree-init')) return
+    root.setAttribute('data-rfr-file-tree-init', '')
+
+    // SSR-static component: expansion/selection are props. Activation is
+    // delivered as bubbling CustomEvents (`rfr-file-tree-select` /
+    // `rfr-file-tree-toggle`); the consumer re-renders with the new state.
+    root.addEventListener('click', (e) => {
+      const item = (e.target as HTMLElement).closest<HTMLElement>('[data-rfr-file-tree-item]')
+      if (!item || item.getAttribute('data-disabled') === 'true') return
+      const id = item.getAttribute('data-rfr-node-id')
+      if (!id) return
+      root.dispatchEvent(new CustomEvent('rfr-file-tree-select', { detail: { id }, bubbles: true }))
+      if (item.getAttribute('data-rfr-has-children') === 'true') {
+        root.dispatchEvent(
+          new CustomEvent('rfr-file-tree-toggle', {
+            detail: { id, expanded: item.getAttribute('aria-expanded') !== 'true' },
+            bubbles: true,
+          }),
+        )
+      }
+    })
+  })
+</script>

--- a/packages/astro-file-tree/src/FileTree.stories.ts
+++ b/packages/astro-file-tree/src/FileTree.stories.ts
@@ -1,14 +1,41 @@
-import Component from './astro-file-tree.astro'
+import Component from './FileTree.astro'
 
 const meta = {
   title: 'Astro/FileTree',
   component: Component,
+  argTypes: {
+    nodes: { control: 'object' },
+    expandedIds: { control: 'object' },
+    selectedId: { control: 'text' },
+  },
 }
 
 export default meta
 
+// Nodes must match the headless core's FileTreeNode shape
+// ({ id, label, children?, disabled? }) — see
+// packages/file-tree/src/file-tree.ts.
 export const Default = {
   args: {
-    
+    nodes: [
+      {
+        id: 'src',
+        label: 'src',
+        children: [
+          {
+            id: 'src-components',
+            label: 'components',
+            children: [
+              { id: 'src-components-button', label: 'Button.tsx' },
+              { id: 'src-components-input', label: 'Input.tsx' },
+            ],
+          },
+          { id: 'src-index', label: 'index.ts' },
+        ],
+      },
+      { id: 'package-json', label: 'package.json' },
+    ],
+    expandedIds: ['src', 'src-components'],
+    selectedId: 'src-components-button',
   }
 }

--- a/packages/astro-file-tree/src/FileTreeItems.astro
+++ b/packages/astro-file-tree/src/FileTreeItems.astro
@@ -1,0 +1,77 @@
+---
+import {
+  fileTreeItemVariants,
+  fileTreeGlyphClass,
+  type FileTreeAPI,
+  type FileTreeNode,
+  type VisibleTreeItem,
+} from '@refraction-ui/file-tree'
+import FileTreeItems from './FileTreeItems.astro'
+
+/**
+ * Recursive partial for `<FileTree>` — renders one depth level of the tree
+ * (`role="none"` list items wrapping `role="treeitem"` rows) and nests
+ * `role="group"` lists for expanded parents, mirroring the React adapter's
+ * markup. Not exported from the package entry; use `<FileTree>`.
+ */
+
+interface Props {
+  nodes: FileTreeNode[]
+  /** 1-based nesting depth (ARIA `aria-level`). */
+  depth: number
+  api: FileTreeAPI
+  expandedIds: string[]
+  selectedId: string | null
+  firstVisibleId: string | undefined
+}
+
+const { nodes, depth, api, expandedIds, selectedId, firstVisibleId } = Astro.props
+---
+
+{nodes.map((node) => {
+  const hasChildren = Boolean(node.children && node.children.length > 0)
+  const isExpanded = hasChildren && expandedIds.includes(node.id)
+  const isSelected = selectedId === node.id
+  const item: VisibleTreeItem = {
+    node,
+    parentId: null, // unused by getItemAria; the core tracks real parents
+    depth,
+    hasChildren,
+    isExpanded,
+    isSelected,
+    isFocused: false, // SSR has no roving focus; the first visible item tabs in
+  }
+  const tabbable = node.id === firstVisibleId
+
+  return (
+    <li role="none" class="list-none">
+      <div
+        {...api.getItemAria(item)}
+        tabindex={tabbable ? 0 : -1}
+        data-disabled={node.disabled ? 'true' : undefined}
+        data-rfr-file-tree-item
+        data-rfr-node-id={node.id}
+        data-rfr-has-children={hasChildren ? 'true' : undefined}
+        style={`padding-left: ${(depth - 1) * 12}px`}
+        class={fileTreeItemVariants({ selected: isSelected ? 'true' : 'false' })}
+      >
+        <span aria-hidden="true" class={fileTreeGlyphClass}>
+          {hasChildren ? (isExpanded ? '▾' : '▸') : '·'}
+        </span>
+        <span class="truncate">{node.label}</span>
+      </div>
+      {hasChildren && isExpanded && (
+        <ul role="group" class="m-0 p-0">
+          <FileTreeItems
+            nodes={node.children!}
+            depth={depth + 1}
+            api={api}
+            expandedIds={expandedIds}
+            selectedId={selectedId}
+            firstVisibleId={firstVisibleId}
+          />
+        </ul>
+      )}
+    </li>
+  )
+})}

--- a/packages/astro-file-tree/src/astro-file-tree.astro
+++ b/packages/astro-file-tree/src/astro-file-tree.astro
@@ -1,4 +1,0 @@
----
-// Astro component
----
-<div></div>

--- a/packages/astro-file-tree/src/index.ts
+++ b/packages/astro-file-tree/src/index.ts
@@ -1,4 +1,2 @@
-// `.astro` single-file components have no wildcard surface — re-export the
-// default export by name. (The astro-meta build used to paper over the broken
-// `export * from './astro-file-tree'` by rewriting it to exactly this.)
-export { default as FileTree } from './astro-file-tree.astro'
+export { default as FileTree } from './FileTree.astro'
+export type { FileTreeNode } from '@refraction-ui/file-tree'

--- a/packages/astro-meta/__tests__/deep.test.ts
+++ b/packages/astro-meta/__tests__/deep.test.ts
@@ -8,6 +8,10 @@ import RadioComposition from './compositions/radio.astro'
 import DropdownMenuComposition from './compositions/dropdown-menu.astro'
 import ToasterComposition from './compositions/toaster.astro'
 import Switch from '../dist/astro-switch/Switch.astro'
+import Pagination from '../dist/astro-pagination/Pagination.astro'
+import FileTree from '../dist/astro-file-tree/FileTree.astro'
+import Slider from '../dist/astro-slider/Slider.astro'
+import SkipToContent from '../dist/astro-skip-to-content/SkipToContent.astro'
 
 /**
  * Deep render tests for the stateful / ARIA-heavy adapters. Multi-part
@@ -195,5 +199,156 @@ describe('astro-switch', () => {
     const html = await render(Switch)
 
     expect(html).toMatch(/<button[^>]*role="switch"[^>]*aria-checked="false"[^>]*data-state="unchecked"/)
+  })
+})
+
+describe('astro-pagination', () => {
+  it('renders the navigation landmark with windowed range, ellipses and current-page ARIA', async () => {
+    const html = await render(Pagination, {
+      props: { page: 5, totalPages: 20, siblingCount: 1 },
+    })
+
+    // Nav landmark + the state hooks the client script drives.
+    expect(html).toMatch(/<div[^>]*role="navigation"[^>]*aria-label="Pagination"/)
+    expect(html).toContain('data-rfr-pagination')
+    expect(html).toContain('data-page="5"')
+    expect(html).toContain('data-total-pages="20"')
+
+    // Prev/next controls carry their target page and labels.
+    expect(html).toMatch(/<button[^>]*aria-label="Previous page"[^>]*data-rfr-page="4"/)
+    expect(html).toMatch(/<button[^>]*aria-label="Next page"[^>]*data-rfr-page="6"/)
+
+    // Windowed range 1 … 4 5 6 … 20: two ellipses, five page buttons.
+    expect(count(html, '>…</span>')).toBe(2)
+    for (const p of [1, 4, 5, 6, 20]) {
+      expect(html).toMatch(new RegExp(`<button[^>]*data-rfr-page="${p}"[^>]*>\\s*${p}\\s*</button>`))
+    }
+
+    // Current page gets aria-current + the current state hook; others do not.
+    expect(html).toMatch(
+      /<button[^>]*aria-current="page"[^>]*data-state="current"[^>]*data-rfr-page="5"[^>]*>\s*5\s*<\/button>/
+    )
+    expect(count(html, 'aria-current="page"')).toBe(1)
+    expect(html).toMatch(/<button[^>]*data-state="default"[^>]*data-rfr-page="4"/)
+  })
+
+  it('disables previous on the first page and next on the last', async () => {
+    // SSR attribute order is deterministic: the `disabled` attribute follows
+    // the aria-label when present (the class list also contains the word
+    // "disabled" in utilities, so attribute-order pinning is required).
+    const first = await render(Pagination, { props: { page: 1, totalPages: 3 } })
+    expect(first).toContain('aria-label="Previous page" disabled')
+    expect(first).not.toContain('aria-label="Next page" disabled')
+
+    const last = await render(Pagination, { props: { page: 3, totalPages: 3 } })
+    expect(last).toContain('aria-label="Next page" disabled')
+    expect(last).not.toContain('aria-label="Previous page" disabled')
+  })
+})
+
+describe('astro-file-tree', () => {
+  const NODES = [
+    {
+      id: 'src',
+      label: 'src',
+      children: [
+        {
+          id: 'src-components',
+          label: 'components',
+          children: [
+            { id: 'src-components-button', label: 'Button.tsx' },
+            { id: 'src-components-input', label: 'Input.tsx' },
+          ],
+        },
+        { id: 'src-index', label: 'index.ts' },
+      ],
+    },
+    { id: 'package-json', label: 'package.json' },
+  ]
+
+  it('renders tree/treeitem/group roles with expansion, selection and level ARIA', async () => {
+    const html = await render(FileTree, {
+      props: {
+        nodes: NODES,
+        expandedIds: ['src', 'src-components'],
+        selectedId: 'src-components-button',
+      },
+    })
+
+    // Tree container.
+    expect(html).toMatch(/<ul[^>]*role="tree"[^>]*aria-label="File tree"/)
+    expect(html).toContain('data-rfr-file-tree')
+
+    // All six rows visible; two expanded parents nest role="group" lists.
+    expect(count(html, 'role="treeitem"')).toBe(6)
+    expect(count(html, 'role="group"')).toBe(2)
+
+    // Expanded parent at depth 1 and 2.
+    expect(html).toMatch(
+      /role="treeitem"[^>]*aria-level="1"[^>]*aria-expanded="true"[^>]*data-rfr-node-id="src"/
+    )
+    expect(html).toMatch(
+      /role="treeitem"[^>]*aria-level="2"[^>]*aria-expanded="true"[^>]*data-rfr-node-id="src-components"/
+    )
+
+    // Selected leaf at depth 3.
+    expect(html).toMatch(
+      /role="treeitem"[^>]*aria-level="3"[^>]*aria-selected="true"[^>]*data-rfr-node-id="src-components-button"/
+    )
+    expect(count(html, 'aria-selected="true"')).toBe(1)
+
+    // Roving-tabindex seed: only the first visible row is tabbable in SSR.
+    expect(count(html, 'tabindex="0"')).toBe(1)
+    expect(html).toMatch(/tabindex="0"[^>]*data-rfr-node-id="src"/)
+
+    // Labels render.
+    expect(html).toContain('Button.tsx')
+    expect(html).toContain('package.json')
+  })
+
+  it('collapses parents by default (only root rows visible)', async () => {
+    const html = await render(FileTree, { props: { nodes: NODES } })
+
+    expect(count(html, 'role="treeitem"')).toBe(2)
+    expect(count(html, 'role="group"')).toBe(0)
+    expect(html).toMatch(/aria-expanded="false"[^>]*data-rfr-node-id="src"/)
+    expect(html).not.toContain('Button.tsx')
+  })
+})
+
+describe('astro-slider', () => {
+  it('renders the slider role with core-normalized value ARIA', async () => {
+    const html = await render(Slider, {
+      props: { value: 43, min: 0, max: 100, step: 5 },
+    })
+
+    // 43 rounds to the nearest step (45) via the headless core.
+    expect(html).toMatch(/<input[^>]*type="range"[^>]*data-rfr-slider[^>]*role="slider"/)
+    expect(html).toContain('aria-valuemin="0"')
+    expect(html).toContain('aria-valuemax="100"')
+    expect(html).toContain('aria-valuenow="45"')
+    expect(html).toContain('value="45"')
+    expect(html).toContain('data-value="45"')
+  })
+
+  it('clamps out-of-range values and forwards aria-label', async () => {
+    const html = await render(Slider, {
+      props: { value: 250, max: 100, 'aria-label': 'Volume' },
+    })
+
+    expect(html).toContain('aria-valuenow="100"')
+    expect(html).toContain('aria-label="Volume"')
+  })
+})
+
+describe('astro-skip-to-content', () => {
+  it('renders a visually-hidden-until-focused skip link to the target', async () => {
+    const html = await render(SkipToContent, { props: { targetId: 'content' } })
+
+    expect(html).toMatch(/<a[^>]*href="#content"[^>]*data-slot="skip-to-content"/)
+    // Off-screen until focused (the core's variant classes carry the behavior).
+    expect(html).toContain('-translate-y-16')
+    expect(html).toContain('focus:translate-y-0')
+    expect(html).toContain('Skip to content')
   })
 })

--- a/packages/astro-meta/__tests__/fixtures.ts
+++ b/packages/astro-meta/__tests__/fixtures.ts
@@ -41,6 +41,16 @@ export const PROPS: Record<string, Record<string, unknown>> = {
     tabs: [{ id: '1', label: 'index.ts' }],
     activeId: '1',
   },
+  'astro-file-tree': {
+    nodes: [
+      {
+        id: 'src',
+        label: 'src',
+        children: [{ id: 'src-index', label: 'index.ts' }],
+      },
+    ],
+    expandedIds: ['src'],
+  },
   'astro-flow-editor': {
     nodes: [{ id: 'n1', x: 0, y: 0, label: 'Start' }],
     edges: [],
@@ -65,6 +75,7 @@ export const PROPS: Record<string, Record<string, unknown>> = {
   'astro-marquee-strip': { items: ['One', 'Two'] },
   'astro-mini-map': { items: [{ id: '1', x: 0, y: 0 }] },
   'astro-numbered-steps': { items: [{ title: 'Step one', body: 'Do it' }] },
+  'astro-pagination': { page: 5, totalPages: 20 },
   'astro-pricing-card': {
     name: 'Pro',
     price: '$29',
@@ -125,6 +136,7 @@ export const EXPECT_SLOT_CONTENT = new Set([
   'astro-input-group',
   'astro-link-card',
   'astro-mobile-nav',
+  'astro-pagination',
   'astro-popover',
   'astro-radio',
   'astro-resizable-layout',
@@ -133,6 +145,8 @@ export const EXPECT_SLOT_CONTENT = new Set([
   'astro-segmented-control',
   'astro-select',
   'astro-separator',
+  'astro-skip-to-content',
+  'astro-steps',
   'astro-sticky-note',
   'astro-tabs',
   'astro-toast',
@@ -144,13 +158,7 @@ export const EXPECT_SLOT_CONTENT = new Set([
  * class hook) is their entire current implementation. Asserted to render
  * without throwing; a marker assertion would be meaningless.
  */
-export const PLACEHOLDERS = new Set([
-  'astro-file-tree',
-  'astro-icon-system',
-  'astro-pagination',
-  'astro-skip-to-content',
-  'astro-steps',
-])
+export const PLACEHOLDERS = new Set(['astro-icon-system'])
 
 /** Pin a different primary component than the namesake/first-file rule. */
 export const COMPONENT_OVERRIDES: Record<string, string> = {

--- a/packages/astro-meta/__tests__/smoke.test.ts
+++ b/packages/astro-meta/__tests__/smoke.test.ts
@@ -31,7 +31,7 @@ const primaries = discoverPrimaries(COMPONENT_OVERRIDES)
 
 describe('astro adapter smoke (meta dist, container API)', () => {
   it('discovers a primary component for (almost) every adapter package', () => {
-    // 125 astro-* packages; astro-slider ships no .astro component.
+    // 125 astro-* packages ship at least one .astro primary component.
     expect(primaries.length).toBeGreaterThanOrEqual(120)
   })
 

--- a/packages/astro-pagination/src/Pagination.astro
+++ b/packages/astro-pagination/src/Pagination.astro
@@ -1,3 +1,102 @@
 ---
+import {
+  createPagination,
+  paginationVariants,
+  paginationItemVariants,
+  paginationEllipsisClass,
+} from '@refraction-ui/pagination'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Current page, 1-based. Clamped into `[1, totalPages]` (default 1). */
+  page?: number
+  /** Total number of pages (default 1). */
+  totalPages?: number
+  /** Pages shown on each side of the current page (default 1). */
+  siblingCount?: number
+  /** Disables every control. */
+  disabled?: boolean
+}
+
+const {
+  page = 1,
+  totalPages = 1,
+  siblingCount = 1,
+  disabled = false,
+  class: className,
+  ...props
+} = Astro.props
+
+const api = createPagination({ page, totalPages, siblingCount })
 ---
-<div></div>
+
+<div
+  data-rfr-pagination
+  data-rfr-pagination-disabled={disabled ? '' : undefined}
+  class={cn(paginationVariants(), className)}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+>
+  {Astro.slots.has('default') ? (
+    <slot />
+  ) : (
+    <>
+      <button
+        type="button"
+        {...api.getPreviousAria()}
+        disabled={disabled || !api.canGoPrevious}
+        class={paginationItemVariants()}
+        data-rfr-page={api.previousPage}
+      >
+        Previous
+      </button>
+      {api.items.map((item) =>
+        item.type === 'ellipsis' ? (
+          <span aria-hidden="true" class={paginationEllipsisClass}>…</span>
+        ) : (
+          <button
+            type="button"
+            {...api.getPageAria(item.page)}
+            disabled={disabled}
+            data-state={item.page === api.page ? 'current' : 'default'}
+            class={paginationItemVariants({
+              state: item.page === api.page ? 'current' : 'default',
+            })}
+            data-rfr-page={item.page}
+          >
+            {item.page}
+          </button>
+        ),
+      )}
+      <button
+        type="button"
+        {...api.getNextAria()}
+        disabled={disabled || !api.canGoNext}
+        class={paginationItemVariants()}
+        data-rfr-page={api.nextPage}
+      >
+        Next
+      </button>
+    </>
+  )}
+</div>
+
+<script>
+  document.querySelectorAll<HTMLElement>('[data-rfr-pagination]').forEach((root) => {
+    if (root.hasAttribute('data-rfr-pagination-init')) return
+    root.setAttribute('data-rfr-pagination-init', '')
+
+    // SSR-static component: activation is delivered as a bubbling
+    // `rfr-page-change` CustomEvent; the consumer re-renders (or navigates)
+    // with the requested page. The DOM is never mutated here.
+    root.addEventListener('click', (e) => {
+      if (root.hasAttribute('data-rfr-pagination-disabled')) return
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-rfr-page]')
+      if (!btn || btn.disabled) return
+      const page = parseInt(btn.getAttribute('data-rfr-page') || '', 10)
+      if (Number.isNaN(page) || String(page) === root.getAttribute('data-page')) return
+      root.dispatchEvent(new CustomEvent('rfr-page-change', { detail: { page }, bubbles: true }))
+    })
+  })
+</script>

--- a/packages/astro-pagination/src/Pagination.stories.ts
+++ b/packages/astro-pagination/src/Pagination.stories.ts
@@ -3,10 +3,20 @@ import Component from './Pagination.astro'
 const meta = {
   title: 'Astro/Pagination',
   component: Component,
+  argTypes: {
+    page: { control: 'number' },
+    totalPages: { control: 'number' },
+    siblingCount: { control: 'number' },
+    disabled: { control: 'boolean' },
+  },
 }
 
 export default meta
 
 export const Default = {
-  args: {},
+  args: {
+    page: 5,
+    totalPages: 20,
+    siblingCount: 1,
+  },
 }

--- a/packages/astro-pagination/src/index.ts
+++ b/packages/astro-pagination/src/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { default as Pagination } from './Pagination.astro'

--- a/packages/astro-skip-to-content/src/SkipToContent.astro
+++ b/packages/astro-skip-to-content/src/SkipToContent.astro
@@ -1,3 +1,24 @@
 ---
+import {
+  createSkipToContent,
+  skipToContentVariants,
+} from '@refraction-ui/skip-to-content'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** The target element ID to skip to (without the #) */
+  targetId?: string
+}
+
+const { targetId = 'main-content', class: className, ...props } = Astro.props
+const api = createSkipToContent()
 ---
-<div></div>
+
+<a
+  href={`#${targetId}`}
+  class={cn(skipToContentVariants(), className)}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot>Skip to content</slot>
+</a>

--- a/packages/astro-skip-to-content/src/SkipToContent.stories.ts
+++ b/packages/astro-skip-to-content/src/SkipToContent.stories.ts
@@ -3,10 +3,16 @@ import Component from './SkipToContent.astro'
 const meta = {
   title: 'Astro/SkipToContent',
   component: Component,
+  argTypes: {
+    targetId: { control: 'text' },
+  },
 }
 
 export default meta
 
 export const Default = {
-  args: {},
+  args: {
+    default: 'Skip to content',
+    targetId: 'main-content',
+  },
 }

--- a/packages/astro-skip-to-content/src/index.ts
+++ b/packages/astro-skip-to-content/src/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { default as SkipToContent } from './SkipToContent.astro'

--- a/packages/astro-slider/src/Slider.astro
+++ b/packages/astro-slider/src/Slider.astro
@@ -1,0 +1,75 @@
+---
+import { createSlider } from '@refraction-ui/slider'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  /** Current value. Clamped into `[min, max]` and rounded to `step`. */
+  value?: number
+  /** Initial value when `value` is not given (defaults to `min`). */
+  defaultValue?: number
+  /** Minimum selectable value (default 0). */
+  min?: number
+  /** Maximum selectable value (default 100). */
+  max?: number
+  /** Granularity between selectable values (default 1). */
+  step?: number
+  /** Disables the control. */
+  disabled?: boolean
+  variant?: 'default'
+}
+
+const {
+  value,
+  defaultValue,
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled,
+  variant: _variant,
+  class: className,
+  ...props
+} = Astro.props
+
+// Native `<input type="range">` owns keyboard/pointer interaction; the core
+// normalizes the rendered value and supplies the slider ARIA object.
+const api = createSlider({
+  value: value ?? defaultValue ?? min,
+  min,
+  max,
+  step,
+  disabled,
+  'aria-label': props['aria-label'] as string | undefined,
+})
+---
+
+<input
+  type="range"
+  data-rfr-slider
+  min={min}
+  max={max}
+  step={step}
+  value={api.value}
+  disabled={disabled}
+  class={cn('w-full', className)}
+  {...api.ariaProps}
+  {...api.dataAttributes}
+  {...props}
+/>
+
+<script>
+  document.querySelectorAll<HTMLInputElement>('input[data-rfr-slider]').forEach((input) => {
+    if (input.hasAttribute('data-rfr-slider-init')) return
+    input.setAttribute('data-rfr-slider-init', '')
+
+    // The native range input owns keyboard/pointer interaction and its own
+    // DOM value; the change is delivered as a bubbling `rfr-value-change`
+    // CustomEvent (SSR-static adapter — consumers re-render with the value).
+    input.addEventListener('input', () => {
+      input.setAttribute('data-value', input.value)
+      input.setAttribute('aria-valuenow', input.value)
+      input.dispatchEvent(
+        new CustomEvent('rfr-value-change', { detail: { value: Number(input.value) }, bubbles: true }),
+      )
+    })
+  })
+</script>

--- a/packages/astro-slider/src/Slider.stories.ts
+++ b/packages/astro-slider/src/Slider.stories.ts
@@ -1,0 +1,24 @@
+import Component from './Slider.astro'
+
+const meta = {
+  title: 'Astro/Slider',
+  component: Component,
+  argTypes: {
+    value: { control: 'number' },
+    min: { control: 'number' },
+    max: { control: 'number' },
+    step: { control: 'number' },
+    disabled: { control: 'boolean' },
+  },
+}
+
+export default meta
+
+export const Default = {
+  args: {
+    value: 40,
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+}

--- a/packages/astro-slider/src/index.ts
+++ b/packages/astro-slider/src/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { default as Slider } from './Slider.astro'

--- a/packages/astro-steps/src/Step.astro
+++ b/packages/astro-steps/src/Step.astro
@@ -1,0 +1,20 @@
+---
+import { createStep, stepVariants } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  status?: 'completed' | 'active' | 'upcoming'
+}
+
+const { status, class: className, ...props } = Astro.props
+const api = createStep()
+---
+
+<div
+  class={cn(stepVariants({ status }), className)}
+  data-state={status ?? 'upcoming'}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-steps/src/StepContent.astro
+++ b/packages/astro-steps/src/StepContent.astro
@@ -1,0 +1,17 @@
+---
+import { createStepContent } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createStepContent()
+---
+
+<div
+  class={cn('flex-1 pb-8', className)}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-steps/src/StepDescription.astro
+++ b/packages/astro-steps/src/StepDescription.astro
@@ -1,0 +1,17 @@
+---
+import { createStepDescription, stepDescriptionVariants } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createStepDescription()
+---
+
+<p
+  class={cn(stepDescriptionVariants(), className)}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</p>

--- a/packages/astro-steps/src/StepIndicator.astro
+++ b/packages/astro-steps/src/StepIndicator.astro
@@ -1,0 +1,20 @@
+---
+import { createStepIndicator, stepIndicatorVariants } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  status?: 'completed' | 'active' | 'upcoming'
+}
+
+const { status, class: className, ...props } = Astro.props
+const api = createStepIndicator()
+---
+
+<div
+  class={cn(stepIndicatorVariants({ status }), className)}
+  data-state={status ?? 'upcoming'}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-steps/src/StepTitle.astro
+++ b/packages/astro-steps/src/StepTitle.astro
@@ -1,0 +1,17 @@
+---
+import { createStepTitle, stepTitleVariants } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {}
+
+const { class: className, ...props } = Astro.props
+const api = createStepTitle()
+---
+
+<h4
+  class={cn(stepTitleVariants(), className)}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</h4>

--- a/packages/astro-steps/src/Steps.astro
+++ b/packages/astro-steps/src/Steps.astro
@@ -1,3 +1,19 @@
 ---
+import { createSteps, stepsVariants } from '@refraction-ui/steps'
+import { cn } from '@refraction-ui/shared'
+
+interface Props extends astroHTML.JSX.HTMLAttributes {
+  orientation?: 'vertical' | 'horizontal'
+}
+
+const { orientation, class: className, ...props } = Astro.props
+const api = createSteps()
 ---
-<div></div>
+
+<div
+  class={cn(stepsVariants({ orientation }), className)}
+  {...api.dataAttributes}
+  {...props}
+>
+  <slot />
+</div>

--- a/packages/astro-steps/src/Steps.stories.ts
+++ b/packages/astro-steps/src/Steps.stories.ts
@@ -3,10 +3,16 @@ import Component from './Steps.astro'
 const meta = {
   title: 'Astro/Steps',
   component: Component,
+  argTypes: {
+    orientation: { control: 'select', options: ['vertical', 'horizontal'] },
+  },
 }
 
 export default meta
 
 export const Default = {
-  args: {},
+  args: {
+    default: '<div data-slot="step" data-state="completed"><strong>1. Account</strong></div><div data-slot="step" data-state="active"><strong>2. Profile</strong></div><div data-slot="step" data-state="upcoming"><strong>3. Review</strong></div>',
+    orientation: 'vertical',
+  }
 }

--- a/packages/astro-steps/src/index.ts
+++ b/packages/astro-steps/src/index.ts
@@ -1,1 +1,6 @@
-export { default as Steps } from './Steps.astro';
+export { default as Steps } from './Steps.astro'
+export { default as Step } from './Step.astro'
+export { default as StepIndicator } from './StepIndicator.astro'
+export { default as StepContent } from './StepContent.astro'
+export { default as StepTitle } from './StepTitle.astro'
+export { default as StepDescription } from './StepDescription.astro'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,7 +1163,17 @@ importers:
         specifier: 6.4.8
         version: 6.4.8(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3)
 
-  packages/astro-file-tree: {}
+  packages/astro-file-tree:
+    dependencies:
+      '@refraction-ui/file-tree':
+        specifier: workspace:*
+        version: link:../file-tree
+      '@refraction-ui/shared':
+        specifier: workspace:*
+        version: link:../shared
+      astro:
+        specifier: 6.4.8
+        version: 6.4.8(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3)
 
   packages/astro-file-upload:
     dependencies:
@@ -1453,7 +1463,7 @@ importers:
     dependencies:
       astro:
         specifier: 6.4.8
-        version: 6.4.8(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3)
+        version: 6.4.8(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3)
     devDependencies:
       '@refraction-ui/astro-accordion':
         specifier: workspace:*
@@ -8098,56 +8108,28 @@ packages:
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
-    engines: {node: '>=20'}
-
   '@shikijs/engine-javascript@4.0.2':
     resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
     engines: {node: '>=20'}
 
   '@shikijs/engine-oniguruma@4.0.2':
     resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
-    engines: {node: '>=20'}
-
   '@shikijs/langs@4.0.2':
     resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
-    engines: {node: '>=20'}
-
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
     engines: {node: '>=20'}
 
   '@shikijs/primitive@4.0.2':
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
-    engines: {node: '>=20'}
-
   '@shikijs/themes@4.0.2':
     resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
-    engines: {node: '>=20'}
-
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
-    engines: {node: '>=20'}
-
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -10167,14 +10149,8 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
-  oniguruma-parser@0.12.2:
-    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
-
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
-
-  oniguruma-to-es@4.3.6:
-    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -10681,10 +10657,6 @@ packages:
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
-    engines: {node: '>=20'}
-
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
   siginfo@2.0.0:
@@ -11474,7 +11446,7 @@ snapshots:
       js-yaml: 4.3.0
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
-      shiki: 4.3.1
+      shiki: 4.0.2
       smol-toml: 1.7.1
       unified: 11.0.5
 
@@ -12703,43 +12675,20 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@4.3.1':
-    dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-      hast-util-to-html: 9.0.5
-
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.5
 
-  '@shikijs/engine-javascript@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
   '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/langs@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
-
-  '@shikijs/langs@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
 
   '@shikijs/primitive@4.0.2':
     dependencies:
@@ -12747,29 +12696,14 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/primitive@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
   '@shikijs/themes@4.0.2':
     dependencies:
       '@shikijs/types': 4.0.2
-
-  '@shikijs/themes@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
 
   '@shikijs/types@4.0.2':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-
-  '@shikijs/types@4.3.1':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
@@ -13381,6 +13315,99 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  astro@6.4.8(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3):
+    dependencies:
+      '@astrojs/compiler': 4.0.0
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
+      '@astrojs/telemetry': 3.3.2
+      '@capsizecss/unpack': 4.0.1
+      '@clack/prompts': 1.7.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.4.0(rollup@4.59.0)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 1.1.1
+      devalue: 5.8.1
+      diff: 8.0.4
+      dset: 3.1.4
+      es-module-lexer: 2.3.1
+      esbuild: 0.28.1
+      flattie: 1.1.1
+      fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.3.0
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.21
+      magicast: 0.5.3
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      obug: 2.1.4
+      p-limit: 7.3.1
+      p-queue: 9.3.3
+      package-manager-detector: 1.8.0
+      piccolore: 0.1.3
+      picomatch: 4.0.4
+      rehype: 13.0.2
+      semver: 7.8.5
+      shiki: 4.0.2
+      smol-toml: 1.7.1
+      svgo: 4.0.2
+      tinyclip: 0.1.15
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      ultrahtml: 1.7.0
+      unifont: 0.7.4
+      unist-util-visit: 5.1.0
+      unstorage: 1.17.5
+      vfile: 6.0.3
+      vite: 7.3.6(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@7.3.6(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - uploadthing
+      - yaml
+
   astro@6.4.8(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 4.0.0
@@ -13422,7 +13449,7 @@ snapshots:
       picomatch: 4.0.4
       rehype: 13.0.2
       semver: 7.8.5
-      shiki: 4.3.1
+      shiki: 4.0.2
       smol-toml: 1.7.1
       svgo: 4.0.2
       tinyclip: 0.1.15
@@ -15114,17 +15141,9 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
-  oniguruma-parser@0.12.2: {}
-
   oniguruma-to-es@4.3.5:
     dependencies:
       oniguruma-parser: 0.12.1
-      regex: 6.1.0
-      regex-recursion: 6.0.2
-
-  oniguruma-to-es@4.3.6:
-    dependencies:
-      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
@@ -15758,17 +15777,6 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  shiki@4.3.1:
-    dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.5
-
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -16315,6 +16323,21 @@ snapshots:
       lightningcss: 1.32.0
       yaml: 2.8.3
 
+  vite@7.3.6(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.23
+      rollup: 4.59.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.0.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      yaml: 2.8.3
+
   vite@7.3.6(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.28.1
@@ -16329,6 +16352,10 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       yaml: 2.8.3
+
+  vitefu@1.1.3(vite@7.3.6(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
   vitefu@1.1.3(vite@7.3.6(@types/node@24.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
Brings the astro adapters to 1:1 with the react changes that landed in recent waves (real cores for pagination/slider/file-tree/steps/skip-to-content were react-only; astro side were placeholders rendering empty divs).

- **astro-pagination**: real nav landmark with windowed range, ellipsis, aria-current, disabled edges — consumes packages/pagination core
- **astro-file-tree**: real nested tree/treeitem/group markup from packages/file-tree core (+ fixed missing declared deps that would have leaked a private specifier into the meta dist)
- **astro-slider**: new Slider.astro (native range input + core normalization + ARIA) with `rfr-value-change` CustomEvent — the astro analogue of react's onChange, matching 20+ existing astro adapters' convention
- **astro-skip-to-content / astro-steps**: real implementations with core variants + data-slot hooks
- **prop parity**: astro-calendar `today` passthrough; astro-date-picker formatted-date span (format+value) matching react
- Audit-verified no-change-needed: toast, diff-viewer, file-upload, badge/callout (shared cores), command-input, search-bar, version-selector, tabs
- Deliberately left: astro-accordion/carousel (SSR-static placeholders — a details-based version would invent a divergent API, not mirror react's compound context API); astro-icon-system (intentional stub everywhere)

Harness: smoke fixtures updated for the former placeholders; deep suite gained pagination nav, file-tree treeview, slider ARIA, skip-to-content. 146/146 tests, 392/392 build/lint/typecheck/test tasks green.

## Checklist
- [x] Tests added or updated (harness smoke+deep)
- [x] Axe/Accessibility checks pass (ARIA asserted in deep tests)
- [x] Docs updated (n/a)
- [x] Changeset added (minor @refraction-ui/astro)

## Breaking changes?
None — placeholders become real components; all props optional.