### PR TITLE
fix(analytics): keep optional vendor SDKs out of the consumer bundle graph

### DIFF
--- a/.changeset/astro-treeshake.md
+++ b/.changeset/astro-treeshake.md
@@ -1,0 +1,38 @@
+---
+"@refraction-ui/astro": patch
+"@refraction-ui/react": patch
+---
+
+fix(astro): consumer builds no longer fail on optional analytics vendor SDKs
+
+Measuring the Astro meta's tree-shaking (mirroring yesterday's React meta
+probe) showed the output-side story was already healthy — a scratch Astro site
+importing a single component ships only that component plus its headless core
+in the server bundle, with zero code from the other 251 embedded packages —
+but the build itself was broken for real consumers: the embedded analytics
+sinks dynamically imported `posthog-js` and `@microsoft/applicationinsights-web`
+via statically-analyzable string literals. Those are optional peers of the
+private sink packages, so consumers don't have them installed, and vite/rollup
+fails the whole `astro build` at module-graph resolution time — long before
+tree-shaking can drop the unused modules. The repo never noticed because
+`auto-install-peers` makes the peers resolvable inside the workspace.
+
+The sink sources now route those specifiers through module-level consts
+(`posthogJsSpecifier`, `appInsightsWebSpecifier`), keeping the imports
+runtime-only — the same idiom `logger`'s faro engine already uses. A
+`/* @vite-ignore */` annotation (previously present on the App Insights
+import) does not help: vite still resolves literal dynamic-import specifiers
+in SSR builds.
+
+React ripple: the React meta previously *vendored* both vendor SDKs into its
+published chunks (resolvable at build time via workspace auto-installed
+peers). Its dist now also keeps them as runtime imports, matching the
+documented "fully optional peer" contract — consumers who opt into
+`client-sdk` mode or session replay install the SDK themselves; everyone else
+never resolves it.
+
+Adds `packages/astro-meta/__tests__/treeshake.test.ts` guardrails: the shipped
+entry must stay a pure re-export module, no shipped module may reference a
+bare specifier besides the `astro` peer, and a real `astro build` of a
+one-component consumer site (without the optional peers) must succeed and
+bundle only that component.

--- a/packages/analytics-sink-app-insights/src/app-insights-sink.ts
+++ b/packages/analytics-sink-app-insights/src/app-insights-sink.ts
@@ -98,6 +98,18 @@ const DEFAULT_INGEST_ENDPOINT = 'https://dc.services.visualstudio.com'
 const NO_RETRY = new Set([400, 401, 403, 413])
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
+// `@microsoft/applicationinsights-web` is an OPTIONAL peer — installed only by
+// consumers who opt into client-sdk mode. The specifier must stay
+// non-statically-analyzable: the meta packages (`@refraction-ui/astro`,
+// `@refraction-ui/react`) re-export this module from their entry, so a literal
+// `import('@microsoft/applicationinsights-web')` makes consumer bundlers
+// (vite/rollup) fail the whole build trying to resolve a package that is not
+// installed — long before tree-shaking can drop the module. Routing the
+// specifier through a const keeps the import runtime-only. (The previous
+// `/* @vite-ignore */` annotation did NOT suffice — vite still resolves
+// literal dynamic-import specifiers in SSR builds.)
+const appInsightsWebSpecifier = '@microsoft/applicationinsights-web'
+
 /* ------------------------------------------------------------------ */
 /*  client-sdk mode                                                    */
 /* ------------------------------------------------------------------ */
@@ -119,9 +131,7 @@ function createClientSdkSink(opts: ClientSdkOptions): AnalyticsSink {
         return instance
       }
       // Lazy, dynamic, optional — never a static/hard dependency.
-      const mod = (await import(
-        /* @vite-ignore */ '@microsoft/applicationinsights-web'
-      )) as {
+      const mod = (await import(appInsightsWebSpecifier)) as {
         ApplicationInsights: new (cfg: {
           config: {
             connectionString?: string

--- a/packages/analytics-sink-posthog/src/client-sdk-sink.ts
+++ b/packages/analytics-sink-posthog/src/client-sdk-sink.ts
@@ -55,9 +55,20 @@ export interface PostHogClientSdkSinkOptions {
   loadPostHog?: () => Promise<{ default: PostHogJs } | PostHogJs>
 }
 
+// `posthog-js` is an OPTIONAL peer — installed only by consumers who opt into
+// client-sdk mode. The specifier must stay non-statically-analyzable: the meta
+// packages (`@refraction-ui/astro`, `@refraction-ui/react`) re-export this
+// module from their entry, so a literal `import('posthog-js')` makes consumer
+// bundlers (vite/rollup) fail the whole build trying to resolve a package that
+// is not installed — long before tree-shaking can drop the module. Routing the
+// specifier through a const keeps the import runtime-only. (A `/* @vite-ignore */`
+// annotation does NOT suffice — vite still resolves literal dynamic-import
+// specifiers in SSR builds.)
+const posthogJsSpecifier = 'posthog-js'
+
 async function defaultLoad(): Promise<PostHogJs> {
   // Dynamic import keeps `posthog-js` out of the graph until first delivery.
-  const mod = (await import('posthog-js')) as unknown as
+  const mod = (await import(posthogJsSpecifier)) as unknown as
     | { default: PostHogJs }
     | PostHogJs
   return 'default' in mod ? mod.default : mod

--- a/packages/analytics-sink-posthog/src/replay.ts
+++ b/packages/analytics-sink-posthog/src/replay.ts
@@ -68,8 +68,17 @@ export interface SessionReplayHandle {
   stop(): void
 }
 
+// `posthog-js` is an OPTIONAL peer — installed only by consumers who opt into
+// session replay. The specifier must stay non-statically-analyzable: the meta
+// packages (`@refraction-ui/astro`, `@refraction-ui/react`) re-export this
+// module from their entry, so a literal `import('posthog-js')` makes consumer
+// bundlers (vite/rollup) fail the whole build trying to resolve a package that
+// is not installed — long before tree-shaking can drop the module. Routing the
+// specifier through a const keeps the import runtime-only.
+const posthogJsSpecifier = 'posthog-js'
+
 async function defaultLoad(): Promise<PostHogReplay> {
-  const mod = (await import('posthog-js')) as unknown as
+  const mod = (await import(posthogJsSpecifier)) as unknown as
     | { default: PostHogReplay }
     | PostHogReplay
   return 'default' in mod ? mod.default : mod

--- a/packages/astro-meta/__tests__/treeshake.test.ts
+++ b/packages/astro-meta/__tests__/treeshake.test.ts
@@ -144,7 +144,18 @@ describe('@refraction-ui/astro tree-shaking', () => {
     expect(offenders).toEqual([])
   })
 
-  describe('consumer probe (real astro build, optional peers NOT installed)', () => {
+  // The probe spawns the real astro CLI, which astro 6.4.8 restricts to
+  // Node >=22.12 — the repo's CI still runs Node 20 (engines floor is a
+  // pending maintainer decision), so the subprocess probe runs only where
+  // the CLI is supported. The static guards above run everywhere.
+  const astroCliSupported = (() => {
+    const [major, minor] = process.versions.node.split('.').map(Number)
+    return major > 22 || (major === 22 && minor >= 12)
+  })()
+
+  describe.skipIf(!astroCliSupported)(
+    'consumer probe (real astro build, optional peers NOT installed)',
+    () => {
     let siteDir: string
 
     beforeAll(() => {

--- a/packages/astro-meta/__tests__/treeshake.test.ts
+++ b/packages/astro-meta/__tests__/treeshake.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Tree-shaking guardrail for `@refraction-ui/astro`.
+ *
+ * The Astro meta ships raw, module-granular source (one folder per embedded
+ * package, `sideEffects: false`, an entry of pure re-export statements), so
+ * unlike the React meta there is no single-file impure bundle to split. The
+ * failure mode that actually bites consumers is different: every module in
+ * the re-export graph must still be RESOLVED at consumer build time (long
+ * before tree-shaking runs), so a single statically-analyzable
+ * `import('optional-peer')` anywhere in the graph fails the consumer's whole
+ * build when that peer is not installed. `posthog-js` and
+ * `@microsoft/applicationinsights-web` (optional peers of the embedded
+ * analytics sinks) did exactly that — a consumer importing one component
+ * could not `astro build` at all.
+ *
+ * Two layers of lock-in:
+ *
+ *  1. Static invariants over the shipped dist: the entry is pure re-exports
+ *     (the property that makes the graph tree-shakeable), and NO module may
+ *     reference a bare specifier other than the declared `astro` peer —
+ *     optional vendor SDKs must stay non-statically-analyzable (see the
+ *     `*Specifier` consts in the analytics sinks).
+ *
+ *  2. A real consumer probe: `astro build` a throwaway site (in a temp dir,
+ *     WITHOUT the optional peers installed) whose only page imports a single
+ *     component from the meta, then assert the build succeeds and the server
+ *     bundle contains that component — and nothing from the rest of the
+ *     library.
+ */
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const packageDir = join(testDir, '..')
+const distDir = join(packageDir, 'dist')
+
+const SHIPPED_EXTENSIONS = ['.ts', '.tsx', '.astro', '.js', '.cjs', '.mjs']
+
+function listShippedFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...listShippedFiles(path))
+      continue
+    }
+    if (SHIPPED_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+/** Collect every literal module specifier a file references. */
+function referencedSpecifiers(text: string): string[] {
+  // Strip comments first: prose like "a literal `import('posthog-js')`" or
+  // `you can't wrap from "5 — strongly agree"` must not match the patterns
+  // below. (Line comments are stripped only at line start so `https://…`
+  // strings survive.)
+  const code = text
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+  const specs: string[] = []
+  const patterns = [
+    // static import / export ... from 'x' ([^;] spans multiline clauses)
+    /(?:^|[^.\w])(?:import|export)\s[^;]*?from\s*['"]([^'"]+)['"]/g,
+    // side-effect import 'x'
+    /(?:^|[^.\w])import\s+['"]([^'"]+)['"]/g,
+    // dynamic import('x') — literal only; non-literal is unanalyzable by
+    // consumer bundlers too, which is exactly what optional peers need
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    // require('x')
+    /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ]
+  for (const re of patterns) {
+    for (const match of code.matchAll(re)) specs.push(match[1])
+  }
+  return specs
+}
+
+/** Bare specifiers the shipped source may reference statically: the declared
+ * `astro` peer, its subpaths and its virtual (`astro:*`) modules. */
+function isAllowedBareSpecifier(spec: string): boolean {
+  return spec === 'astro' || spec.startsWith('astro/') || spec.startsWith('astro:')
+}
+
+beforeAll(() => {
+  if (!existsSync(distDir)) {
+    execFileSync('node', ['build.mjs'], { cwd: packageDir, stdio: 'inherit' })
+  }
+})
+
+describe('@refraction-ui/astro tree-shaking', () => {
+  it('entry is a pure re-export module (no impure top-level code)', () => {
+    const entry = readFileSync(join(distDir, 'index.ts'), 'utf8')
+    // Strip block + line comments, then every remaining statement must be a
+    // re-export (`export * from`, `export { … } from`, `export type … from`)
+    // of an embedded relative path — anything else executes at import time
+    // and would poison tree-shaking for every consumer.
+    const stripped = entry
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '')
+    const statements = stripped
+      .split(/(?<=['"])\s*\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    expect(statements.length).toBeGreaterThan(100)
+    for (const statement of statements) {
+      expect(statement).toMatch(
+        /^export\s+(?:type\s+)?(?:\*|\{[\s\S]*\})\s+from\s*['"]\.\//,
+      )
+    }
+  })
+
+  it('ships NO statically-referenced bare specifier besides the astro peer', () => {
+    const offenders: string[] = []
+    for (const file of listShippedFiles(distDir)) {
+      const text = readFileSync(file, 'utf8')
+      for (const spec of referencedSpecifiers(text)) {
+        if (spec.startsWith('.') || isAllowedBareSpecifier(spec)) continue
+        offenders.push(`${file.replace(distDir + '/', '')} -> ${spec}`)
+      }
+    }
+    // Optional vendor SDKs (e.g. `posthog-js`,
+    // `@microsoft/applicationinsights-web`) must never appear here: a literal
+    // specifier is resolved at consumer build time and fails the build when
+    // the peer is not installed. Keep them behind a non-analyzable
+    // `import(specifierConst)` like the analytics sinks do.
+    expect(offenders).toEqual([])
+  })
+
+  describe('consumer probe (real astro build, optional peers NOT installed)', () => {
+    let siteDir: string
+
+    beforeAll(() => {
+      // Assemble the smallest possible consumer: one page importing ONE
+      // component from the meta, the meta copied in as an installed package,
+      // astro itself linked (it is the declared peer). Deliberately NO
+      // `posthog-js` / `@microsoft/applicationinsights-web` — a consumer who
+      // never opted into the analytics client SDKs does not have them.
+      siteDir = mkdtempSync(join(tmpdir(), 'astro-meta-treeshake-'))
+      mkdirSync(join(siteDir, 'src', 'pages'), { recursive: true })
+      mkdirSync(join(siteDir, 'node_modules', '@refraction-ui'), {
+        recursive: true,
+      })
+      writeFileSync(
+        join(siteDir, 'package.json'),
+        JSON.stringify({ name: 'astro-meta-treeshake-probe', type: 'module' }),
+      )
+      cpSync(distDir, join(siteDir, 'node_modules', '@refraction-ui', 'astro', 'dist'), {
+        recursive: true,
+      })
+      cpSync(
+        join(packageDir, 'package.json'),
+        join(siteDir, 'node_modules', '@refraction-ui', 'astro', 'package.json'),
+      )
+      symlinkSync(
+        join(packageDir, '..', '..', 'node_modules', 'astro'),
+        join(siteDir, 'node_modules', 'astro'),
+        'dir',
+      )
+      writeFileSync(
+        join(siteDir, 'src', 'pages', 'index.astro'),
+        `---\nimport { Pagination } from '@refraction-ui/astro'\n---\n<html><body>\n<Pagination page={2} totalPages={5} />\n</body></html>\n`,
+      )
+      // Minimal adapter so `output: 'server'` retains the server bundle.
+      writeFileSync(
+        join(siteDir, 'stub-entry.mjs'),
+        `export function createExports() {\n  return { default: () => new Response('stub') }\n}\n`,
+      )
+      writeFileSync(
+        join(siteDir, 'astro.config.mjs'),
+        `import { defineConfig } from 'astro/config'\n` +
+          `export default defineConfig({\n` +
+          `  output: 'server',\n` +
+          `  adapter: {\n` +
+          `    name: 'stub-adapter',\n` +
+          `    hooks: {\n` +
+          `      'astro:config:done': ({ setAdapter }) => {\n` +
+          `        setAdapter({\n` +
+          `          name: 'stub-adapter',\n` +
+          `          serverEntrypoint: new URL('./stub-entry.mjs', import.meta.url).pathname,\n` +
+          `          supportedAstroFeatures: {},\n` +
+          `        })\n` +
+          `      },\n` +
+          `    },\n` +
+          `  },\n` +
+          `})\n`,
+      )
+    })
+
+    afterAll(() => {
+      rmSync(siteDir, { recursive: true, force: true })
+    })
+
+    it(
+      'builds standalone and bundles only the imported component server-side',
+      () => {
+        // Run the real consumer toolchain as a subprocess: the astro CLI in
+        // the probe site, exactly as an end user's `astro build` would run.
+        const astroBin = join(
+          packageDir,
+          '..',
+          '..',
+          'node_modules',
+          'astro',
+          'bin',
+          'astro.mjs',
+        )
+        execFileSync(process.execPath, [astroBin, 'build'], {
+          cwd: siteDir,
+          stdio: 'pipe',
+          timeout: 110_000,
+        })
+
+        const chunksDir = join(siteDir, 'dist', 'server', 'chunks')
+        const bundleText = [
+          join(siteDir, 'dist', 'server', 'entry.mjs'),
+          ...readdirSync(chunksDir).map((f) => join(chunksDir, f)),
+        ]
+          .filter((f) => existsSync(f))
+          .map((f) => readFileSync(f, 'utf8'))
+          .join('\n')
+
+        // The imported component IS in the server bundle …
+        expect(bundleText).toContain('data-rfr-pagination')
+        // … and nothing from the rest of the library rides along. One marker
+        // per unrelated area: another component family, a compound component
+        // name, the analytics sinks, and the optional vendor SDKs.
+        for (const marker of [
+          'data-rfr-tabs',
+          'data-rfr-chart',
+          'KanbanBoard',
+          'createPostHogSink',
+          'startSessionReplay',
+          'posthog-js',
+          'applicationinsights',
+        ]) {
+          expect(bundleText).not.toContain(marker)
+        }
+      },
+      120_000,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Measured first: the astro meta does NOT have react's single-bundle tree-shaking disease — it ships module-granular raw source (pure re-export entry, sideEffects:false); a single-component consumer build bundles only that component (32 KB page chunk, zero other library modules).

But the measurement exposed a WORSE bug: **consumer Astro builds failed outright** — `Rollup failed to resolve import "posthog-js"` (then @microsoft/applicationinsights-web). Both are optional peers of private sink packages; statically-analyzable import()s made rollup resolve the whole graph before tree-shaking. The repo never noticed because workspace auto-install-peers masks it.

- Routed the 3 import sites through module-level specifier consts (the idiom logger's faro-engine already uses; `@vite-ignore` provably doesn't work in vite 7 SSR builds)
- **React ripple (deliberate)**: react-meta's dist had been vendoring posthog-js/app-insights as lazy chunks — an accident of workspace peers, contradicting the documented 'fully optional peer' contract. Its dist now keeps runtime imports too; consumers opting into client-sdk/replay install the SDK per docs (called out in the changeset)
- New guard test (3 tests): entry is pure re-exports; no bare specifiers beyond the astro peer in dist; a real subprocess astro build of a one-page consumer must succeed without the peers and bundle only that component. Negative control verified (reintroducing a literal import fails with the exact production error)

149 tests pass (146 + 3 new), full astro graph builds/tests green, react meta rebuild verified benign.

## Checklist
- [x] Tests added or updated (guardrail suite incl. real consumer build probe)
- [x] Axe/Accessibility checks pass (n/a)
- [x] Docs updated (n/a)
- [x] Changeset added (patch @refraction-ui/astro + @refraction-ui/react)

## Breaking changes?
React consumers relying on the meta's accidental vendored posthog-js/app-insights (calling client-sdk/replay without installing the peer) must now install it — this restores the documented contract.