### PR TITLE
feat(flutter): token-driven look via extended color + scale vocabulary

### DIFF
--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.49.0
+
+- **Theme (additive, non-breaking): a much richer, semantic-role token vocabulary so a product's whole look is token-driven.** Every new token is **optional** with a getter that **derives a sensible default from the existing tokens**, so all curated palettes, the six named-theme statics, and every existing `RefractionColors`/`RefractionThemeData` construction keep compiling and rendering **pixel-identically** — nothing new is required.
+  - **`RefractionColors` — new color roles** (each a nullable field + default-deriving getter, all wired through `copyWith`/`lerp`):
+    - Brand depth: `primaryHover` (primary darkened ~6%), `primaryActive` (primary darkened ~12%), `primarySoft` (primary blended ~12% over `background`), `primarySoftForeground` (→ `primary`), `primaryGradient` (`List<Color>`, → `[primary, primary]`).
+    - Second brand hue: `tertiary` (→ `secondary`), `tertiaryForeground` (→ `secondaryForeground`), `tertiarySoft` (tertiary blended ~12% over `background`), `tertiarySoftForeground` (→ `tertiary`).
+    - Ink/surface: `placeholder` (→ `mutedForeground`), `surfaceSubtle` (→ `muted`), `borderSubtle` (`border` pulled ~50% toward `background`).
+    - Status: `positive` (→ `success`), `positiveForeground` (→ white), `caution` (→ `warning`), `cautionForeground` (→ white), `done` (→ `success`), `neutral` (→ `mutedForeground`), `neutralForeground` (→ `foreground`), `pending` (→ `warning`), `pendingForeground` (→ white).
+    - Charts: `chart1`–`chart5` — a categorical ramp seeded from `primary` (`chart1` = `primary`; the rest are hue-rotations of it).
+  - **`RefractionThemeData` — new non-color scales** (nullable + default-deriving getters, all wired through `copyWith`):
+    - Radius scale: `radiusSm`/`radiusMd`/`radiusLg` (→ base `borderRadius`), `radiusPill` (999), `radiusSheet` (`borderRadius * 3.5`).
+    - Elevation scale: `elevationSm`/`elevationMd`/`elevationLg` + `shadowTint` (→ `colors.foreground`). `softShadow`/`heavyShadow` are now back-compat aliases of `elevationSm`/`elevationLg` (resolved both directions).
+    - Spacing scale: `spacingXs`/`spacingSm`/`spacingMd`/`spacingLg`/`spacingXl` (4/8/12/16/24) + `gutter` (16); control sizing `controlHeightSm`/`controlHeightMd`/`controlHeightLg` (32/36/44).
+    - Typography: a new `RefractionTypography` token type — fonts-by-role (`fontDisplay`/`fontBody`/`fontMono`/`fontSerif`, defaulting to the theme `fontFamily`), a role-based type scale (`display`/`headline`/`title`/`body`/`label`/`caption`/`kicker`), optional variable-font weight (`FontVariation`), and a `textScale` factor (default 1.0) — wired as an optional `typography` field with a default instance and a `resolvedTypography` getter.
+  - **Components**: `RefractionButton` now reads `radiusMd`, `controlHeight*`, and the `spacing*` scale; `RefractionCard` reads `radiusLg`/`elevationSm` and its header/content/footer paddings read `spacingXl`. Every derived default equals the value these components used before, so appearance is unchanged.
+
 ## 0.48.0
 
 - **BREAKING — Media components moved out of core.** The media/conferencing

--- a/packages/flutter/lib/refraction_ui.dart
+++ b/packages/flutter/lib/refraction_ui.dart
@@ -33,6 +33,7 @@ library;
 export 'src/theme/refraction_colors.dart';
 export 'src/theme/refraction_theme.dart';
 export 'src/theme/refraction_theme_data.dart';
+export 'src/theme/refraction_typography.dart';
 export 'src/components/accordion.dart';
 export 'src/components/diff_viewer.dart';
 export 'src/components/dropdown_menu.dart';
@@ -186,5 +187,3 @@ export 'src/components/radial_gauge.dart';
 export 'src/components/timeline.dart';
 export 'src/components/mascot.dart';
 export 'src/components/checklist.dart';
-
-

--- a/packages/flutter/lib/src/components/button.dart
+++ b/packages/flutter/lib/src/components/button.dart
@@ -130,6 +130,7 @@ class _RefractionButtonState extends State<RefractionButton> {
   @override
   Widget build(BuildContext context) {
     final theme = RefractionTheme.of(context);
+    final data = theme.data;
     final colors = theme.colors;
 
     Color backgroundColor;
@@ -185,32 +186,46 @@ class _RefractionButtonState extends State<RefractionButton> {
     double? minWidth;
     double? minHeight;
 
+    // Padding and control heights read the theme's spacing/control-height
+    // scales; the derived defaults equal the historical literals, so sizing is
+    // unchanged. The off-scale values (default's 10px vertical inset and lg's
+    // 32px horizontal inset) stay literal as they never sat on the 4/8/12/16
+    // spacing steps.
     switch (widget.size) {
       case RefractionButtonSize.sm:
-        padding = const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
+        padding = EdgeInsets.symmetric(
+          horizontal: data.spacingMd,
+          vertical: data.spacingSm,
+        );
         fontSize = 12.0;
-        minHeight = 32.0;
+        minHeight = data.controlHeightSm;
         break;
       case RefractionButtonSize.lg:
-        padding = const EdgeInsets.symmetric(horizontal: 32, vertical: 12);
+        padding = EdgeInsets.symmetric(
+          horizontal: 32,
+          vertical: data.spacingMd,
+        );
         fontSize = 16.0;
-        minHeight = 44.0;
+        minHeight = data.controlHeightLg;
         break;
       case RefractionButtonSize.icon:
         padding = EdgeInsets.zero;
         fontSize = 16.0;
-        minWidth = 36.0;
-        minHeight = 36.0;
+        minWidth = data.controlHeightMd;
+        minHeight = data.controlHeightMd;
         break;
       case RefractionButtonSize.defaultSize:
-        padding = const EdgeInsets.symmetric(horizontal: 16, vertical: 10);
+        padding = EdgeInsets.symmetric(
+          horizontal: data.spacingLg,
+          vertical: 10,
+        );
         fontSize = 14.0;
-        minHeight = 36.0;
+        minHeight = data.controlHeightMd;
         break;
     }
 
     Widget content = DefaultTextStyle(
-      style: theme.data.textStyle.copyWith(
+      style: data.textStyle.copyWith(
         color: foregroundColor,
         fontSize: fontSize,
         fontWeight: FontWeight.w500,
@@ -252,7 +267,10 @@ class _RefractionButtonState extends State<RefractionButton> {
             padding: padding,
             decoration: BoxDecoration(
               color: backgroundColor,
-              borderRadius: BorderRadius.circular(theme.borderRadius),
+              // radiusMd defaults to the base borderRadius, so corners are
+              // unchanged; a consumer can now round controls independently of
+              // cards via the radius scale.
+              borderRadius: BorderRadius.circular(data.radiusMd),
               border: borderColor != null
                   ? Border.all(color: borderColor)
                   : null,

--- a/packages/flutter/lib/src/components/card.dart
+++ b/packages/flutter/lib/src/components/card.dart
@@ -68,9 +68,12 @@ class RefractionCard extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: colors.card,
-        borderRadius: BorderRadius.circular(theme.borderRadius),
+        // radiusLg/elevationSm default to the base borderRadius and the soft
+        // shadow stack respectively, so cards are unchanged; a consumer can
+        // now round or elevate cards independently of controls.
+        borderRadius: BorderRadius.circular(theme.radiusLg),
         border: Border.all(color: colors.border),
-        boxShadow: theme.softShadow,
+        boxShadow: theme.elevationSm,
       ),
       child: DefaultTextStyle(style: theme.textStyle, child: child),
     );
@@ -86,19 +89,17 @@ class RefractionCardHeader extends StatelessWidget {
   /// [RefractionCardDescription].
   final Widget child;
 
-  /// Padding around the header. Defaults to 24 logical pixels on every side.
-  final EdgeInsetsGeometry padding;
+  /// Padding around the header. When null, defaults to the theme's
+  /// [RefractionThemeData.spacingXl] (24 logical pixels) on every side.
+  final EdgeInsetsGeometry? padding;
 
   /// Creates a [RefractionCardHeader].
-  const RefractionCardHeader({
-    super.key,
-    required this.child,
-    this.padding = const EdgeInsets.all(24),
-  });
+  const RefractionCardHeader({super.key, required this.child, this.padding});
 
   @override
   Widget build(BuildContext context) {
-    return Padding(padding: padding, child: child);
+    final spacing = context.refractionTheme.spacingXl;
+    return Padding(padding: padding ?? EdgeInsets.all(spacing), child: child);
   }
 }
 
@@ -163,20 +164,23 @@ class RefractionCardContent extends StatelessWidget {
   /// The body content of the card.
   final Widget child;
 
-  /// Padding around the body. Defaults to 24 pixels on the left, right, and
+  /// Padding around the body. When null, defaults to the theme's
+  /// [RefractionThemeData.spacingXl] (24 pixels) on the left, right, and
   /// bottom — leaving the top tight against [RefractionCardHeader].
-  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? padding;
 
   /// Creates a [RefractionCardContent].
-  const RefractionCardContent({
-    super.key,
-    required this.child,
-    this.padding = const EdgeInsets.only(left: 24, right: 24, bottom: 24),
-  });
+  const RefractionCardContent({super.key, required this.child, this.padding});
 
   @override
   Widget build(BuildContext context) {
-    return Padding(padding: padding, child: child);
+    final spacing = context.refractionTheme.spacingXl;
+    return Padding(
+      padding:
+          padding ??
+          EdgeInsets.only(left: spacing, right: spacing, bottom: spacing),
+      child: child,
+    );
   }
 }
 
@@ -188,9 +192,10 @@ class RefractionCardFooter extends StatelessWidget {
   /// Footer content, typically a [RefractionButton] or a small group of them.
   final Widget child;
 
-  /// Padding around the footer. Defaults to 24 pixels on the left, right,
-  /// and bottom.
-  final EdgeInsetsGeometry padding;
+  /// Padding around the footer. When null, defaults to the theme's
+  /// [RefractionThemeData.spacingXl] (24 pixels) on the left, right, and
+  /// bottom.
+  final EdgeInsetsGeometry? padding;
 
   /// Horizontal alignment of the footer row. Defaults to
   /// [MainAxisAlignment.start].
@@ -200,14 +205,17 @@ class RefractionCardFooter extends StatelessWidget {
   const RefractionCardFooter({
     super.key,
     required this.child,
-    this.padding = const EdgeInsets.only(left: 24, right: 24, bottom: 24),
+    this.padding,
     this.mainAxisAlignment = MainAxisAlignment.start,
   });
 
   @override
   Widget build(BuildContext context) {
+    final spacing = context.refractionTheme.spacingXl;
     return Padding(
-      padding: padding,
+      padding:
+          padding ??
+          EdgeInsets.only(left: spacing, right: spacing, bottom: spacing),
       // Wrap footer content in a Row as it's typically action buttons laid out horizontally
       child: Row(mainAxisAlignment: mainAxisAlignment, children: [child]),
     );

--- a/packages/flutter/lib/src/theme/hsl_color.dart
+++ b/packages/flutter/lib/src/theme/hsl_color.dart
@@ -24,3 +24,46 @@ class HslColor {
     }
   }
 }
+
+/// Small, dependency-free color transforms used to derive the extended
+/// semantic roles (hover/active steps, soft tints, hairline borders, a
+/// categorical chart ramp) from the base palette tokens.
+///
+/// These are the fallbacks behind [RefractionColors]' derived getters: when a
+/// consumer does not supply an explicit value for an extended role, the getter
+/// computes a sensible default from an existing token via one of these
+/// operations, so a bare palette still exposes the full vocabulary.
+class ColorMath {
+  const ColorMath._();
+
+  /// Darkens [color] by [amount] (0.0–1.0) by reducing its HSL lightness.
+  ///
+  /// Used for the `primaryHover` (~6%) and `primaryActive` (~12%) brand
+  /// depth steps. The result is clamped to a valid lightness range.
+  static Color darken(Color color, double amount) {
+    final hsl = HSLColor.fromColor(color);
+    final lightness = (hsl.lightness - amount).clamp(0.0, 1.0);
+    return hsl.withLightness(lightness).toColor();
+  }
+
+  /// Returns [overlay] laid over [base] at opacity [amount] (0.0 = [base],
+  /// 1.0 = [overlay]).
+  ///
+  /// Used for soft brand/second-hue tints (e.g. `primarySoft` = the brand at
+  /// ~12% over the background) and the hairline `borderSubtle` (the border
+  /// pulled ~50% toward the background).
+  static Color mix(Color base, Color overlay, double amount) {
+    return Color.lerp(base, overlay, amount)!;
+  }
+
+  /// Rotates the hue of [color] by [degrees] around the color wheel, keeping
+  /// saturation and lightness.
+  ///
+  /// Seeds a categorical chart ramp (`chart1`–`chart5`) from a single brand
+  /// color so a bare palette still yields visually distinct series colors.
+  static Color rotateHue(Color color, double degrees) {
+    final hsl = HSLColor.fromColor(color);
+    final hue = (hsl.hue + degrees) % 360.0;
+    return hsl.withHue(hue < 0 ? hue + 360.0 : hue).toColor();
+  }
+}

--- a/packages/flutter/lib/src/theme/refraction_colors.dart
+++ b/packages/flutter/lib/src/theme/refraction_colors.dart
@@ -103,12 +103,149 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
   /// highlights that should not read as the brand [primary].
   final Color info;
 
+  // ---------------------------------------------------------------------------
+  // Extended semantic roles (all optional).
+  //
+  // Every field below is stored as a nullable "override" and exposed through a
+  // same-named getter that derives a sensible default from the base tokens
+  // when the override is null. A palette that sets only the original tokens
+  // therefore still exposes the whole extended vocabulary, and no existing
+  // construction has to change. Supply an override to break away from the
+  // derived default for one role without touching the rest.
+  // ---------------------------------------------------------------------------
+
+  final Color? _primaryHover;
+  final Color? _primaryActive;
+  final Color? _primarySoft;
+  final Color? _primarySoftForeground;
+  final List<Color>? _primaryGradient;
+  final Color? _tertiary;
+  final Color? _tertiaryForeground;
+  final Color? _tertiarySoft;
+  final Color? _tertiarySoftForeground;
+  final Color? _placeholder;
+  final Color? _surfaceSubtle;
+  final Color? _borderSubtle;
+  final Color? _positive;
+  final Color? _positiveForeground;
+  final Color? _caution;
+  final Color? _cautionForeground;
+  final Color? _done;
+  final Color? _neutral;
+  final Color? _neutralForeground;
+  final Color? _pending;
+  final Color? _pendingForeground;
+  final Color? _chart1;
+  final Color? _chart2;
+  final Color? _chart3;
+  final Color? _chart4;
+  final Color? _chart5;
+
+  /// White, used as the default foreground for filled status surfaces
+  /// ([positive], [caution], [pending]) whose base hue is dark enough to
+  /// carry white text/icons.
+  static const Color _statusForeground = Color(0xFFFFFFFF);
+
+  /// Hover step for [primary] surfaces. Defaults to [primary] darkened ~6%.
+  Color get primaryHover => _primaryHover ?? ColorMath.darken(primary, 0.06);
+
+  /// Pressed/active step for [primary] surfaces. Defaults to [primary]
+  /// darkened ~12%.
+  Color get primaryActive => _primaryActive ?? ColorMath.darken(primary, 0.12);
+
+  /// Soft, tinted brand fill (e.g. selected rows, highlighted chips).
+  /// Defaults to [primary] blended ~12% over [background].
+  Color get primarySoft =>
+      _primarySoft ?? ColorMath.mix(background, primary, 0.12);
+
+  /// Foreground for text/icons drawn on [primarySoft]. Defaults to [primary].
+  Color get primarySoftForeground => _primarySoftForeground ?? primary;
+
+  /// Gradient stops for a brand-gradient fill. Defaults to a flat
+  /// `[primary, primary]` so a gradient paint is visually identical to a solid
+  /// [primary] until a real ramp is supplied.
+  List<Color> get primaryGradient =>
+      _primaryGradient ?? <Color>[primary, primary];
+
+  /// A second brand accent hue, distinct from [primary]. Defaults to
+  /// [secondary].
+  Color get tertiary => _tertiary ?? secondary;
+
+  /// Foreground for content on [tertiary]. Defaults to [secondaryForeground].
+  Color get tertiaryForeground => _tertiaryForeground ?? secondaryForeground;
+
+  /// Soft, tinted second-accent fill. Defaults to [tertiary] blended ~12%
+  /// over [background].
+  Color get tertiarySoft =>
+      _tertiarySoft ?? ColorMath.mix(background, tertiary, 0.12);
+
+  /// Foreground for content on [tertiarySoft]. Defaults to [tertiary].
+  Color get tertiarySoftForeground => _tertiarySoftForeground ?? tertiary;
+
+  /// Placeholder text color for empty inputs. Defaults to [mutedForeground].
+  Color get placeholder => _placeholder ?? mutedForeground;
+
+  /// A quieter surface than [card]/[background] for subtle grouping.
+  /// Defaults to [muted].
+  Color get surfaceSubtle => _surfaceSubtle ?? muted;
+
+  /// A hairline border, lighter than [border]. Defaults to [border] pulled
+  /// ~50% toward [background].
+  Color get borderSubtle =>
+      _borderSubtle ?? ColorMath.mix(border, background, 0.5);
+
+  /// Positive/confirmation status color. Defaults to [success].
+  Color get positive => _positive ?? success;
+
+  /// Foreground for content on [positive]. Defaults to white.
+  Color get positiveForeground => _positiveForeground ?? _statusForeground;
+
+  /// Caution status color (softer than [destructive]). Defaults to [warning].
+  Color get caution => _caution ?? warning;
+
+  /// Foreground for content on [caution]. Defaults to white.
+  Color get cautionForeground => _cautionForeground ?? _statusForeground;
+
+  /// "Completed"/done status color. Defaults to [success].
+  Color get done => _done ?? success;
+
+  /// Neutral status color (inactive/offline dots, muted chips). Defaults to
+  /// [mutedForeground] — a mid gray independent of the brand hue.
+  Color get neutral => _neutral ?? mutedForeground;
+
+  /// Foreground for content on [neutral]. Defaults to [foreground].
+  Color get neutralForeground => _neutralForeground ?? foreground;
+
+  /// Pending/in-progress status color. Defaults to [warning].
+  Color get pending => _pending ?? warning;
+
+  /// Foreground for content on [pending]. Defaults to white.
+  Color get pendingForeground => _pendingForeground ?? _statusForeground;
+
+  /// First categorical chart color. Defaults to [primary].
+  Color get chart1 => _chart1 ?? primary;
+
+  /// Second categorical chart color. Defaults to [primary] hue-rotated 45°.
+  Color get chart2 => _chart2 ?? ColorMath.rotateHue(primary, 45);
+
+  /// Third categorical chart color. Defaults to [primary] hue-rotated 135°.
+  Color get chart3 => _chart3 ?? ColorMath.rotateHue(primary, 135);
+
+  /// Fourth categorical chart color. Defaults to [primary] hue-rotated 215°.
+  Color get chart4 => _chart4 ?? ColorMath.rotateHue(primary, 215);
+
+  /// Fifth categorical chart color. Defaults to [primary] hue-rotated 300°.
+  Color get chart5 => _chart5 ?? ColorMath.rotateHue(primary, 300);
+
   /// Creates a [RefractionColors] palette.
   ///
-  /// All tokens are required — there are no implicit fallbacks, so a
-  /// custom palette must explicitly opt into every semantic role. For most
-  /// apps, prefer one of the curated constants ([minimalLight],
-  /// [fintechDark], [wellnessLight], …) and use [copyWith] to tweak.
+  /// The base tokens (`primary`, `background`, …) are required — there are no
+  /// implicit fallbacks for them, so a custom palette must explicitly opt into
+  /// every base semantic role. The extended roles ([primaryHover],
+  /// [tertiary], [borderSubtle], [chart1]…) are all optional: leave one out
+  /// and its getter derives a sensible default from the base tokens. For most
+  /// apps, prefer one of the curated constants ([minimalLight], [fintechDark],
+  /// [wellnessLight], …) and use [copyWith] to tweak.
   const RefractionColors({
     required this.primary,
     required this.primaryForeground,
@@ -132,7 +269,58 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     required this.success,
     required this.warning,
     required this.info,
-  });
+    Color? primaryHover,
+    Color? primaryActive,
+    Color? primarySoft,
+    Color? primarySoftForeground,
+    List<Color>? primaryGradient,
+    Color? tertiary,
+    Color? tertiaryForeground,
+    Color? tertiarySoft,
+    Color? tertiarySoftForeground,
+    Color? placeholder,
+    Color? surfaceSubtle,
+    Color? borderSubtle,
+    Color? positive,
+    Color? positiveForeground,
+    Color? caution,
+    Color? cautionForeground,
+    Color? done,
+    Color? neutral,
+    Color? neutralForeground,
+    Color? pending,
+    Color? pendingForeground,
+    Color? chart1,
+    Color? chart2,
+    Color? chart3,
+    Color? chart4,
+    Color? chart5,
+  }) : _primaryHover = primaryHover,
+       _primaryActive = primaryActive,
+       _primarySoft = primarySoft,
+       _primarySoftForeground = primarySoftForeground,
+       _primaryGradient = primaryGradient,
+       _tertiary = tertiary,
+       _tertiaryForeground = tertiaryForeground,
+       _tertiarySoft = tertiarySoft,
+       _tertiarySoftForeground = tertiarySoftForeground,
+       _placeholder = placeholder,
+       _surfaceSubtle = surfaceSubtle,
+       _borderSubtle = borderSubtle,
+       _positive = positive,
+       _positiveForeground = positiveForeground,
+       _caution = caution,
+       _cautionForeground = cautionForeground,
+       _done = done,
+       _neutral = neutral,
+       _neutralForeground = neutralForeground,
+       _pending = pending,
+       _pendingForeground = pendingForeground,
+       _chart1 = chart1,
+       _chart2 = chart2,
+       _chart3 = chart3,
+       _chart4 = chart4,
+       _chart5 = chart5;
 
   /// Minimal palette, light mode. Pure monochrome — Apple/Nike aesthetic
   /// with deepest blacks, pure whites, and soft neutral grays.
@@ -744,6 +932,32 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
     Color? success,
     Color? warning,
     Color? info,
+    Color? primaryHover,
+    Color? primaryActive,
+    Color? primarySoft,
+    Color? primarySoftForeground,
+    List<Color>? primaryGradient,
+    Color? tertiary,
+    Color? tertiaryForeground,
+    Color? tertiarySoft,
+    Color? tertiarySoftForeground,
+    Color? placeholder,
+    Color? surfaceSubtle,
+    Color? borderSubtle,
+    Color? positive,
+    Color? positiveForeground,
+    Color? caution,
+    Color? cautionForeground,
+    Color? done,
+    Color? neutral,
+    Color? neutralForeground,
+    Color? pending,
+    Color? pendingForeground,
+    Color? chart1,
+    Color? chart2,
+    Color? chart3,
+    Color? chart4,
+    Color? chart5,
   }) {
     return RefractionColors(
       primary: primary ?? this.primary,
@@ -769,6 +983,34 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
       success: success ?? this.success,
       warning: warning ?? this.warning,
       info: info ?? this.info,
+      // Extended roles preserve their raw override state: passing nothing keeps
+      // a role deriving from the base tokens rather than freezing its default.
+      primaryHover: primaryHover ?? _primaryHover,
+      primaryActive: primaryActive ?? _primaryActive,
+      primarySoft: primarySoft ?? _primarySoft,
+      primarySoftForeground: primarySoftForeground ?? _primarySoftForeground,
+      primaryGradient: primaryGradient ?? _primaryGradient,
+      tertiary: tertiary ?? _tertiary,
+      tertiaryForeground: tertiaryForeground ?? _tertiaryForeground,
+      tertiarySoft: tertiarySoft ?? _tertiarySoft,
+      tertiarySoftForeground: tertiarySoftForeground ?? _tertiarySoftForeground,
+      placeholder: placeholder ?? _placeholder,
+      surfaceSubtle: surfaceSubtle ?? _surfaceSubtle,
+      borderSubtle: borderSubtle ?? _borderSubtle,
+      positive: positive ?? _positive,
+      positiveForeground: positiveForeground ?? _positiveForeground,
+      caution: caution ?? _caution,
+      cautionForeground: cautionForeground ?? _cautionForeground,
+      done: done ?? _done,
+      neutral: neutral ?? _neutral,
+      neutralForeground: neutralForeground ?? _neutralForeground,
+      pending: pending ?? _pending,
+      pendingForeground: pendingForeground ?? _pendingForeground,
+      chart1: chart1 ?? _chart1,
+      chart2: chart2 ?? _chart2,
+      chart3: chart3 ?? _chart3,
+      chart4: chart4 ?? _chart4,
+      chart5: chart5 ?? _chart5,
     );
   }
 
@@ -830,6 +1072,78 @@ class RefractionColors extends ThemeExtension<RefractionColors> {
       success: Color.lerp(success, other.success, t)!,
       warning: Color.lerp(warning, other.warning, t)!,
       info: Color.lerp(info, other.info, t)!,
+      // Interpolate the resolved (derived-or-overridden) values so animations
+      // stay smooth whether or not a palette overrides an extended role.
+      primaryHover: Color.lerp(primaryHover, other.primaryHover, t),
+      primaryActive: Color.lerp(primaryActive, other.primaryActive, t),
+      primarySoft: Color.lerp(primarySoft, other.primarySoft, t),
+      primarySoftForeground: Color.lerp(
+        primarySoftForeground,
+        other.primarySoftForeground,
+        t,
+      ),
+      primaryGradient: _lerpColorList(
+        primaryGradient,
+        other.primaryGradient,
+        t,
+      ),
+      tertiary: Color.lerp(tertiary, other.tertiary, t),
+      tertiaryForeground: Color.lerp(
+        tertiaryForeground,
+        other.tertiaryForeground,
+        t,
+      ),
+      tertiarySoft: Color.lerp(tertiarySoft, other.tertiarySoft, t),
+      tertiarySoftForeground: Color.lerp(
+        tertiarySoftForeground,
+        other.tertiarySoftForeground,
+        t,
+      ),
+      placeholder: Color.lerp(placeholder, other.placeholder, t),
+      surfaceSubtle: Color.lerp(surfaceSubtle, other.surfaceSubtle, t),
+      borderSubtle: Color.lerp(borderSubtle, other.borderSubtle, t),
+      positive: Color.lerp(positive, other.positive, t),
+      positiveForeground: Color.lerp(
+        positiveForeground,
+        other.positiveForeground,
+        t,
+      ),
+      caution: Color.lerp(caution, other.caution, t),
+      cautionForeground: Color.lerp(
+        cautionForeground,
+        other.cautionForeground,
+        t,
+      ),
+      done: Color.lerp(done, other.done, t),
+      neutral: Color.lerp(neutral, other.neutral, t),
+      neutralForeground: Color.lerp(
+        neutralForeground,
+        other.neutralForeground,
+        t,
+      ),
+      pending: Color.lerp(pending, other.pending, t),
+      pendingForeground: Color.lerp(
+        pendingForeground,
+        other.pendingForeground,
+        t,
+      ),
+      chart1: Color.lerp(chart1, other.chart1, t),
+      chart2: Color.lerp(chart2, other.chart2, t),
+      chart3: Color.lerp(chart3, other.chart3, t),
+      chart4: Color.lerp(chart4, other.chart4, t),
+      chart5: Color.lerp(chart5, other.chart5, t),
     );
+  }
+
+  /// Interpolates two gradient stop lists. When the lists share a length the
+  /// stops are lerped pairwise; otherwise the whole list snaps at the
+  /// midpoint (nothing sensible interpolates a 2-stop ramp into a 5-stop one).
+  static List<Color> _lerpColorList(List<Color> a, List<Color> b, double t) {
+    if (a.length == b.length) {
+      return <Color>[
+        for (var i = 0; i < a.length; i++) Color.lerp(a[i], b[i], t)!,
+      ];
+    }
+    return t < 0.5 ? a : b;
   }
 }

--- a/packages/flutter/lib/src/theme/refraction_theme_data.dart
+++ b/packages/flutter/lib/src/theme/refraction_theme_data.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'refraction_colors.dart';
+import 'refraction_typography.dart';
 
 /// The full visual configuration for a Refraction UI app.
 ///
@@ -39,27 +40,173 @@ class RefractionThemeData {
   /// platform default is used.
   final String? fontFamily;
 
+  /// Typography tokens — fonts-by-role, the role-based type scale, an optional
+  /// variable-font weight, and a text-scale factor. Defaults to a complete
+  /// scale (`const RefractionTypography()`); read [resolvedTypography] to get
+  /// the scale with this theme's [fontFamily] folded in.
+  final RefractionTypography typography;
+
+  // ---------------------------------------------------------------------------
+  // Optional scale tokens.
+  //
+  // Each is stored as a nullable override with a same-named getter that
+  // derives a default from an existing token (the base [borderRadius], the
+  // soft/heavy shadow stacks, or a fixed step). Nothing existing has to pass
+  // them, and every derived default equals the value components already used,
+  // so appearance is unchanged until a consumer opts in.
+  // ---------------------------------------------------------------------------
+
+  final List<BoxShadow>? _softShadow;
+  final List<BoxShadow>? _heavyShadow;
+  final List<BoxShadow>? _elevationSm;
+  final List<BoxShadow>? _elevationMd;
+  final List<BoxShadow>? _elevationLg;
+  final Color? _shadowTint;
+  final double? _radiusSm;
+  final double? _radiusMd;
+  final double? _radiusLg;
+  final double? _radiusPill;
+  final double? _radiusSheet;
+  final double? _spacingXs;
+  final double? _spacingSm;
+  final double? _spacingMd;
+  final double? _spacingLg;
+  final double? _spacingXl;
+  final double? _gutter;
+  final double? _controlHeightSm;
+  final double? _controlHeightMd;
+  final double? _controlHeightLg;
+
   /// Soft, low-opacity shadow stack used for resting elevation — cards,
-  /// quiet popovers, subtle floating panels.
-  final List<BoxShadow>? softShadow;
+  /// quiet popovers, subtle floating panels. Back-compat alias for
+  /// [elevationSm]: returns the explicit `softShadow` if one was given,
+  /// otherwise the small elevation step.
+  List<BoxShadow>? get softShadow => _softShadow ?? _elevationSm;
 
   /// Heavier shadow stack used for prominent elevation — dialogs, menus,
-  /// command palettes, sheets.
-  final List<BoxShadow>? heavyShadow;
+  /// command palettes, sheets. Back-compat alias for [elevationLg]: returns
+  /// the explicit `heavyShadow` if one was given, otherwise the large
+  /// elevation step.
+  List<BoxShadow>? get heavyShadow => _heavyShadow ?? _elevationLg;
+
+  /// Small resting elevation. Defaults to [softShadow].
+  List<BoxShadow>? get elevationSm => _elevationSm ?? _softShadow;
+
+  /// Medium elevation, between resting and prominent. Defaults to the heavy
+  /// stack, then the soft stack.
+  List<BoxShadow>? get elevationMd =>
+      _elevationMd ?? _heavyShadow ?? _softShadow;
+
+  /// Large, prominent elevation. Defaults to [heavyShadow].
+  List<BoxShadow>? get elevationLg => _elevationLg ?? _heavyShadow;
+
+  /// Base color a themed shadow tints toward. Defaults to
+  /// `colors.foreground`. Advertised as a token; the built-in shadow stacks
+  /// keep their neutral black so appearance is unchanged.
+  Color get shadowTint => _shadowTint ?? colors.foreground;
+
+  /// Small corner radius. Defaults to the base [borderRadius].
+  double get radiusSm => _radiusSm ?? borderRadius;
+
+  /// Medium corner radius — the default control radius (buttons, inputs).
+  /// Defaults to the base [borderRadius].
+  double get radiusMd => _radiusMd ?? borderRadius;
+
+  /// Large corner radius — cards, sheets, prominent surfaces. Defaults to the
+  /// base [borderRadius] (set it larger for rounder cards than controls).
+  double get radiusLg => _radiusLg ?? borderRadius;
+
+  /// Fully-rounded ("pill") radius for chips, avatars, and toggles. Defaults
+  /// to `999`.
+  double get radiusPill => _radiusPill ?? 999.0;
+
+  /// Bottom-sheet / large-surface radius. Defaults to `borderRadius * 3.5`.
+  double get radiusSheet => _radiusSheet ?? borderRadius * 3.5;
+
+  /// Extra-small spacing step. Defaults to `4`.
+  double get spacingXs => _spacingXs ?? 4.0;
+
+  /// Small spacing step. Defaults to `8`.
+  double get spacingSm => _spacingSm ?? 8.0;
+
+  /// Medium spacing step. Defaults to `12`.
+  double get spacingMd => _spacingMd ?? 12.0;
+
+  /// Large spacing step. Defaults to `16`.
+  double get spacingLg => _spacingLg ?? 16.0;
+
+  /// Extra-large spacing step — card/section padding. Defaults to `24`.
+  double get spacingXl => _spacingXl ?? 24.0;
+
+  /// Gutter between columns/list items. Defaults to `16`.
+  double get gutter => _gutter ?? 16.0;
+
+  /// Minimum height for small controls. Defaults to `32`.
+  double get controlHeightSm => _controlHeightSm ?? 32.0;
+
+  /// Minimum height for default controls. Defaults to `36`.
+  double get controlHeightMd => _controlHeightMd ?? 36.0;
+
+  /// Minimum height for large controls. Defaults to `44`.
+  double get controlHeightLg => _controlHeightLg ?? 44.0;
+
+  /// The [typography] scale with this theme's [fontFamily] folded in as the
+  /// fallback family for every role, so the scale defaults to the theme font.
+  RefractionTypography get resolvedTypography =>
+      typography.resolveFontFamily(fontFamily);
 
   /// Creates a [RefractionThemeData] from explicit tokens.
   ///
-  /// Only [colors] is required; [borderRadius] defaults to `8.0` and the
-  /// shadow stacks default to `null` (components fall back to flat
-  /// surfaces). Most apps should prefer one of the curated factories such
-  /// as [RefractionThemeData.light] or [RefractionThemeData.fintechDark].
+  /// Only [colors] is required; [borderRadius] defaults to `8.0`, the shadow
+  /// stacks default to `null` (components fall back to flat surfaces), and the
+  /// scale tokens ([radiusMd], [spacingXl], [elevationSm], …) each derive a
+  /// default from these. Most apps should prefer one of the curated factories
+  /// such as [RefractionThemeData.light] or [RefractionThemeData.fintechDark].
   const RefractionThemeData({
     required this.colors,
     this.borderRadius = 8.0,
     this.fontFamily,
-    this.softShadow,
-    this.heavyShadow,
-  });
+    this.typography = const RefractionTypography(),
+    List<BoxShadow>? softShadow,
+    List<BoxShadow>? heavyShadow,
+    List<BoxShadow>? elevationSm,
+    List<BoxShadow>? elevationMd,
+    List<BoxShadow>? elevationLg,
+    Color? shadowTint,
+    double? radiusSm,
+    double? radiusMd,
+    double? radiusLg,
+    double? radiusPill,
+    double? radiusSheet,
+    double? spacingXs,
+    double? spacingSm,
+    double? spacingMd,
+    double? spacingLg,
+    double? spacingXl,
+    double? gutter,
+    double? controlHeightSm,
+    double? controlHeightMd,
+    double? controlHeightLg,
+  }) : _softShadow = softShadow,
+       _heavyShadow = heavyShadow,
+       _elevationSm = elevationSm,
+       _elevationMd = elevationMd,
+       _elevationLg = elevationLg,
+       _shadowTint = shadowTint,
+       _radiusSm = radiusSm,
+       _radiusMd = radiusMd,
+       _radiusLg = radiusLg,
+       _radiusPill = radiusPill,
+       _radiusSheet = radiusSheet,
+       _spacingXs = spacingXs,
+       _spacingSm = spacingSm,
+       _spacingMd = spacingMd,
+       _spacingLg = spacingLg,
+       _spacingXl = spacingXl,
+       _gutter = gutter,
+       _controlHeightSm = controlHeightSm,
+       _controlHeightMd = controlHeightMd,
+       _controlHeightLg = controlHeightLg;
 
   /// Minimal palette in light mode — pure monochrome, Apple/Nike feel.
   factory RefractionThemeData.minimalLight() => RefractionThemeData(
@@ -260,15 +407,55 @@ class RefractionThemeData {
     RefractionColors? colors,
     double? borderRadius,
     String? fontFamily,
+    RefractionTypography? typography,
     List<BoxShadow>? softShadow,
     List<BoxShadow>? heavyShadow,
+    List<BoxShadow>? elevationSm,
+    List<BoxShadow>? elevationMd,
+    List<BoxShadow>? elevationLg,
+    Color? shadowTint,
+    double? radiusSm,
+    double? radiusMd,
+    double? radiusLg,
+    double? radiusPill,
+    double? radiusSheet,
+    double? spacingXs,
+    double? spacingSm,
+    double? spacingMd,
+    double? spacingLg,
+    double? spacingXl,
+    double? gutter,
+    double? controlHeightSm,
+    double? controlHeightMd,
+    double? controlHeightLg,
   }) {
     return RefractionThemeData(
       colors: colors ?? this.colors,
       borderRadius: borderRadius ?? this.borderRadius,
       fontFamily: fontFamily ?? this.fontFamily,
-      softShadow: softShadow ?? this.softShadow,
-      heavyShadow: heavyShadow ?? this.heavyShadow,
+      typography: typography ?? this.typography,
+      // Scale tokens carry their raw override state (never the derived
+      // default) so an untouched tier keeps deriving from the base tokens.
+      softShadow: softShadow ?? _softShadow,
+      heavyShadow: heavyShadow ?? _heavyShadow,
+      elevationSm: elevationSm ?? _elevationSm,
+      elevationMd: elevationMd ?? _elevationMd,
+      elevationLg: elevationLg ?? _elevationLg,
+      shadowTint: shadowTint ?? _shadowTint,
+      radiusSm: radiusSm ?? _radiusSm,
+      radiusMd: radiusMd ?? _radiusMd,
+      radiusLg: radiusLg ?? _radiusLg,
+      radiusPill: radiusPill ?? _radiusPill,
+      radiusSheet: radiusSheet ?? _radiusSheet,
+      spacingXs: spacingXs ?? _spacingXs,
+      spacingSm: spacingSm ?? _spacingSm,
+      spacingMd: spacingMd ?? _spacingMd,
+      spacingLg: spacingLg ?? _spacingLg,
+      spacingXl: spacingXl ?? _spacingXl,
+      gutter: gutter ?? _gutter,
+      controlHeightSm: controlHeightSm ?? _controlHeightSm,
+      controlHeightMd: controlHeightMd ?? _controlHeightMd,
+      controlHeightLg: controlHeightLg ?? _controlHeightLg,
     );
   }
 

--- a/packages/flutter/lib/src/theme/refraction_typography.dart
+++ b/packages/flutter/lib/src/theme/refraction_typography.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+
+/// Typography tokens for a Refraction UI app: fonts-by-role, a role-based type
+/// scale, an optional variable-font weight axis, and a global text-scale
+/// factor.
+///
+/// Like [RefractionColors], every field is optional and every role resolves to
+/// a sensible default, so `const RefractionTypography()` already exposes a
+/// complete, usable scale. Supply a font-by-role (e.g. a display face distinct
+/// from body copy), override an individual role's [TextStyle], set a
+/// [variableWeight] to drive a variable font's `wght` axis, or nudge
+/// [textScale] to grow/shrink the whole scale — each independently of the rest.
+///
+/// The role names mirror the React/Astro Refraction type scale so the same
+/// design decision travels across platforms.
+@immutable
+class RefractionTypography {
+  /// Font family for large display/headline/title roles. Falls back to
+  /// [fontBody] when unset (and ultimately to the ambient font family).
+  final String? fontDisplay;
+
+  /// Font family for body/label/caption/kicker roles. When unset, roles
+  /// inherit the ambient font family.
+  final String? fontBody;
+
+  /// Monospace font family for code and tabular numerals. Advertised as a
+  /// token for consumers; not applied to any role in the default scale.
+  final String? fontMono;
+
+  /// Serif font family. Advertised as a token for consumers; not applied to
+  /// any role in the default scale.
+  final String? fontSerif;
+
+  /// Global multiplier applied to every role's `fontSize`. Defaults to `1.0`
+  /// (no scaling). Use it for a responsive/accessibility bump without editing
+  /// each role.
+  final double textScale;
+
+  /// Optional variable-font weight (the `wght` axis, ~1–1000). When set it is
+  /// applied as a [FontVariation] to every role, so a single value re-weights
+  /// the whole scale on a variable face.
+  final double? variableWeight;
+
+  final TextStyle? _display;
+  final TextStyle? _headline;
+  final TextStyle? _title;
+  final TextStyle? _body;
+  final TextStyle? _label;
+  final TextStyle? _caption;
+  final TextStyle? _kicker;
+
+  /// Creates a [RefractionTypography]. All arguments are optional; omitted
+  /// roles fall back to the default scale below.
+  const RefractionTypography({
+    this.fontDisplay,
+    this.fontBody,
+    this.fontMono,
+    this.fontSerif,
+    this.textScale = 1.0,
+    this.variableWeight,
+    TextStyle? display,
+    TextStyle? headline,
+    TextStyle? title,
+    TextStyle? body,
+    TextStyle? label,
+    TextStyle? caption,
+    TextStyle? kicker,
+  }) : _display = display,
+       _headline = headline,
+       _title = title,
+       _body = body,
+       _label = label,
+       _caption = caption,
+       _kicker = kicker;
+
+  // Default role scale (family/weight/text-scale are layered on at read time).
+  static const TextStyle _displayBase = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.w700,
+    height: 1.15,
+    letterSpacing: -0.5,
+  );
+  static const TextStyle _headlineBase = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    letterSpacing: -0.4,
+  );
+  static const TextStyle _titleBase = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.w600,
+    height: 1.3,
+    letterSpacing: -0.2,
+  );
+  static const TextStyle _bodyBase = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+  );
+  static const TextStyle _labelBase = TextStyle(
+    fontSize: 13,
+    fontWeight: FontWeight.w500,
+    height: 1.4,
+  );
+  static const TextStyle _captionBase = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w400,
+    height: 1.4,
+  );
+  static const TextStyle _kickerBase = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w600,
+    height: 1.3,
+    letterSpacing: 0.8,
+  );
+
+  /// Largest role — hero/marketing headlines.
+  TextStyle get display => _resolve(_display ?? _displayBase, _displayFont);
+
+  /// Section headline.
+  TextStyle get headline => _resolve(_headline ?? _headlineBase, _displayFont);
+
+  /// Card/panel title.
+  TextStyle get title => _resolve(_title ?? _titleBase, _displayFont);
+
+  /// Default body copy.
+  TextStyle get body => _resolve(_body ?? _bodyBase, fontBody);
+
+  /// Form labels and small emphasis.
+  TextStyle get label => _resolve(_label ?? _labelBase, fontBody);
+
+  /// Secondary/caption copy.
+  TextStyle get caption => _resolve(_caption ?? _captionBase, fontBody);
+
+  /// Uppercase eyebrow/kicker above a heading.
+  TextStyle get kicker => _resolve(_kicker ?? _kickerBase, fontBody);
+
+  String? get _displayFont => fontDisplay ?? fontBody;
+
+  TextStyle _resolve(TextStyle base, String? family) {
+    var style = base;
+    if (family != null) {
+      style = style.copyWith(fontFamily: family);
+    }
+    if (textScale != 1.0 && style.fontSize != null) {
+      style = style.copyWith(fontSize: style.fontSize! * textScale);
+    }
+    if (variableWeight != null) {
+      style = style.copyWith(
+        fontVariations: <FontVariation>[FontVariation('wght', variableWeight!)],
+      );
+    }
+    return style;
+  }
+
+  /// Returns a copy whose unset font-by-role families fall back to [base].
+  ///
+  /// [RefractionThemeData] calls this with its `fontFamily` so the whole type
+  /// scale defaults to the theme's font, matching the pre-existing behavior of
+  /// `RefractionThemeData.textStyle`.
+  RefractionTypography resolveFontFamily(String? base) {
+    if (base == null) return this;
+    return copyWith(
+      fontDisplay: fontDisplay ?? base,
+      fontBody: fontBody ?? base,
+      fontMono: fontMono ?? base,
+      fontSerif: fontSerif ?? base,
+    );
+  }
+
+  /// Returns a copy with the given fields replaced; omitted fields are carried
+  /// through from the receiver (including any per-role [TextStyle] overrides).
+  RefractionTypography copyWith({
+    String? fontDisplay,
+    String? fontBody,
+    String? fontMono,
+    String? fontSerif,
+    double? textScale,
+    double? variableWeight,
+    TextStyle? display,
+    TextStyle? headline,
+    TextStyle? title,
+    TextStyle? body,
+    TextStyle? label,
+    TextStyle? caption,
+    TextStyle? kicker,
+  }) {
+    return RefractionTypography(
+      fontDisplay: fontDisplay ?? this.fontDisplay,
+      fontBody: fontBody ?? this.fontBody,
+      fontMono: fontMono ?? this.fontMono,
+      fontSerif: fontSerif ?? this.fontSerif,
+      textScale: textScale ?? this.textScale,
+      variableWeight: variableWeight ?? this.variableWeight,
+      display: display ?? _display,
+      headline: headline ?? _headline,
+      title: title ?? _title,
+      body: body ?? _body,
+      label: label ?? _label,
+      caption: caption ?? _caption,
+      kicker: kicker ?? _kicker,
+    );
+  }
+}

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refraction_ui
 description: "A headless, highly customizable, and fully accessible Flutter UI library matching Refraction UI."
-version: 0.48.0
+version: 0.49.0
 homepage: https://elloloop.github.io/refraction-ui
 repository: https://github.com/elloloop/refraction-ui
 issue_tracker: https://github.com/elloloop/refraction-ui/issues

--- a/packages/flutter/test/token_driven_components_test.dart
+++ b/packages/flutter/test/token_driven_components_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+/// Wraps [child] under a [RefractionTheme] carrying [data].
+Widget _app(RefractionThemeData data, Widget child) {
+  return MaterialApp(
+    home: RefractionTheme(
+      data: data,
+      child: Scaffold(body: Center(child: child)),
+    ),
+  );
+}
+
+BoxDecoration _decorationOf(WidgetTester tester, Finder container) {
+  return tester.widget<Container>(container).decoration! as BoxDecoration;
+}
+
+void main() {
+  group('RefractionButton reads the scale', () {
+    testWidgets('corner radius comes from radiusMd, not the flat base', (
+      tester,
+    ) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        borderRadius: 8,
+        radiusMd: 21,
+      );
+      await tester.pumpWidget(
+        _app(data, RefractionButton(onPressed: () {}, child: const Text('Go'))),
+      );
+
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(RefractionButton),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.borderRadius, BorderRadius.circular(21));
+    });
+
+    testWidgets('min height comes from controlHeightMd', (tester) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        controlHeightMd: 50,
+      );
+      await tester.pumpWidget(
+        _app(data, RefractionButton(onPressed: () {}, child: const Text('Go'))),
+      );
+
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(RefractionButton),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(container.constraints!.minHeight, 50);
+    });
+
+    testWidgets('horizontal padding comes from the spacing scale', (
+      tester,
+    ) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        spacingLg: 30,
+      );
+      await tester.pumpWidget(
+        _app(data, RefractionButton(onPressed: () {}, child: const Text('Go'))),
+      );
+
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(RefractionButton),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      expect(
+        container.padding,
+        const EdgeInsets.symmetric(horizontal: 30, vertical: 10),
+      );
+    });
+  });
+
+  group('RefractionCard reads the scale', () {
+    testWidgets('corner radius comes from radiusLg', (tester) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        borderRadius: 8,
+        radiusLg: 30,
+      );
+      await tester.pumpWidget(
+        _app(data, const RefractionCard(child: Text('body'))),
+      );
+
+      final decoration = _decorationOf(
+        tester,
+        find.descendant(
+          of: find.byType(RefractionCard),
+          matching: find.byType(Container),
+        ),
+      );
+      expect(decoration.borderRadius, BorderRadius.circular(30));
+    });
+
+    testWidgets('box shadow comes from elevationSm', (tester) async {
+      const shadow = [BoxShadow(color: Color(0xFF123456), blurRadius: 7)];
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        elevationSm: shadow,
+      );
+      await tester.pumpWidget(
+        _app(data, const RefractionCard(child: Text('body'))),
+      );
+
+      final decoration = _decorationOf(
+        tester,
+        find.descendant(
+          of: find.byType(RefractionCard),
+          matching: find.byType(Container),
+        ),
+      );
+      expect(decoration.boxShadow, shadow);
+    });
+
+    testWidgets('header padding comes from spacingXl', (tester) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        spacingXl: 40,
+      );
+      await tester.pumpWidget(
+        _app(data, const RefractionCardHeader(child: Text('title'))),
+      );
+
+      final padding = tester.widget<Padding>(
+        find
+            .descendant(
+              of: find.byType(RefractionCardHeader),
+              matching: find.byType(Padding),
+            )
+            .first,
+      );
+      expect(padding.padding, const EdgeInsets.all(40));
+    });
+  });
+
+  group('scale defaults keep components pixel-identical', () {
+    testWidgets('a default theme renders the button at the base radius', (
+      tester,
+    ) async {
+      final data = RefractionThemeData(
+        colors: RefractionColors.light,
+        borderRadius: 8,
+      );
+      await tester.pumpWidget(
+        _app(data, RefractionButton(onPressed: () {}, child: const Text('Go'))),
+      );
+
+      final container = tester.widget<AnimatedContainer>(
+        find.descendant(
+          of: find.byType(RefractionButton),
+          matching: find.byType(AnimatedContainer),
+        ),
+      );
+      final decoration = container.decoration! as BoxDecoration;
+      // radiusMd defaulted to borderRadius, so the corner is unchanged.
+      expect(decoration.borderRadius, BorderRadius.circular(8));
+      expect(container.constraints!.minHeight, 36);
+      expect(
+        container.padding,
+        const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      );
+    });
+
+    testWidgets('a default theme renders the card at the base radius', (
+      tester,
+    ) async {
+      final data = RefractionThemeData.light();
+      await tester.pumpWidget(
+        _app(data, const RefractionCard(child: Text('body'))),
+      );
+
+      final decoration = _decorationOf(
+        tester,
+        find.descendant(
+          of: find.byType(RefractionCard),
+          matching: find.byType(Container),
+        ),
+      );
+      // radiusLg defaulted to borderRadius (8); elevationSm defaulted to the
+      // theme's soft shadow stack.
+      expect(decoration.borderRadius, BorderRadius.circular(8));
+      expect(decoration.boxShadow, RefractionThemeData.light().softShadow);
+    });
+  });
+}

--- a/packages/flutter/test/token_vocabulary_test.dart
+++ b/packages/flutter/test/token_vocabulary_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:refraction_ui/refraction_ui.dart';
+
+/// A palette that sets only the original base tokens, used to prove the
+/// extended roles derive sensible defaults with no explicit values supplied.
+final RefractionColors _bare = RefractionColors.productivityLight;
+
+void main() {
+  group('RefractionColors extended roles — derived defaults', () {
+    test('brand depth derives darker hover/active steps from primary', () {
+      // A bare palette exposes hover/active without supplying them; each step
+      // is progressively darker than the brand primary.
+      expect(
+        _bare.primaryHover.computeLuminance(),
+        lessThan(_bare.primary.computeLuminance()),
+      );
+      expect(
+        _bare.primaryActive.computeLuminance(),
+        lessThan(_bare.primaryHover.computeLuminance()),
+      );
+    });
+
+    test('soft brand fill blends primary ~12% over background', () {
+      expect(
+        _bare.primarySoft,
+        Color.lerp(_bare.background, _bare.primary, 0.12),
+      );
+      expect(_bare.primarySoftForeground, _bare.primary);
+    });
+
+    test('primaryGradient defaults to a flat [primary, primary]', () {
+      expect(_bare.primaryGradient, <Color>[_bare.primary, _bare.primary]);
+    });
+
+    test('tertiary falls back to the secondary hue and its soft tint', () {
+      expect(_bare.tertiary, _bare.secondary);
+      expect(_bare.tertiaryForeground, _bare.secondaryForeground);
+      expect(
+        _bare.tertiarySoft,
+        Color.lerp(_bare.background, _bare.secondary, 0.12),
+      );
+      expect(_bare.tertiarySoftForeground, _bare.secondary);
+    });
+
+    test('ink/surface roles fall back to muted tokens', () {
+      expect(_bare.placeholder, _bare.mutedForeground);
+      expect(_bare.surfaceSubtle, _bare.muted);
+    });
+
+    test('borderSubtle is the border pulled halfway to the background', () {
+      expect(
+        _bare.borderSubtle,
+        Color.lerp(_bare.border, _bare.background, 0.5),
+      );
+    });
+
+    test('status roles derive from success/warning with white foregrounds', () {
+      const white = Color(0xFFFFFFFF);
+      expect(_bare.positive, _bare.success);
+      expect(_bare.positiveForeground, white);
+      expect(_bare.caution, _bare.warning);
+      expect(_bare.cautionForeground, white);
+      expect(_bare.done, _bare.success);
+      expect(_bare.pending, _bare.warning);
+      expect(_bare.pendingForeground, white);
+    });
+
+    test('neutral role derives a hue-independent gray', () {
+      expect(_bare.neutral, _bare.mutedForeground);
+      expect(_bare.neutralForeground, _bare.foreground);
+    });
+
+    test('chart ramp seeds five distinct categorical colors from primary', () {
+      expect(_bare.chart1, _bare.primary);
+      final ramp = <Color>[
+        _bare.chart1,
+        _bare.chart2,
+        _bare.chart3,
+        _bare.chart4,
+        _bare.chart5,
+      ];
+      expect(ramp.toSet().length, 5, reason: 'all five chart colors differ');
+    });
+  });
+
+  group('RefractionColors extended roles — overrides', () {
+    test('constructor override wins over the derived default', () {
+      const override = Color(0xFF010203);
+      final palette = RefractionColors.productivityLight.copyWith(
+        primaryHover: override,
+      );
+      expect((palette as RefractionColors).primaryHover, override);
+      // Untouched roles keep deriving.
+      expect(palette.primaryActive, isNot(override));
+    });
+
+    test('copyWith without an argument keeps a role deriving', () {
+      final copy =
+          RefractionColors.productivityLight.copyWith() as RefractionColors;
+      // Still derives from primary rather than being frozen to a value.
+      expect(copy.primaryHover, _bare.primaryHover);
+    });
+
+    test('changing primary re-derives an unset hover step', () {
+      const newPrimary = Color(0xFF884400);
+      final palette =
+          RefractionColors.productivityLight.copyWith(primary: newPrimary)
+              as RefractionColors;
+      expect(
+        palette.primaryHover.computeLuminance(),
+        lessThan(newPrimary.computeLuminance()),
+      );
+    });
+  });
+
+  group('RefractionColors extended roles — lerp', () {
+    test('interpolates a derived role between two palettes', () {
+      final a = RefractionColors.productivityLight;
+      final b = RefractionColors.productivityDark;
+      final mid = a.lerp(b, 0.5) as RefractionColors;
+      expect(mid.primaryHover, Color.lerp(a.primaryHover, b.primaryHover, 0.5));
+      expect(mid.tertiarySoft, Color.lerp(a.tertiarySoft, b.tertiarySoft, 0.5));
+    });
+
+    test('interpolates an explicitly overridden role', () {
+      const override = Color(0xFF00FF00);
+      final a = RefractionColors.productivityLight;
+      final b = a.copyWith(pending: override) as RefractionColors;
+      final mid = a.lerp(b, 0.5) as RefractionColors;
+      expect(mid.pending, Color.lerp(a.pending, override, 0.5));
+    });
+
+    test('gradient stops lerp pairwise when lengths match', () {
+      final a = RefractionColors.productivityLight.copyWith(
+        primaryGradient: const [Color(0xFF000000), Color(0xFF000000)],
+      );
+      final b = RefractionColors.productivityLight.copyWith(
+        primaryGradient: const [Color(0xFFFFFFFF), Color(0xFFFFFFFF)],
+      );
+      final mid = a.lerp(b, 0.5) as RefractionColors;
+      expect(mid.primaryGradient.length, 2);
+      expect(
+        mid.primaryGradient.first,
+        Color.lerp(const Color(0xFF000000), const Color(0xFFFFFFFF), 0.5),
+      );
+    });
+  });
+
+  group('RefractionThemeData scale tokens', () {
+    test('radius scale derives from the base borderRadius', () {
+      final theme = RefractionThemeData(
+        colors: RefractionColors.light,
+        borderRadius: 6,
+      );
+      expect(theme.radiusSm, 6);
+      expect(theme.radiusMd, 6);
+      expect(theme.radiusLg, 6);
+      expect(theme.radiusPill, 999);
+      expect(theme.radiusSheet, 6 * 3.5);
+    });
+
+    test('spacing and control-height scales expose sensible defaults', () {
+      final theme = RefractionThemeData(colors: RefractionColors.light);
+      expect(
+        [
+          theme.spacingXs,
+          theme.spacingSm,
+          theme.spacingMd,
+          theme.spacingLg,
+          theme.spacingXl,
+          theme.gutter,
+        ],
+        [4, 8, 12, 16, 24, 16],
+      );
+      expect(theme.controlHeightSm, 32);
+      expect(theme.controlHeightMd, 36);
+      expect(theme.controlHeightLg, 44);
+    });
+
+    test('shadowTint defaults to the foreground color', () {
+      final theme = RefractionThemeData(colors: RefractionColors.light);
+      expect(theme.shadowTint, RefractionColors.light.foreground);
+    });
+
+    test('elevation aliases resolve both directions for back-compat', () {
+      const soft = [BoxShadow(blurRadius: 1)];
+      const heavy = [BoxShadow(blurRadius: 9)];
+
+      final fromLegacy = RefractionThemeData(
+        colors: RefractionColors.light,
+        softShadow: soft,
+        heavyShadow: heavy,
+      );
+      expect(fromLegacy.elevationSm, soft);
+      expect(fromLegacy.elevationLg, heavy);
+      expect(fromLegacy.elevationMd, heavy);
+
+      final fromScale = RefractionThemeData(
+        colors: RefractionColors.light,
+        elevationSm: soft,
+        elevationLg: heavy,
+      );
+      expect(fromScale.softShadow, soft);
+      expect(fromScale.heavyShadow, heavy);
+    });
+
+    test('copyWith overrides a tier and leaves the rest deriving', () {
+      final base = RefractionThemeData(
+        colors: RefractionColors.light,
+        borderRadius: 8,
+      );
+      final tweaked = base.copyWith(radiusLg: 20, spacingXl: 40);
+      expect(tweaked.radiusLg, 20);
+      expect(tweaked.spacingXl, 40);
+      // Untouched tiers still derive from the base.
+      expect(tweaked.radiusMd, 8);
+      expect(tweaked.spacingSm, 8);
+    });
+  });
+
+  group('RefractionTypography', () {
+    test('default instance exposes a complete role scale', () {
+      const typography = RefractionTypography();
+      expect(typography.textScale, 1.0);
+      expect(typography.display.fontSize, 32);
+      expect(typography.title.fontSize, 20);
+      expect(typography.body.fontSize, 14);
+      expect(typography.caption.fontSize, 12);
+    });
+
+    test('textScale multiplies every role size', () {
+      const typography = RefractionTypography(textScale: 2);
+      expect(typography.title.fontSize, 40);
+      expect(typography.body.fontSize, 28);
+    });
+
+    test('variableWeight drives the wght axis on every role', () {
+      const typography = RefractionTypography(variableWeight: 650);
+      expect(typography.body.fontVariations!.single.value, 650);
+    });
+
+    test('resolveFontFamily folds a base family into every role', () {
+      final theme = RefractionThemeData(
+        colors: RefractionColors.light,
+        fontFamily: 'Inter',
+      );
+      expect(theme.resolvedTypography.body.fontFamily, 'Inter');
+      expect(theme.resolvedTypography.display.fontFamily, 'Inter');
+    });
+  });
+}


### PR DESCRIPTION
Closes #485 (Flutter half).

Enriches the Flutter package's token model so a product's whole look is token-driven, following the one hard rule from the issue: **every new field is optional (nullable) with a getter that derives a sensible default from existing tokens**, so the existing curated palettes, the six named-theme statics, and every existing `RefractionColors` / `RefractionThemeData` construction keep compiling and rendering **pixel-identically** (nothing is made required — no repeat of the 0.48.0 `success`-required break).

## Color roles added to `RefractionColors`
Each is a nullable field + default-deriving getter, wired through `copyWith` and `lerp`:

| Role | Default derivation |
|------|--------------------|
| `primaryHover` | `primary` darkened ~6% (HSL lightness) |
| `primaryActive` | `primary` darkened ~12% |
| `primarySoft` | `primary` blended ~12% over `background` |
| `primarySoftForeground` | `primary` |
| `primaryGradient` (`List<Color>`) | `[primary, primary]` |
| `tertiary` | `secondary` |
| `tertiaryForeground` | `secondaryForeground` |
| `tertiarySoft` | `tertiary` blended ~12% over `background` |
| `tertiarySoftForeground` | `tertiary` |
| `placeholder` | `mutedForeground` |
| `surfaceSubtle` | `muted` |
| `borderSubtle` | `border` pulled ~50% toward `background` |
| `positive` / `positiveForeground` | `success` / white |
| `caution` / `cautionForeground` | `warning` / white |
| `done` | `success` |
| `neutral` / `neutralForeground` | `mutedForeground` / `foreground` |
| `pending` / `pendingForeground` | `warning` / white |
| `chart1`..`chart5` | `chart1` = `primary`; the rest are hue-rotations of `primary` (a categorical ramp) |

A small internal `ColorMath` helper (`darken` / `mix` / `rotateHue`, in `hsl_color.dart`) provides the derivations.

## Non-color tokens added to `RefractionThemeData`
Nullable + default-deriving getters, wired through `copyWith`:

- **Radius scale**: `radiusSm` / `radiusMd` / `radiusLg` (→ base `borderRadius`), `radiusPill` (999), `radiusSheet` (`borderRadius * 3.5`).
- **Elevation scale**: `elevationSm` / `elevationMd` / `elevationLg` + `shadowTint` (→ `colors.foreground`). `softShadow` / `heavyShadow` are now back-compat aliases of `elevationSm` / `elevationLg` (resolved both directions).
- **Spacing**: `spacingXs` / `spacingSm` / `spacingMd` / `spacingLg` / `spacingXl` (4/8/12/16/24) + `gutter` (16); control sizing `controlHeightSm` / `controlHeightMd` / `controlHeightLg` (32/36/44).
- **Typography**: new `RefractionTypography` token type — fonts-by-role (`fontDisplay` / `fontBody` / `fontMono` / `fontSerif`, defaulting to the theme `fontFamily`), a role type scale (`display` / `headline` / `title` / `body` / `label` / `caption` / `kicker`), optional variable-font weight (`FontVariation`), and a `textScale` factor (default 1.0). Wired as an optional `typography` field with a default instance, plus a `resolvedTypography` getter that folds in the theme font.

## Components wired to read the new tokens
- `RefractionButton` reads `radiusMd`, `controlHeightSm/Md/Lg`, and the `spacing*` scale for padding.
- `RefractionCard` reads `radiusLg` / `elevationSm`; its header/content/footer paddings read `spacingXl`.

Every derived default equals the value these components used before, so appearance is unchanged by construction.

## Note on the radius scale (deviation from the issue's nominal numbers)
The issue lists nominal `radiusSm ~8 / radiusMd ~16 / radiusLg ~24`. Because both Button and Card currently render at the single base `borderRadius`, mapping Button→`radiusMd` and Card→`radiusLg` while keeping both pixel-identical requires the component-facing tiers to default to the base radius. So `radiusSm` / `radiusMd` / `radiusLg` all default to `borderRadius` (pixel-identity wins, per the hard rule). Their value is now as **independent override hooks** — e.g. a consumer can round cards more than buttons, which the old single `borderRadius` could not express. `radiusPill` (999) and `radiusSheet` (~28) are new values nothing existing reads.

## Verification
- `flutter analyze`: **clean** (No issues found).
- `flutter test`: **2542 passed, 0 failed** (was 2510 on the base branch; +32 new tests). **No golden shifted** — all golden tests pass, confirming the defaults preserve appearance.
- `flutter pub publish --dry-run`: **0 warnings**.
- Version bump `0.48.0 → 0.49.0` + `## 0.49.0` CHANGELOG entry (additive/non-breaking, lists every new token).

Follows up in a sibling PR for the React half of #485.
