### PR TITLE
docs: document why decorative colors are deliberately not tokenized

### DIFF
--- a/packages/diff-viewer/src/diff-viewer.styles.ts
+++ b/packages/diff-viewer/src/diff-viewer.styles.ts
@@ -9,6 +9,9 @@ export const diffViewerTokens: TokenContract = {
     sidebarBg: { variable: '--rfr-diff-sidebar-bg', fallback: 'hsl(var(--muted))' },
     headerBg: { variable: '--rfr-diff-header-bg', fallback: 'hsl(var(--muted))' },
     border: { variable: '--rfr-diff-border', fallback: 'hsl(var(--border))' },
+    // Diff add/del colors are syntax semantics (like code highlighting), not
+    // theme status tones — deliberately NOT routed through the success/
+    // destructive tokens. The --rfr-diff-* variables are the theming seam.
     addBg: { variable: '--rfr-diff-add-bg', fallback: 'rgba(46, 160, 67, 0.15)' },
     delBg: { variable: '--rfr-diff-del-bg', fallback: 'rgba(248, 81, 73, 0.15)' },
     addFg: { variable: '--rfr-diff-add-fg', fallback: '#3fb950' },

--- a/packages/react-browser-chrome-mock/src/browser-chrome-mock.tsx
+++ b/packages/react-browser-chrome-mock/src/browser-chrome-mock.tsx
@@ -24,6 +24,7 @@ export interface BrowserChromeMockProps
 }
 
 /** Three traffic-light dots rendered in the chrome bar. */
+// macOS window-chrome realism, not status tones — deliberately not tokenized.
 const TRAFFIC_DOTS = ['bg-red-400', 'bg-yellow-400', 'bg-green-400'] as const
 
 /**

--- a/packages/slide-viewer/src/slide-viewer.styles.ts
+++ b/packages/slide-viewer/src/slide-viewer.styles.ts
@@ -45,6 +45,8 @@ export { slideViewerProgressBarVariants as progressBarVariants }
 export const slideTypeBadgeVariants = cva({
   base: 'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
   variants: {
+    // Slide-type accents are a content-category palette (lesson/quiz/exercise…),
+    // not status tones — deliberately not routed through the theme tokens.
     type: {
       lesson: 'bg-blue-100 text-blue-800',
       quiz: 'bg-purple-100 text-purple-800',

--- a/packages/sticky-note/src/sticky-note.styles.ts
+++ b/packages/sticky-note/src/sticky-note.styles.ts
@@ -14,6 +14,8 @@ export const stickyNoteVariants = cva({
     'min-w-[160px] min-h-[120px]',
   ].join(' '),
   variants: {
+    // Named paper colors are product semantics (physical sticky notes),
+    // not status tones — deliberately not routed through the theme tokens.
     color: {
       yellow: 'bg-yellow-100 text-yellow-900',
       pink: 'bg-pink-100 text-pink-900',


### PR DESCRIPTION
## Summary
Closes the token work's last loose end: the remaining hardcoded colors were deliberately left in #475 (decorative, not status). This records that decision inline so future sweeps don't re-flag them:

- **diff-viewer add/del** — syntax semantics (like code highlighting); the `--rfr-diff-*` vars with fallbacks are the theming seam
- **sticky-note** — named paper colors (physical product semantics)
- **slide-viewer type badges** — content-category accent palette (lesson/quiz/exercise…)
- **browser-chrome traffic lights** — macOS window realism

Comments only; zero behavior change. Lint/typecheck green on all 4 touched packages.

## Checklist
- [x] Tests added or updated (n/a — comments)
- [x] Axe/Accessibility checks pass (n/a)
- [x] Docs updated (this is it)
- [ ] Changeset added (no runtime change)

## Breaking changes?
None.