### PR TITLE
ci: consolidate PR checks — Test Matrix runs the graph once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,29 +31,14 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
 
-  dependencies:
+  # Single coverage run, main pushes only. On PRs the full
+  # lint+typecheck+test+build graph already runs in "Test Matrix"
+  # (test-matrix.yml); the old build-test-* jobs here re-ran that entire graph
+  # a second time per PR (and a `dependencies` job duplicated PR Validation's
+  # "Audit dependencies" step) for the codecov signal alone.
+  coverage:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-      - name: Install deps
-        run: make install
-      - name: Check for outdated dependencies
-        run: pnpm outdated || true
-      - name: Audit dependencies
-        run: make audit
-
-  build-test-react:
-    runs-on: ubuntu-latest
-    needs: [security, dependencies]
     permissions:
       contents: read
     steps:
@@ -79,72 +64,16 @@ jobs:
             turbo-${{ runner.os }}-
       - name: Install deps
         run: make install
-      - name: Run CI for React
-        run: pnpm turbo run lint typecheck test:coverage build --filter="!*astro*" --continue
-      - name: Build Storybooks — React
-        run: pnpm build-storybook
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-  build-test-astro:
-    runs-on: ubuntu-latest
-    needs: [security, dependencies]
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10.13.1
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
-      - name: Cache Turborepo
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
-          # Restore this job's own most recent cache first. The bare
-          # `turbo-<os>-` prefix alone matched EVERY job's cache across all
-          # workflows (whichever saved last), so jobs routinely restored a
-          # foreign, near-useless snapshot.
-          restore-keys: |
-            turbo-${{ runner.os }}-${{ github.job }}-
-            turbo-${{ runner.os }}-
-      - name: Install deps
-        run: make install
-      - name: Run CI for Astro
-        run: pnpm turbo run lint typecheck test:coverage build --filter="*astro*" --continue
-      - name: Build Storybooks — Astro
-        run: pnpm build-storybook:astro
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-  build-test-flutter:
-    runs-on: ubuntu-latest
-    needs: [security, dependencies]
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
+      - name: Run CI with coverage
+        run: pnpm turbo run lint typecheck test:coverage build --continue
       - name: Setup Flutter
         uses: subosito/flutter-action@v2.16.0
         with:
           channel: stable
-      - name: Install Dependencies
+      - name: Install Flutter Dependencies
         working-directory: packages/flutter
         run: flutter pub get
-      - name: Static Analysis
-        working-directory: packages/flutter
-        run: dart analyze lib
-      - name: Run Tests with Coverage
+      - name: Run Flutter Tests with Coverage
         working-directory: packages/flutter
         run: flutter test --coverage || echo "Flutter tests failed, ignoring for now"
       - name: Upload coverage reports

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -76,24 +76,11 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      # Persist Turborepo's local cache across runs (free, GitHub Actions cache
-      # backed). A PR that touches a few packages then replays everything else
-      # from cache instead of re-running lint/typecheck/test/build for all ~250
-      # packages. PR branches restore from main's cache via the restore-keys
-      # prefix; keyed by sha so each run also saves a fresh snapshot.
-      - name: Cache Turborepo
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-validation-${{ github.sha }}
-          # Restore the validation job's own most recent cache first; the
-          # bare `turbo-<os>-` prefix stays as a cross-job fallback only.
-          restore-keys: |
-            turbo-${{ runner.os }}-validation-
-            turbo-${{ runner.os }}-
+      # The full lint+typecheck+test+build graph no longer runs here — that
+      # coverage lives in "Test Matrix" (test-matrix.yml), which runs the same
+      # graph on every PR. This job keeps only the dependency audit (known-red
+      # on a pre-existing esbuild advisory; tolerated, not gating).
       - run: make install
-      - name: Run CI
-        run: make ci
       - name: Audit dependencies
         run: make audit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,9 +81,9 @@ ones that bite every time:
 
 Publishing is CI-only (Changesets → Version PR → OIDC). Key gating facts in
 `CLAUDE.md` → "CI gating facts": only `commit-lint` is required; the
-`validation`/`dependencies` **audit** step fails on a pre-existing esbuild
-advisory and does **not** gate publishing (but confirm the validation **"Run CI"**
-step is green); the `Release` workflow fires on **Test Matrix** success on `main`,
+`validation` **audit** step fails on a pre-existing esbuild
+advisory and does **not** gate publishing (but confirm the **Test Matrix**
+jobs — the full lint/typecheck/test/build graph — are green); the `Release` workflow fires on **Test Matrix** success on `main`,
 then a `chore: release packages` Version PR must be merged to publish. Flutter
 publishes to pub.dev via the `flutter-publish` tag (golden tests excluded from
 the gate).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,20 +220,28 @@ reason new feature packages must stay private and ride the metas.
 
 - **Only `commit-lint` is a required status check.** Everything else is
   informational at the branch-protection level.
-- The **`dependencies` / `validation` "Audit dependencies"** step fails on a
+- The **`validation` "Audit dependencies"** step fails on a
   **pre-existing transitive esbuild advisory** that is present on `main` and
   unrelated to component work. It does **not** gate the release pipeline. Do not
-  treat it as your failure — but **do** confirm the `validation` job's **"Run CI"
-  step** (the full `make ci`: lint + typecheck + test + build) **succeeded**;
-  that is the real green signal. Verify by step conclusion, never assume.
+  treat it as your failure — but **do** confirm the **Test Matrix** jobs
+  (`test-matrix-react` / `test-matrix-astro` — the full lint + typecheck +
+  test + build graph, run on every PR) **succeeded**; that is the real green
+  signal. Verify by job conclusion, never assume.
+- **Workflow division of labor on PRs:** `PR Validation` = PR-meta checks
+  (title/description/branch/commit-lint/summary) + the audit; `Test Matrix` =
+  the full lint/typecheck/test/build graph + `browser-tests`; `CI` =
+  `commit-lint` + CodeQL only (its `coverage` job — the one remaining
+  full-graph run with `test:coverage` + codecov — is main-push-only);
+  `Visual Regression Tests` = Playwright + Lost Pixel. The graph intentionally
+  runs once per PR — don't re-add it to `CI` or `PR Validation`.
 - The **`Release` workflow is `workflow_run` on _"Test Matrix"_ success** (not on
   the "CI" workflow). So the publish pipeline is gated by **Test Matrix passing
   on `main`**, regardless of the audit red. Sequence after merging a feature PR:
   Test Matrix (main) → Release opens the **`chore: release packages` Version PR**
   → merge it → Test Matrix again → Release sees no changesets → `publish-oidc`
   publishes via OIDC. Each Test Matrix run is ~25–35 min; poll, don't assume.
-- Admin-merging past the audit red is acceptable **only after** the validation
-  "Run CI" step is confirmed green and `commit-lint` passes. Surface that you did
+- Admin-merging past the audit red is acceptable **only after** the Test Matrix
+  jobs are confirmed green and `commit-lint` passes. Surface that you did
   so and why.
 - The recurring esbuild audit failure is tracked separately; if asked to fix CI
   reds, that audit advisory — not your component — is usually the culprit.


### PR DESCRIPTION
## Summary
Every PR ran the full ~390-package graph **3×** (ci.yml build-test jobs, test-matrix, pr-validation's 'Run CI'). Consolidated, keeping every check name that exists today:

- **test-matrix.yml — untouched** (release.yml's workflow_run watches its name; its 4 jobs stay byte-stable)
- **ci.yml** — keeps commit-lint + security (CodeQL); deletes the duplicate build-test-react/astro/flutter jobs (already skip-blocked on the audit red in practice); gains ONE `coverage` job on **main pushes only** (test:coverage + flutter coverage + single codecov upload — coverage moves off the PR path)
- **pr-validation.yml** — keeps all meta checks (pr-title/description/branch/summary + commit-lint) and the known-tolerated 'Audit dependencies' step; drops its duplicate 'Run CI' full-graph step
- Gating signal moves to the Test Matrix jobs — CLAUDE.md/AGENTS.md 'CI gating facts' updated to match

Verified: live branch protection (only commit-lint required) via gh api; every check name survives (commit-lint still arrives from both workflows); all make/turbo targets referenced exist; all 9 workflow YAMLs parse. Net effect: PR compute ~3× → 1×.

## Checklist
- [x] Tests added or updated (gate coverage preserved)
- [x] Axe/Accessibility checks pass (n/a)
- [x] Docs updated (CLAUDE.md/AGENTS.md gating facts)
- [ ] Changeset added (CI only)

## Breaking changes?
Check names 'dependencies'/'build-test-*' disappear (non-required duplicates). The 'validation' check now contains only the audit step — still the known tolerated red.