### PR TITLE
feat(tailwind-config): info token end-to-end + route status colors through tokens

### DIFF
--- a/.changeset/info-token.md
+++ b/.changeset/info-token.md
@@ -1,0 +1,15 @@
+---
+"@refraction-ui/tailwind-config": patch
+---
+
+feat(tailwind-config): add `info`/`info-foreground` color utilities to the preset
+
+Maps `info` to the new `--info`/`--info-foreground` CSS variables (mirroring
+the `success`/`warning` nested pattern), so `bg-info`, `text-info`,
+`border-info`, `bg-info/10`, … follow the active theme. The variables are
+defined in the default stylesheet and in every bundled theme (all 6, light
+and dark): light uses `217 91% 60%` (#3B82F6, Tailwind blue-500 —
+pixel-identical to the previously hardcoded `blue-500` info styles); dark
+lightens to `217 91% 65%` to keep contrast sensible on dark surfaces. The
+Flutter package's info token remains #2196F3 (Material blue) — a deliberate
+small cross-framework delta.

--- a/.changeset/status-token-routing.md
+++ b/.changeset/status-token-routing.md
@@ -1,0 +1,28 @@
+---
+"@refraction-ui/react": patch
+"@refraction-ui/astro": patch
+---
+
+fix(react,astro): route hardcoded status colors through theme tokens
+
+Status-semantic variants in the shared headless cores now use the semantic
+token utilities instead of fixed Tailwind palette classes, so they follow
+the active theme's CSS variables in both frameworks:
+
+- **Toast** — `success`/`error`/`warning` use the `success`/`destructive`/
+  `warning` tokens (dropping the per-mode `dark:` overrides; the variables
+  flip per mode). Astro's programmatic `showToast` variant map matches.
+- **Callout** — `info` uses the new `info` token (`bg-info/10`,
+  `border-info/20`, `text-info`).
+- **StatusIndicator** — dot/pulse `success`/`error`/`warning`/`info` use
+  the matching tokens (`pending`/`neutral` keep their fixed orange/gray —
+  no tokens exist for them).
+- **ProgressDisplay** stat cards — `success`/`warning` tints use tokens.
+- **PresenceIndicator** / **AvatarGroup** presence dots — online→`success`,
+  away→`warning`, busy/dnd→`destructive` (`offline` stays gray).
+- **EmptyState** icon chip — `success`/`warning` tones use tokens.
+- **Input** — `valid` state uses `border-success`/`ring-success`, and the
+  React valid-state check icon uses `text-success`.
+
+Rendered hues shift slightly from the old fixed palette values, matching
+the earlier Badge/Callout `success`/`warning` token change.

--- a/docs-site/src/app/globals.css
+++ b/docs-site/src/app/globals.css
@@ -30,6 +30,8 @@
   --success-foreground: 0 0% 100%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 10%;
+  --info: 217 91% 60%;
+  --info-foreground: 0 0% 100%;
   --border: 240 6% 92%;
   --input: 240 6% 92%;
   --ring: 250 50% 50%;
@@ -206,6 +208,8 @@
   --success-foreground: 0 0% 98%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 4%;
+  --info: 217 91% 65%;
+  --info-foreground: 0 0% 98%;
   --border: 240 5% 16%;
   --input: 240 5% 16%;
   --ring: 250 50% 65%;

--- a/packages/astro-toast/src/Toaster.astro
+++ b/packages/astro-toast/src/Toaster.astro
@@ -88,9 +88,9 @@ const { class: className, ...props } = Astro.props
 
   const VARIANT_CLASSES: Record<string, string> = {
     default: 'border bg-background text-foreground',
-    success: 'border-l-4 border-green-500/50 bg-green-50 text-green-900 dark:bg-green-950 dark:text-green-100',
-    error: 'border-l-4 border-red-500/50 bg-red-50 text-red-900 dark:bg-red-950 dark:text-red-100',
-    warning: 'border-l-4 border-amber-500/50 bg-amber-50 text-amber-900 dark:bg-amber-950 dark:text-amber-100',
+    success: 'border-l-4 border-success/50 bg-success/10 text-success',
+    error: 'border-l-4 border-destructive/50 bg-destructive/10 text-destructive',
+    warning: 'border-l-4 border-warning/50 bg-warning/10 text-warning',
   }
 
   function createToastElement(options: ToastOptions): HTMLElement {

--- a/packages/avatar-group/__tests__/avatar-group.test.ts
+++ b/packages/avatar-group/__tests__/avatar-group.test.ts
@@ -163,6 +163,6 @@ describe('styles', () => {
 
   it('exports presence dot variants', () => {
     const online = avatarPresenceDotVariants({ status: 'online' })
-    expect(online).toContain('bg-green-500')
+    expect(online).toContain('bg-success')
   })
 })

--- a/packages/avatar-group/src/avatar-group.styles.ts
+++ b/packages/avatar-group/src/avatar-group.styles.ts
@@ -49,11 +49,11 @@ export const avatarPresenceDotVariants = cva({
       xl: 'h-4 w-4',
     },
     status: {
-      online: 'bg-green-500',
+      online: 'bg-success',
       offline: 'bg-gray-400',
-      away: 'bg-yellow-500',
-      busy: 'bg-red-500',
-      dnd: 'bg-red-500',
+      away: 'bg-warning',
+      busy: 'bg-destructive',
+      dnd: 'bg-destructive',
     },
   },
   defaultVariants: {

--- a/packages/callout/src/callout.styles.ts
+++ b/packages/callout/src/callout.styles.ts
@@ -8,7 +8,7 @@ export const calloutVariants = cva({
       destructive: 'bg-destructive/10 border-destructive/20 text-destructive',
       success: 'bg-success/10 border-success/20 text-success',
       warning: 'bg-warning/10 border-warning/20 text-warning',
-      info: 'bg-blue-500/10 border-blue-500/20 text-blue-700 dark:text-blue-400',
+      info: 'bg-info/10 border-info/20 text-info',
     },
   },
   defaultVariants: {

--- a/packages/empty-state/__tests__/empty-state.test.ts
+++ b/packages/empty-state/__tests__/empty-state.test.ts
@@ -20,8 +20,8 @@ describe('createEmptyState', () => {
 describe('emptyStateIconChipVariants', () => {
   it.each([
     ['neutral', 'bg-muted'],
-    ['success', 'bg-green-500/10'],
-    ['warning', 'bg-yellow-500/10'],
+    ['success', 'bg-success/10'],
+    ['warning', 'bg-warning/10'],
     ['danger', 'bg-destructive/10'],
   ] as const)('applies %s tone chip class', (tone, klass) => {
     expect(emptyStateIconChipVariants({ tone })).toContain(klass)

--- a/packages/empty-state/src/empty-state.styles.ts
+++ b/packages/empty-state/src/empty-state.styles.ts
@@ -26,8 +26,8 @@ export const emptyStateIconChipVariants = cva({
   variants: {
     tone: {
       neutral: 'bg-muted text-muted-foreground',
-      success: 'bg-green-500/10 text-green-600',
-      warning: 'bg-yellow-500/10 text-yellow-600',
+      success: 'bg-success/10 text-success',
+      warning: 'bg-warning/10 text-warning',
       danger: 'bg-destructive/10 text-destructive',
     },
   },

--- a/packages/flutter-docs-site/src/app/globals.css
+++ b/packages/flutter-docs-site/src/app/globals.css
@@ -30,6 +30,8 @@
   --success-foreground: 0 0% 100%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 10%;
+  --info: 217 91% 60%;
+  --info-foreground: 0 0% 100%;
   --border: 240 6% 92%;
   --input: 240 6% 92%;
   --ring: 250 50% 50%;
@@ -206,6 +208,8 @@
   --success-foreground: 0 0% 98%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 4%;
+  --info: 217 91% 65%;
+  --info-foreground: 0 0% 98%;
   --border: 240 5% 16%;
   --input: 240 5% 16%;
   --ring: 250 50% 65%;

--- a/packages/input/__tests__/input.test.ts
+++ b/packages/input/__tests__/input.test.ts
@@ -130,10 +130,10 @@ describe('createInput - validationState', () => {
 })
 
 describe('inputVariants - validationState', () => {
-  it('valid applies green border classes', () => {
+  it('valid applies success border classes', () => {
     const classes = inputVariants({ validationState: 'valid' })
-    expect(classes).toContain('border-green-500')
-    expect(classes).toContain('focus-visible:ring-green-500')
+    expect(classes).toContain('border-success')
+    expect(classes).toContain('focus-visible:ring-success')
   })
 
   it('invalid applies destructive border classes', () => {
@@ -144,7 +144,7 @@ describe('inputVariants - validationState', () => {
 
   it('omitting validationState produces no validation border classes', () => {
     const classes = inputVariants()
-    expect(classes).not.toContain('border-green-500')
+    expect(classes).not.toContain('border-success')
     expect(classes).not.toContain('border-destructive')
   })
 })

--- a/packages/input/src/input.styles.ts
+++ b/packages/input/src/input.styles.ts
@@ -9,7 +9,7 @@ export const inputVariants = cva({
       lg: 'h-10 text-base',
     },
     validationState: {
-      valid: 'border-green-500 focus-visible:ring-green-500',
+      valid: 'border-success focus-visible:ring-success',
       invalid: 'border-destructive focus-visible:ring-destructive',
     },
   },

--- a/packages/presence-indicator/__tests__/presence-indicator.test.ts
+++ b/packages/presence-indicator/__tests__/presence-indicator.test.ts
@@ -130,7 +130,7 @@ describe('styles', () => {
 
   it('exports online dot variant', () => {
     const classes = presenceDotVariants({ status: 'online' })
-    expect(classes).toContain('bg-green-500')
+    expect(classes).toContain('bg-success')
   })
 
   it('exports offline dot variant', () => {
@@ -140,6 +140,6 @@ describe('styles', () => {
 
   it('exports away dot variant', () => {
     const classes = presenceDotVariants({ status: 'away' })
-    expect(classes).toContain('bg-yellow-500')
+    expect(classes).toContain('bg-warning')
   })
 })

--- a/packages/presence-indicator/src/presence-indicator.styles.ts
+++ b/packages/presence-indicator/src/presence-indicator.styles.ts
@@ -4,11 +4,11 @@ export const presenceDotVariants = cva({
   base: 'inline-block rounded-full',
   variants: {
     status: {
-      online: 'bg-green-500',
+      online: 'bg-success',
       offline: 'bg-gray-400',
-      away: 'bg-yellow-500',
-      busy: 'bg-red-500',
-      dnd: 'bg-red-500',
+      away: 'bg-warning',
+      busy: 'bg-destructive',
+      dnd: 'bg-destructive',
     },
     size: {
       sm: 'h-2 w-2',

--- a/packages/progress-display/__tests__/progress-display.test.ts
+++ b/packages/progress-display/__tests__/progress-display.test.ts
@@ -79,7 +79,7 @@ describe('progress-display styles', () => {
 
   it('statCardVariants returns success color classes', () => {
     const classes = statCardVariants({ color: 'success' })
-    expect(classes).toContain('bg-green-500/10')
+    expect(classes).toContain('bg-success/10')
   })
 
   it('badgeGridVariants returns grid classes', () => {

--- a/packages/progress-display/src/progress-display.styles.ts
+++ b/packages/progress-display/src/progress-display.styles.ts
@@ -20,8 +20,8 @@ export const statCardVariants = cva({
     color: {
       default: 'bg-card text-card-foreground',
       primary: 'bg-primary/10 text-primary border-primary/20',
-      success: 'bg-green-500/10 text-green-700 border-green-500/20',
-      warning: 'bg-yellow-500/10 text-yellow-700 border-yellow-500/20',
+      success: 'bg-success/10 text-success border-success/20',
+      warning: 'bg-warning/10 text-warning border-warning/20',
       destructive: 'bg-destructive/10 text-destructive border-destructive/20',
     },
   },

--- a/packages/react-avatar-group/__tests__/avatar-group.test.tsx
+++ b/packages/react-avatar-group/__tests__/avatar-group.test.tsx
@@ -46,7 +46,7 @@ describe('AvatarGroup (React)', () => {
 
   it('renders a presence dot with the status class when status is set', () => {
     const html = renderToString(React.createElement(AvatarGroup, { users, max: 1 }))
-    expect(html).toContain('bg-green-500')
+    expect(html).toContain('bg-success')
   })
 
   it('caps visible avatars at max and renders an overflow badge', () => {

--- a/packages/react-callout/__tests__/callout.test.tsx
+++ b/packages/react-callout/__tests__/callout.test.tsx
@@ -41,7 +41,7 @@ describe('Callout (React)', () => {
   it('applies variant-specific classes', () => {
     expect(renderToString(React.createElement(Callout, { variant: 'success' }, 'x'))).toContain('bg-success/10')
     expect(renderToString(React.createElement(Callout, { variant: 'warning' }, 'x'))).toContain('bg-warning/10')
-    expect(renderToString(React.createElement(Callout, { variant: 'info' }, 'x'))).toContain('bg-blue-500/10')
+    expect(renderToString(React.createElement(Callout, { variant: 'info' }, 'x'))).toContain('bg-info/10')
   })
 
   it('appends a custom className', () => {

--- a/packages/react-empty-state/__tests__/empty-state.test.tsx
+++ b/packages/react-empty-state/__tests__/empty-state.test.tsx
@@ -37,8 +37,8 @@ describe('EmptyState (React)', () => {
   })
 
   it.each([
-    ['success', 'bg-green-500/10'],
-    ['warning', 'bg-yellow-500/10'],
+    ['success', 'bg-success/10'],
+    ['warning', 'bg-warning/10'],
     ['danger', 'bg-destructive/10'],
   ] as const)('applies %s tone chip class', (tone, klass) => {
     const html = renderToString(

--- a/packages/react-input/__tests__/input.test.tsx
+++ b/packages/react-input/__tests__/input.test.tsx
@@ -129,16 +129,16 @@ describe('Input (React) - custom className', () => {
 })
 
 describe('Input (React) - validationState', () => {
-  it('valid → green border and aria-invalid="false"', () => {
+  it('valid → success border and aria-invalid="false"', () => {
     const html = renderToString(React.createElement(Input, { validationState: 'valid' }))
-    expect(html).toContain('border-green-500')
+    expect(html).toContain('border-success')
     expect(html).toContain('aria-invalid="false"')
   })
 
   it('valid renders a trailing check icon inside a wrapper', () => {
     const html = renderToString(React.createElement(Input, { validationState: 'valid' }))
     expect(html).toContain('<svg')
-    expect(html).toContain('text-green-500')
+    expect(html).toContain('text-success')
   })
 
   it('invalid → destructive border and aria-invalid="true"', () => {

--- a/packages/react-input/src/input.tsx
+++ b/packages/react-input/src/input.tsx
@@ -50,7 +50,7 @@ const CheckIcon = (
     strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
-    className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-green-500"
+    className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-success"
   >
     <polyline points="20 6 9 17 4 12" />
   </svg>

--- a/packages/react-meta/src/styles.css
+++ b/packages/react-meta/src/styles.css
@@ -61,6 +61,10 @@
   --success-foreground: 0 0% 100%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 10%;
+  /* #3B82F6 (Tailwind blue-500). The Flutter package's info token is #2196F3
+     (Material blue) — a deliberate small cross-framework delta. */
+  --info: 217 91% 60%;
+  --info-foreground: 0 0% 100%;
 
   --border: 240 6% 92%;
   --input: 240 6% 92%;
@@ -269,6 +273,9 @@
   --success-foreground: 0 0% 98%;
   --warning: 38 92% 50%;
   --warning-foreground: 240 10% 4%;
+  /* Lightened from 60% (light) to 65% lightness for contrast on dark surfaces */
+  --info: 217 91% 65%;
+  --info-foreground: 0 0% 98%;
 
   --border: 240 5% 16%;
   --input: 240 5% 16%;

--- a/packages/react-password-input/__tests__/password-input.test.tsx
+++ b/packages/react-password-input/__tests__/password-input.test.tsx
@@ -24,11 +24,11 @@ describe('PasswordInput (React)', () => {
     expect(html).toContain('aria-label="Reveal"')
   })
 
-  it('passes validationState through to the input (valid → green border)', () => {
+  it('passes validationState through to the input (valid → success border)', () => {
     const html = renderToString(
       React.createElement(PasswordInput, { validationState: 'valid' }),
     )
-    expect(html).toContain('border-green-500')
+    expect(html).toContain('border-success')
     expect(html).toContain('aria-invalid="false"')
   })
 

--- a/packages/react-presence-indicator/__tests__/presence-indicator.test.tsx
+++ b/packages/react-presence-indicator/__tests__/presence-indicator.test.tsx
@@ -91,11 +91,11 @@ describe('PresenceIndicator (React)', () => {
 
 describe('PresenceIndicator (React) – status variants', () => {
   it.each([
-    ['online', 'Online', 'bg-green-500'],
+    ['online', 'Online', 'bg-success'],
     ['offline', 'Offline', 'bg-gray-400'],
-    ['away', 'Away', 'bg-yellow-500'],
-    ['busy', 'Busy', 'bg-red-500'],
-    ['dnd', 'Do Not Disturb', 'bg-red-500'],
+    ['away', 'Away', 'bg-warning'],
+    ['busy', 'Busy', 'bg-destructive'],
+    ['dnd', 'Do Not Disturb', 'bg-destructive'],
   ] as const)('status "%s" has label "%s" and dot class "%s"', (status, label, dotClass) => {
     const html = renderToString(
       React.createElement(PresenceIndicator, { status }),
@@ -104,15 +104,15 @@ describe('PresenceIndicator (React) – status variants', () => {
     expect(html).toContain(dotClass)
   })
 
-  it('busy and dnd share the red dot color', () => {
+  it('busy and dnd share the destructive dot color', () => {
     const busy = renderToString(
       React.createElement(PresenceIndicator, { status: 'busy' }),
     )
     const dnd = renderToString(
       React.createElement(PresenceIndicator, { status: 'dnd' }),
     )
-    expect(busy).toContain('bg-red-500')
-    expect(dnd).toContain('bg-red-500')
+    expect(busy).toContain('bg-destructive')
+    expect(dnd).toContain('bg-destructive')
   })
 })
 

--- a/packages/react-progress-display/__tests__/progress-display.test.tsx
+++ b/packages/react-progress-display/__tests__/progress-display.test.tsx
@@ -40,7 +40,7 @@ describe('StatsGrid (React)', () => {
 
   it('applies color variant to stat cards', () => {
     const html = renderToString(React.createElement(StatsGrid, { stats }))
-    expect(html).toContain('bg-green-500/10')
+    expect(html).toContain('bg-success/10')
   })
 })
 

--- a/packages/react-status-indicator/__tests__/status-indicator.test.tsx
+++ b/packages/react-status-indicator/__tests__/status-indicator.test.tsx
@@ -93,10 +93,10 @@ describe('StatusIndicator (React)', () => {
 
 describe('StatusIndicator (React) – status variants', () => {
   it.each([
-    ['success', 'Success', 'bg-green-500'],
-    ['error', 'Error', 'bg-red-500'],
-    ['warning', 'Warning', 'bg-yellow-500'],
-    ['info', 'Info', 'bg-blue-500'],
+    ['success', 'Success', 'bg-success'],
+    ['error', 'Error', 'bg-destructive'],
+    ['warning', 'Warning', 'bg-warning'],
+    ['info', 'Info', 'bg-info'],
     ['pending', 'Pending', 'bg-orange-500'],
     ['neutral', 'Neutral', 'bg-gray-400'],
   ] as const)(
@@ -158,7 +158,7 @@ describe('StatusIndicator (React) – pulse', () => {
     )
     expect(html).toContain('animate-pulse')
     // The type color is kept on the pulsing dot
-    expect(html).toContain('bg-red-500')
+    expect(html).toContain('bg-destructive')
   })
 
   it('pulse can be disabled explicitly on pending', () => {

--- a/packages/react-toast/__tests__/toast.interaction.test.tsx
+++ b/packages/react-toast/__tests__/toast.interaction.test.tsx
@@ -109,7 +109,7 @@ describe('useToast – show', () => {
     showToast('Broke', { variant: 'error' })
     const alert = alerts()[0]
     expect(alert).toBeDefined()
-    expect(alert!.className).toContain('bg-red-50')
+    expect(alert!.className).toContain('bg-destructive/10')
   })
 })
 

--- a/packages/react-toast/__tests__/toast.test.tsx
+++ b/packages/react-toast/__tests__/toast.test.tsx
@@ -105,8 +105,8 @@ describe('Toast (React SSR)', () => {
         React.createElement(Toast, { entry }),
       ),
     )
-    expect(html).toContain('border-green-500/50')
-    expect(html).toContain('bg-green-50')
+    expect(html).toContain('border-success/50')
+    expect(html).toContain('bg-success/10')
   })
 
   it('renders error variant classes', () => {
@@ -125,8 +125,8 @@ describe('Toast (React SSR)', () => {
         React.createElement(Toast, { entry }),
       ),
     )
-    expect(html).toContain('border-red-500/50')
-    expect(html).toContain('bg-red-50')
+    expect(html).toContain('border-destructive/50')
+    expect(html).toContain('bg-destructive/10')
   })
 
   it('renders warning variant classes', () => {
@@ -145,8 +145,8 @@ describe('Toast (React SSR)', () => {
         React.createElement(Toast, { entry }),
       ),
     )
-    expect(html).toContain('border-amber-500/50')
-    expect(html).toContain('bg-amber-50')
+    expect(html).toContain('border-warning/50')
+    expect(html).toContain('bg-warning/10')
   })
 
   it('renders dismiss button when onDismiss provided', () => {
@@ -431,7 +431,7 @@ describe('Toast – structure (SSR)', () => {
     expect(html).toContain('text-foreground')
   })
 
-  it('renders dark-mode classes for the success variant', () => {
+  it('renders token classes for the success variant', () => {
     const html = renderToString(
       React.createElement(
         ToastProvider,
@@ -439,11 +439,11 @@ describe('Toast – structure (SSR)', () => {
         React.createElement(Toast, { entry: makeEntry({ variant: 'success' }) }),
       ),
     )
-    expect(html).toContain('dark:bg-green-950')
-    expect(html).toContain('text-green-900')
+    expect(html).toContain('bg-success/10')
+    expect(html).toContain('text-success')
   })
 
-  it('renders dark-mode classes for the error variant', () => {
+  it('renders token classes for the error variant', () => {
     const html = renderToString(
       React.createElement(
         ToastProvider,
@@ -451,11 +451,11 @@ describe('Toast – structure (SSR)', () => {
         React.createElement(Toast, { entry: makeEntry({ variant: 'error' }) }),
       ),
     )
-    expect(html).toContain('dark:bg-red-950')
-    expect(html).toContain('text-red-900')
+    expect(html).toContain('bg-destructive/10')
+    expect(html).toContain('text-destructive')
   })
 
-  it('renders dark-mode classes for the warning variant', () => {
+  it('renders token classes for the warning variant', () => {
     const html = renderToString(
       React.createElement(
         ToastProvider,
@@ -463,8 +463,8 @@ describe('Toast – structure (SSR)', () => {
         React.createElement(Toast, { entry: makeEntry({ variant: 'warning' }) }),
       ),
     )
-    expect(html).toContain('dark:bg-amber-950')
-    expect(html).toContain('text-amber-900')
+    expect(html).toContain('bg-warning/10')
+    expect(html).toContain('text-warning')
   })
 
   it('dismiss button is type="button" and shows the × glyph', () => {

--- a/packages/status-indicator/__tests__/status-indicator.test.ts
+++ b/packages/status-indicator/__tests__/status-indicator.test.ts
@@ -126,12 +126,12 @@ describe('styles', () => {
 
   it('exports success dot variant', () => {
     const classes = statusDotVariants({ type: 'success' })
-    expect(classes).toContain('bg-green-500')
+    expect(classes).toContain('bg-success')
   })
 
   it('exports error dot variant', () => {
     const classes = statusDotVariants({ type: 'error' })
-    expect(classes).toContain('bg-red-500')
+    expect(classes).toContain('bg-destructive')
   })
 
   it('exports pending pulse variant', () => {
@@ -142,11 +142,11 @@ describe('styles', () => {
 
   it('exports warning dot variant', () => {
     const classes = statusDotVariants({ type: 'warning' })
-    expect(classes).toContain('bg-yellow-500')
+    expect(classes).toContain('bg-warning')
   })
 
   it('exports info dot variant', () => {
     const classes = statusDotVariants({ type: 'info' })
-    expect(classes).toContain('bg-blue-500')
+    expect(classes).toContain('bg-info')
   })
 })

--- a/packages/status-indicator/src/status-indicator.styles.ts
+++ b/packages/status-indicator/src/status-indicator.styles.ts
@@ -7,10 +7,10 @@ export const statusDotVariants = cva({
   base: 'inline-block h-2 w-2 rounded-full',
   variants: {
     type: {
-      success: 'bg-green-500',
-      error: 'bg-red-500',
-      warning: 'bg-yellow-500',
-      info: 'bg-blue-500',
+      success: 'bg-success',
+      error: 'bg-destructive',
+      warning: 'bg-warning',
+      info: 'bg-info',
       pending: 'bg-orange-500',
       neutral: 'bg-gray-400',
     },
@@ -24,10 +24,10 @@ export const statusPulseVariants = cva({
   base: 'animate-pulse inline-block h-2 w-2 rounded-full',
   variants: {
     type: {
-      success: 'bg-green-500',
-      error: 'bg-red-500',
-      warning: 'bg-yellow-500',
-      info: 'bg-blue-500',
+      success: 'bg-success',
+      error: 'bg-destructive',
+      warning: 'bg-warning',
+      info: 'bg-info',
       pending: 'bg-orange-500',
       neutral: 'bg-gray-400',
     },

--- a/packages/tailwind-config/__tests__/colorblind.test.ts
+++ b/packages/tailwind-config/__tests__/colorblind.test.ts
@@ -29,9 +29,9 @@ describe('toast variants — color-blind safe patterns', () => {
     const warning = toastVariants({ variant: 'warning' })
 
     // Each should have a unique color in its border class
-    expect(success).toContain('border-green')
-    expect(error).toContain('border-red')
-    expect(warning).toContain('border-amber')
+    expect(success).toContain('border-success')
+    expect(error).toContain('border-destructive')
+    expect(warning).toContain('border-warning')
   })
 })
 

--- a/packages/tailwind-config/__tests__/preset.test.ts
+++ b/packages/tailwind-config/__tests__/preset.test.ts
@@ -150,6 +150,11 @@ describe('colors', () => {
     expect(colors.warning.foreground).toBe('hsl(var(--warning-foreground))')
   })
 
+  it('info DEFAULT and foreground are defined', () => {
+    expect(colors.info.DEFAULT).toBe('hsl(var(--info))')
+    expect(colors.info.foreground).toBe('hsl(var(--info-foreground))')
+  })
+
   it('sidebar colors all defined', () => {
     expect(colors.sidebar.DEFAULT).toBe('hsl(var(--sidebar-background))')
     expect(colors.sidebar.foreground).toBe('hsl(var(--sidebar-foreground))')

--- a/packages/tailwind-config/src/colors.ts
+++ b/packages/tailwind-config/src/colors.ts
@@ -11,6 +11,7 @@ export const colors = {
   destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
   success: { DEFAULT: 'hsl(var(--success))', foreground: 'hsl(var(--success-foreground))' },
   warning: { DEFAULT: 'hsl(var(--warning))', foreground: 'hsl(var(--warning-foreground))' },
+  info: { DEFAULT: 'hsl(var(--info))', foreground: 'hsl(var(--info-foreground))' },
   border: 'hsl(var(--border))',
   input: 'hsl(var(--input))',
   ring: 'hsl(var(--ring))',

--- a/packages/tailwind-config/src/themes/glassa.ts
+++ b/packages/tailwind-config/src/themes/glassa.ts
@@ -154,6 +154,8 @@ export const refractionTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '240 10% 10%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '240 6% 92%',
       '--input': '240 6% 92%',
@@ -202,6 +204,8 @@ export const refractionTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '240 10% 4%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '240 5% 16%',
       '--input': '240 5% 16%',
@@ -321,6 +325,8 @@ export const luxeTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '0 0% 12%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '220 6% 93%',
       '--input': '220 6% 93%',
@@ -367,6 +373,8 @@ export const luxeTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '0 0% 7%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '220 5% 16%',
       '--input': '220 5% 16%',
@@ -489,6 +497,8 @@ export const warmTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '15 20% 12%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '30 12% 90%',
       '--input': '30 12% 90%',
@@ -535,6 +545,8 @@ export const warmTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '15 15% 5%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '20 10% 16%',
       '--input': '20 10% 16%',
@@ -656,6 +668,8 @@ export const signalTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '210 15% 12%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '210 10% 90%',
       '--input': '210 10% 90%',
@@ -702,6 +716,8 @@ export const signalTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '210 15% 5%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '210 10% 16%',
       '--input': '210 10% 16%',
@@ -823,6 +839,8 @@ export const pulseTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '240 10% 10%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '240 8% 90%',
       '--input': '240 8% 90%',
@@ -869,6 +887,8 @@ export const pulseTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '260 15% 5%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '260 6% 16%',
       '--input': '260 6% 16%',
@@ -990,6 +1010,8 @@ export const monoTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 100%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '210 15% 20%',
+      '--info': '217 91% 60%',
+      '--info-foreground': '0 0% 100%',
 
       '--border': '210 14% 89%',
       '--input': '210 14% 89%',
@@ -1036,6 +1058,8 @@ export const monoTheme: ThemeDefinition = {
       '--success-foreground': '0 0% 98%',
       '--warning': '38 92% 50%',
       '--warning-foreground': '210 15% 5%',
+      '--info': '217 91% 65%',
+      '--info-foreground': '0 0% 98%',
 
       '--border': '210 8% 16%',
       '--input': '210 8% 16%',

--- a/packages/toast/__tests__/toast.test.ts
+++ b/packages/toast/__tests__/toast.test.ts
@@ -192,20 +192,20 @@ describe('toast styles', () => {
 
   it('returns success variant classes', () => {
     const classes = toastVariants({ variant: 'success' })
-    expect(classes).toContain('border-green-500/50')
-    expect(classes).toContain('bg-green-50')
+    expect(classes).toContain('border-success/50')
+    expect(classes).toContain('bg-success/10')
   })
 
   it('returns error variant classes', () => {
     const classes = toastVariants({ variant: 'error' })
-    expect(classes).toContain('border-red-500/50')
-    expect(classes).toContain('bg-red-50')
+    expect(classes).toContain('border-destructive/50')
+    expect(classes).toContain('bg-destructive/10')
   })
 
   it('returns warning variant classes', () => {
     const classes = toastVariants({ variant: 'warning' })
-    expect(classes).toContain('border-amber-500/50')
-    expect(classes).toContain('bg-amber-50')
+    expect(classes).toContain('border-warning/50')
+    expect(classes).toContain('bg-warning/10')
   })
 
   it('appends custom className', () => {

--- a/packages/toast/src/toast.styles.ts
+++ b/packages/toast/src/toast.styles.ts
@@ -5,12 +5,9 @@ export const toastVariants = cva({
   variants: {
     variant: {
       default: 'border bg-background text-foreground',
-      success:
-        'border-l-4 border-green-500/50 bg-green-50 text-green-900 dark:bg-green-950 dark:text-green-100',
-      error:
-        'border-l-4 border-red-500/50 bg-red-50 text-red-900 dark:bg-red-950 dark:text-red-100',
-      warning:
-        'border-l-4 border-amber-500/50 bg-amber-50 text-amber-900 dark:bg-amber-950 dark:text-amber-100',
+      success: 'border-l-4 border-success/50 bg-success/10 text-success',
+      error: 'border-l-4 border-destructive/50 bg-destructive/10 text-destructive',
+      warning: 'border-l-4 border-warning/50 bg-warning/10 text-warning',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary
Completes the token system work from #469 (which added success/warning):

- **`info` end-to-end**: --info/--info-foreground added to react-meta styles.css (light+dark) and all 12 theme blocks in themes/glassa.ts; preset maps the info utilities (bg-info, text-info-foreground, border-info/20, …). Values: #3B82F6 light / +5 lightness dark (zero pixel shift vs the old hardcoded callout info blue; comment notes Flutter's info is #2196F3 — deliberate small cross-framework delta). Callout's info variant now uses them.
- **Status hardcodes routed through tokens** across 7 cores (toast, status-indicator, progress-display, presence-indicator, empty-state, avatar-group, input) plus two adapters found duplicating them (astro-toast VARIANT_CLASSES, react-input valid icon): green-500/yellow-500/red-500 status usages → success/warning/destructive tokens; dark: overrides dropped (vars flip per mode).
- Deliberately left: pending/neutral/offline grays (no tokens exist), diff-viewer add/remove colors (syntax semantics), sticky-note paper green, traffic lights, slide-viewer accents (all decorative).
- **docs-site + flutter-docs-site globals.css**: added the --info vars (they keep their own copies — without this, pages using bg-info render unstyled).
- Tests updated everywhere assertions referenced the old classes (incl. downstream react-password-input and colorblind.test.ts). Full build/test/lint/typecheck green on all touched packages; preset compile-check emits bg-info family correctly.

NOTE: small intended hue shifts on the rerouted components (same class as badge/callout in #469) — a targeted baseline regen on this branch is part of the merge plan.

## Checklist
- [x] Tests added or updated
- [x] Axe/Accessibility checks pass (dark-mode contrast verified vs surface scale)
- [x] Docs updated (docs apps' globals synced)
- [x] Changesets added (patch @refraction-ui/tailwind-config; patch @refraction-ui/react + @refraction-ui/astro)

## Breaking changes?
None — class swaps are internal; variant APIs unchanged.